### PR TITLE
feat(v0.3): PR 2 kernel — Mode behaviour + parallel tools + mistake counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,86 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and ExAthena adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.3.0-dev — in progress
+## v0.3.0-dev — in progress (PR 2 landed)
 
-v0.3 is a research-driven rewrite of the agent loop (incoming in PRs 2-4).
+### PR 2 — Kernel rewrite (**breaking changes**)
+
+**The return type of `ExAthena.Loop.run/2` is now `{:ok, %Result{}}`
+instead of the v0.2 `{:ok, map()}`.** Consumers pattern-matching on the
+old map shape must update.
+
+#### Added — pluggable Mode behaviour
+
+- `ExAthena.Loop.Mode` — behaviour with `init/1` + `iterate/1`. Drives
+  the turn-by-turn control flow. Kernel handles caps, budget, hooks,
+  counters, events, and Result construction.
+- `ExAthena.Modes.ReAct` — default mode. ReAct cycle (reason → act →
+  observe) with parallel tool execution, mistake counter, and typed
+  terminations.
+- `ExAthena.Modes.PlanAndSolve` + `ExAthena.Modes.Reflexion` — stubs
+  returning `:not_implemented`. Full implementations land in PR 3.
+- `ExAthena.Loop.Mode.resolve/1` translates atom shortcuts (`:react`,
+  `:plan_and_solve`, `:reflexion`) to modules.
+
+#### Added — reliability knobs
+
+- `:max_consecutive_mistakes` (default 3) — trips
+  `:error_consecutive_mistakes` after N consecutive tool errors. A
+  successful tool call resets the counter. Prevents runaway loops
+  (Cline pattern).
+- `:max_budget_usd` — trips `:error_max_budget_usd` when the budget
+  accumulator crosses the cap. PR 3 wires cost computation from provider
+  metadata.
+- `:tool_timeout_ms` (default 60_000) — per-call timeout for parallel
+  execution.
+- `:max_concurrency` (default 4) — `Task.async_stream` concurrency cap.
+
+#### Added — parallel tool execution
+
+- `ExAthena.Loop.Parallel` — classifies a single iteration's tool calls
+  into parallel-safe (read-only) and serial (mutating) groups. Runs
+  mutating calls first in order, then parallel-safe calls concurrently
+  via `Task.async_stream/3`. Result order always matches input call
+  order so the model sees aligned results.
+- `ExAthena.Tool.parallel_safe?/0` — optional behaviour callback.
+  Defaults to `false`.
+- Read-only builtins (`Read`, `Glob`, `Grep`, `WebFetch`) declare
+  `parallel_safe?: true`. Mutating builtins default to `false`.
+
+#### Changed — event shape (**breaking change**)
+
+v0.2's `%ExAthena.Streaming.Event{type:, data:, index:}` struct is
+replaced by flat pattern-matchable tuples modelled on `ash_ai`'s
+`ToolLoop.stream/2`:
+
+    {:content, text}
+    {:tool_call, ToolCall.t()}
+    {:tool_result, ToolResult.t()}
+    {:iteration, integer()}
+    {:usage, usage_map}
+    {:error, term()}
+    {:done, Result.t()}
+
+Consumers subscribing via `:on_event` need to update their handlers.
+OTel span emission in PR 4 consumes the same tuples.
+
+#### Changed — error handling
+
+Tool errors use the `is_error: true` tool-result convention (Cline
+pattern). The model sees its mistake and self-corrects; the mistake
+counter advances; a streak hits the cap.
+
+Unknown tools + parse failures flow as error tool-results rather than
+halting the run. Hook-driven halts produce `:error_halted`. Provider
+errors produce `:error_during_execution`.
+
+#### Tests
+
+126 total (up from 116 in PR 1). 10 new cover Result shape, termination
+subtypes, max_iterations → `:error_max_turns`, mistake counter + reset,
+parallel tool ordering, flat event tuples, Mode resolve/1.
+
+### PR 1 — Foundation (already landed, unchanged)
 PR 1 lays the foundation: canonical types, typed terminations, budget
 accounting, and a single req_llm-backed provider adapter that replaces the
 three hand-written provider modules.

--- a/lib/ex_athena/loop.ex
+++ b/lib/ex_athena/loop.ex
@@ -1,262 +1,220 @@
 defmodule ExAthena.Loop do
   @moduledoc """
-  Multi-turn agent loop.
+  Agent-loop kernel. Dispatches to a `ExAthena.Loop.Mode` implementation
+  and handles everything around it: caps, budget, hooks, counters, events,
+  and termination accounting.
 
-  Orchestrates:
+  Public entry point: `run/2`, returning `{:ok, %ExAthena.Result{}} |
+  {:error, reason}`.
 
-    * `infer` — hand the current message list to the provider
-    * `parse_tool_calls` — pull tool calls out of the response (native +
-      TextTagged fallback)
-    * `permission + hooks` — deny via `Permissions` or `PreToolUse` hooks
-    * `execute` — run each approved tool and append its result to the
-      messages
-    * `replay` — loop back to `infer` with the updated messages
-    * `stop` — when the model emits text with no tool calls, or we hit the
-      `:max_iterations` cap, or a hook asks to halt
+  ## v0.3 breaking change
+
+  The return shape is now an `ExAthena.Result` struct instead of a loose
+  map. Every termination — success or error — produces a Result with the
+  typed `finish_reason` (see `ExAthena.Loop.Terminations` for the
+  enumeration). Callers can dispatch on `Result.category/1`
+  (`:success | :retryable | :capacity | :fatal`) instead of pattern-matching
+  individual atoms.
 
   ## Options
 
-    * `:provider` — any `ExAthena.Config.provider_module/1`-compatible value.
-    * `:model`, `:temperature`, `:top_p`, `:max_tokens`, `:stop`,
-      `:system_prompt`, `:messages` — forwarded to `ExAthena.Request.new/2`.
-    * `:tools` — list of modules implementing `ExAthena.Tool`, or `:all`,
-      or `nil` to use `config :ex_athena, tools: ...`. Defaults to builtins.
-    * `:cwd` — working directory for tool execution (default: `File.cwd!/0`).
-    * `:phase` — `:plan | :default | :bypass_permissions` (default `:default`).
-    * `:allowed_tools` / `:disallowed_tools` — string lists passed to
-      `Permissions`.
-    * `:can_use_tool` — `(name, args, ctx -> :allow | :deny | {:deny, reason})`.
+    * `:provider` — required. Provider atom (`:ollama`, `:openai`,
+      `:claude`, `:mock`, `:req_llm`) or a module implementing
+      `ExAthena.Provider`.
+    * `:model`, `:system_prompt`, `:messages`, `:temperature`, `:top_p`,
+      `:max_tokens`, `:stop`, `:timeout_ms`, `:tool_choice`,
+      `:response_format`, `:provider_opts`, `:metadata` — forwarded to
+      `ExAthena.Request.new/2`.
+    * `:tools` — list of modules implementing `ExAthena.Tool` or `:all`
+      (default — all builtins). `nil` falls back to `config :ex_athena,
+      tools: …`.
+    * `:mode` — atom (`:react`, `:plan_and_solve`, `:reflexion`) or module.
+      Defaults to `:react`.
+    * `:cwd`, `:phase`, `:assigns` — threaded into every tool's
+      `ExAthena.ToolContext`.
+    * `:allowed_tools`, `:disallowed_tools`, `:can_use_tool` — see
+      `ExAthena.Permissions`.
     * `:hooks` — see `ExAthena.Hooks`.
-    * `:max_iterations` — hard stop on loop depth (default 25).
-    * `:on_event` — optional `(Streaming.Event -> term())` callback that fires
-      for text deltas AND synthetic tool-lifecycle events; useful for
-      LiveView updates.
-    * `:assigns` — a map threaded through `ctx.assigns` to every tool.
+    * `:max_iterations` (default 25) — hard iteration cap.
+    * `:max_consecutive_mistakes` (default 3) — counter threshold at
+      which the loop terminates with `:error_consecutive_mistakes`.
+    * `:max_budget_usd` — optional float. Trips
+      `:error_max_budget_usd` when cumulative cost crosses it.
+    * `:tool_timeout_ms` (default 60_000) — per-call timeout for parallel
+      tool execution.
+    * `:max_concurrency` (default 4) — `Task.async_stream` concurrency
+      cap for parallel-safe tool calls in a single iteration.
+    * `:on_event` — `(ExAthena.Loop.Events.t -> term)` callback for
+      streaming. Events are flat tuples (`{:content, text}`,
+      `{:tool_call, tc}`, `{:tool_result, tr}`, `{:iteration, n}`,
+      `{:usage, u}`, `{:error, reason}`, `{:done, Result}`).
 
-  Returns `{:ok, %{text: final_text, messages: [Message.t()], usage: map() | nil}}`
-  or `{:error, reason}`.
+  ## Returns
+
+    * `{:ok, Result.t()}` — ran to termination (possibly with an error
+      subtype like `:error_max_turns`; the Result contains the
+      classification).
+    * `{:error, reason}` — unexpected failure before the loop started
+      (e.g. unknown provider, bad tool module).
   """
 
-  alias ExAthena.{Config, Hooks, Messages, Permissions, Request, Tools, ToolCalls, ToolContext}
-  alias ExAthena.Messages.ToolCall
+  alias ExAthena.{Budget, Config, Error, Request, Result, Tools}
+  alias ExAthena.Loop.{Events, Mode, State}
 
   @default_max_iterations 25
+  @default_max_mistakes 3
+  @default_max_concurrency 4
+  @default_tool_timeout_ms 60_000
 
-  @type run_result :: {:ok, map()} | {:error, term()}
-
-  @spec run(String.t() | nil, keyword()) :: run_result()
+  @spec run(String.t() | nil, keyword()) :: {:ok, Result.t()} | {:error, term()}
   def run(prompt, opts \\ []) do
+    started_at = System.monotonic_time(:millisecond)
+
+    with {:ok, state} <- build_initial_state(prompt, opts),
+         {:ok, state} <- state.mode.init(state) do
+      state |> loop() |> to_result(started_at)
+    end
+  end
+
+  # ── Loop body ─────────────────────────────────────────────────────
+
+  defp loop(%State{} = state) do
+    cond do
+      state.iterations >= state.max_iterations ->
+        state
+        |> set_finish_reason(:error_max_turns)
+
+      state.consecutive_mistakes >= state.max_consecutive_mistakes ->
+        state
+        |> set_finish_reason(:error_consecutive_mistakes)
+
+      Budget.exceeded?(state.budget, state.max_budget_usd) ->
+        state
+        |> set_finish_reason(:error_max_budget_usd)
+
+      true ->
+        Events.emit(state.on_event, {:iteration, state.iterations})
+
+        case state.mode.iterate(state) do
+          {:continue, new_state} ->
+            loop(%{new_state | iterations: new_state.iterations + 1})
+
+          {:halt, new_state} ->
+            new_state
+
+          {:error, reason} ->
+            state
+            |> Map.put(:halted_reason, reason)
+            |> set_finish_reason(:error_during_execution)
+        end
+    end
+  end
+
+  defp set_finish_reason(%State{} = state, reason) do
+    put_in(state.meta[:finish_reason], reason)
+  end
+
+  # ── Result construction ───────────────────────────────────────────
+
+  defp to_result({:error, _} = err, _), do: err
+
+  defp to_result(%State{} = state, started_at) do
+    finish_reason = state.meta[:finish_reason] || :stop
+    final_text = extract_final_text(state)
+
+    duration_ms = System.monotonic_time(:millisecond) - started_at
+
+    result = %Result{
+      text: final_text,
+      messages: state.messages,
+      finish_reason: finish_reason,
+      halted_reason: state.halted_reason,
+      iterations: state.iterations,
+      tool_calls_made: state.tool_calls_made,
+      usage: state.budget && state.budget.usage,
+      cost_usd: state.budget && state.budget.cost_usd,
+      duration_ms: duration_ms,
+      model: state.request_template && state.request_template.model,
+      provider: state.provider_mod,
+      telemetry: %{}
+    }
+
+    Events.emit(state.on_event, {:done, result})
+
+    {:ok, result}
+  end
+
+  defp extract_final_text(%State{messages: messages}) do
+    # The last assistant message's content is the final text. Errors with no
+    # final assistant message leave text nil (callers can still inspect
+    # halted_reason / finish_reason).
+    messages
+    |> Enum.reverse()
+    |> Enum.find_value(nil, fn
+      %{role: :assistant, content: c} when is_binary(c) -> c
+      _ -> nil
+    end)
+  end
+
+  # ── Initial state assembly ────────────────────────────────────────
+
+  defp build_initial_state(prompt, opts) do
     {provider_mod, opts} = Config.pop_provider!(opts)
 
     cwd = Keyword.get(opts, :cwd, File.cwd!())
     phase = Keyword.get(opts, :phase, :default)
     assigns = Keyword.get(opts, :assigns, %{})
-    max_iterations = Keyword.get(opts, :max_iterations, @default_max_iterations)
-    on_event = Keyword.get(opts, :on_event)
+    mode = opts |> Keyword.get(:mode, :react) |> Mode.resolve()
 
     tool_modules = opts |> Tools.resolve() |> normalize_tool_list()
 
-    Tools.validate!(tool_modules)
+    with :ok <- validate_tools(tool_modules) do
+      capabilities = provider_mod.capabilities()
+      request_template = Request.new(prompt, opts)
 
-    permissions_opts = %{
-      phase: phase,
-      allowed_tools: Keyword.get(opts, :allowed_tools),
-      disallowed_tools: Keyword.get(opts, :disallowed_tools),
-      can_use_tool: Keyword.get(opts, :can_use_tool)
-    }
+      permissions_opts = %{
+        phase: phase,
+        allowed_tools: Keyword.get(opts, :allowed_tools),
+        disallowed_tools: Keyword.get(opts, :disallowed_tools),
+        can_use_tool: Keyword.get(opts, :can_use_tool)
+      }
 
-    hooks = Keyword.get(opts, :hooks, %{})
-    session_id = Keyword.get(opts, :session_id)
+      ctx =
+        ExAthena.ToolContext.new(
+          cwd: cwd,
+          phase: phase,
+          session_id: Keyword.get(opts, :session_id),
+          assigns: assigns
+        )
 
-    ctx_base = %ToolContext{
-      cwd: cwd,
-      phase: phase,
-      session_id: session_id,
-      assigns: assigns
-    }
+      state = %State{
+        messages: request_template.messages,
+        tool_modules: tool_modules,
+        capabilities: capabilities,
+        provider_mod: provider_mod,
+        provider_opts: Config.provider_opts(provider_mod, opts),
+        request_template: request_template,
+        permissions_opts: permissions_opts,
+        hooks: Keyword.get(opts, :hooks, %{}),
+        ctx: ctx,
+        on_event: Keyword.get(opts, :on_event),
+        budget: Budget.new(),
+        max_iterations: Keyword.get(opts, :max_iterations, @default_max_iterations),
+        max_consecutive_mistakes:
+          Keyword.get(opts, :max_consecutive_mistakes, @default_max_mistakes),
+        max_budget_usd: Keyword.get(opts, :max_budget_usd),
+        tool_timeout_ms: Keyword.get(opts, :tool_timeout_ms, @default_tool_timeout_ms),
+        max_concurrency: Keyword.get(opts, :max_concurrency, @default_max_concurrency),
+        mode: mode,
+        mode_state: %{},
+        meta: %{}
+      }
 
-    capabilities = provider_mod.capabilities()
-    initial_request = Request.new(prompt, opts)
+      _ = ExAthena.Hooks.run_lifecycle(state.hooks, :SessionStart, %{})
 
-    initial_messages = prepend_system_prompt(initial_request, tool_modules, capabilities)
-
-    state = %{
-      messages: initial_messages,
-      tool_modules: tool_modules,
-      capabilities: capabilities,
-      provider_mod: provider_mod,
-      provider_opts: Config.provider_opts(provider_mod, opts),
-      request_template: initial_request,
-      permissions_opts: permissions_opts,
-      hooks: hooks,
-      ctx: ctx_base,
-      on_event: on_event,
-      usage: nil,
-      final_text: nil,
-      iterations: 0,
-      max_iterations: max_iterations
-    }
-
-    _ = Hooks.run_lifecycle(hooks, :SessionStart, %{session_id: session_id})
-
-    result = iterate(state)
-
-    _ = Hooks.run_lifecycle(hooks, :SessionEnd, %{session_id: session_id})
-
-    result
-  end
-
-  # ── Main loop ──────────────────────────────────────────────────────
-
-  defp iterate(%{iterations: i, max_iterations: m}) when i >= m do
-    {:error, {:max_iterations_exceeded, m}}
-  end
-
-  defp iterate(state) do
-    request = %{
-      state.request_template
-      | messages: state.messages,
-        tools: tool_schemas(state.tool_modules, state.capabilities),
-        system_prompt: effective_system_prompt(state)
-    }
-
-    case state.provider_mod.query(request, state.provider_opts) do
-      {:ok, response} ->
-        emit(state.on_event, %ExAthena.Streaming.Event{type: :text_delta, data: response.text || ""})
-        handle_response(response, state)
-
-      {:error, _} = err ->
-        err
+      {:ok, state}
     end
   end
-
-  defp handle_response(response, state) do
-    usage = response.usage || state.usage
-
-    case extract_tool_calls(response, state.capabilities) do
-      {:ok, []} ->
-        {:ok,
-         %{
-           text: response.text,
-           messages: state.messages ++ [Messages.assistant(response.text)],
-           usage: usage,
-           finish_reason: response.finish_reason,
-           iterations: state.iterations
-         }}
-
-      {:ok, tool_calls} ->
-        assistant_msg = Messages.assistant(response.text, tool_calls)
-
-        state = %{state | messages: state.messages ++ [assistant_msg], usage: usage}
-
-        case execute_tool_calls(tool_calls, state) do
-          {:ok, tool_messages, state} ->
-            iterate(%{
-              state
-              | messages: state.messages ++ tool_messages,
-                iterations: state.iterations + 1
-            })
-
-          {:halt, reason, state} ->
-            {:ok,
-             %{
-               text: response.text,
-               messages: state.messages,
-               usage: state.usage,
-               finish_reason: :error,
-               iterations: state.iterations,
-               halted: reason
-             }}
-        end
-
-      {:error, reason} ->
-        {:error, {:tool_call_parse_failed, reason}}
-    end
-  end
-
-  # Execute every tool call in order, appending each result to `messages`.
-  # Any `{:halt, reason}` return short-circuits the loop.
-  defp execute_tool_calls(calls, state) do
-    Enum.reduce_while(calls, {:ok, [], state}, fn call, {:ok, acc, state} ->
-      case run_one(call, state) do
-        {:ok, message, state} -> {:cont, {:ok, acc ++ [message], state}}
-        {:halt, reason, state} -> {:halt, {:halt, reason, state}}
-      end
-    end)
-  end
-
-  defp run_one(%ToolCall{name: name, arguments: args, id: id} = call, state) do
-    ctx = %{state.ctx | tool_call_id: id}
-
-    with :allow <- Permissions.check(call, ctx, state.permissions_opts),
-         :ok <- Hooks.run_pre_tool_use(state.hooks, name, args, id),
-         {:ok, result, state} <- dispatch_and_execute(name, args, ctx, state),
-         :ok <- Hooks.run_post_tool_use(state.hooks, name, %{result: result}, id) do
-      {:ok, Messages.tool_result(id, stringify(result)), state}
-    else
-      {:deny, reason} ->
-        {:ok, Messages.tool_result(id, "permission denied: #{inspect(reason)}", true), state}
-
-      {:halt, reason} ->
-        {:halt, reason, state}
-
-      {:error, reason, state_after} when is_map(state_after) ->
-        {:ok, Messages.tool_result(id, "error: #{inspect(reason)}", true), state_after}
-
-      {:error, reason} ->
-        {:ok, Messages.tool_result(id, "error: #{inspect(reason)}", true), state}
-    end
-  end
-
-  defp dispatch_and_execute(name, args, ctx, state) do
-    case Tools.find(state.tool_modules, name) do
-      nil ->
-        {:error, {:unknown_tool, name}, state}
-
-      mod ->
-        case mod.execute(args, ctx) do
-          {:ok, %{phase_transition: new_phase} = result} ->
-            new_ctx = %{state.ctx | phase: new_phase}
-            {:ok, Map.get(result, :message, "phase -> #{new_phase}"), %{state | ctx: new_ctx}}
-
-          {:ok, result} ->
-            {:ok, result, state}
-
-          {:error, reason} ->
-            {:error, reason, state}
-
-          {:halt, reason} ->
-            {:halt, reason}
-
-          other ->
-            {:error, {:invalid_tool_return, other}, state}
-        end
-    end
-  end
-
-  # ── Helpers ────────────────────────────────────────────────────────
-
-  defp extract_tool_calls(response, capabilities) do
-    ToolCalls.extract(%{tool_calls: response.tool_calls, text: response.text}, capabilities)
-  end
-
-  defp tool_schemas(modules, %{native_tool_calls: true}), do: Tools.describe_for_provider(modules)
-  defp tool_schemas(_modules, _caps), do: nil
-
-  # For providers without native tool calls, bake tool instructions into the
-  # system prompt so the model knows the TextTagged protocol.
-  defp effective_system_prompt(%{capabilities: %{native_tool_calls: true}} = state),
-    do: state.request_template.system_prompt
-
-  defp effective_system_prompt(state) do
-    tools = Tools.describe_for_prompt(state.tool_modules)
-    ToolCalls.augment_system_prompt(state.request_template.system_prompt, tools)
-  end
-
-  # If there's a system_prompt + initial messages don't include one, don't
-  # inject — providers handle :system_prompt natively. But keep a hook for
-  # future work that wants it inline.
-  defp prepend_system_prompt(%Request{messages: messages}, _tools, _caps), do: messages
 
   defp normalize_tool_list(list) do
     Enum.map(list, fn
@@ -271,13 +229,13 @@ defmodule ExAthena.Loop do
     end)
   end
 
-  defp stringify(s) when is_binary(s), do: s
-  defp stringify(other), do: inspect(other, pretty: true, limit: :infinity)
-
-  defp emit(nil, _event), do: :ok
-
-  defp emit(callback, event) when is_function(callback, 1) do
-    callback.(event)
-    :ok
+  defp validate_tools(tool_modules) do
+    try do
+      Tools.validate!(tool_modules)
+      :ok
+    rescue
+      e in ArgumentError ->
+        {:error, Error.new(:bad_request, Exception.message(e), provider: :loop)}
+    end
   end
 end

--- a/lib/ex_athena/loop/events.ex
+++ b/lib/ex_athena/loop/events.ex
@@ -1,0 +1,50 @@
+defmodule ExAthena.Loop.Events do
+  @moduledoc """
+  Flat, pattern-matchable event tuples the loop emits to `:on_event`.
+
+  Event shape inspired by `ash_ai`'s `ToolLoop.stream/2` — one tuple per
+  logical event, exhaustive, easy to match on in LiveView handlers, OTel
+  emitters, and cost trackers. Same events feed the OpenTelemetry span
+  emitter (landing in PR 4).
+
+  Events:
+
+    * `{:content, text}` — partial or full assistant text.
+    * `{:tool_call, ToolCall.t()}` — model requested a tool call.
+    * `{:tool_result, ToolResult.t()}` — tool produced a result (or error).
+    * `{:iteration, n}` — a new iteration is starting.
+    * `{:compaction, %{before:, after:, reason:}}` — context compacted.
+    * `{:subagent_spawn, %{id:, prompt:}}` — a sub-agent started.
+    * `{:subagent_result, %{id:, text:}}` — sub-agent returned.
+    * `{:usage, usage_map}` — partial usage report from the provider.
+    * `{:structured_retry, %{attempt:, error:}}` — extract_structured
+      retry.
+    * `{:error, reason}` — non-fatal warning (the loop continues).
+    * `{:done, Result.t()}` — terminal event. Always the last event
+      emitted; the Result carries the finish_reason.
+  """
+
+  alias ExAthena.Messages.{ToolCall, ToolResult}
+  alias ExAthena.Result
+
+  @type t ::
+          {:content, String.t()}
+          | {:tool_call, ToolCall.t()}
+          | {:tool_result, ToolResult.t()}
+          | {:iteration, non_neg_integer()}
+          | {:compaction, %{required(:before) => integer(), required(:after) => integer(), required(:reason) => term()}}
+          | {:subagent_spawn, %{required(:id) => term(), required(:prompt) => String.t()}}
+          | {:subagent_result, %{required(:id) => term(), required(:text) => String.t()}}
+          | {:usage, map()}
+          | {:structured_retry, %{required(:attempt) => non_neg_integer(), required(:error) => term()}}
+          | {:error, term()}
+          | {:done, Result.t()}
+
+  @doc "Emit an event via the supplied callback (nil is a no-op)."
+  @spec emit((t() -> term()) | nil, t()) :: :ok
+  def emit(nil, _event), do: :ok
+  def emit(callback, event) when is_function(callback, 1) do
+    callback.(event)
+    :ok
+  end
+end

--- a/lib/ex_athena/loop/mode.ex
+++ b/lib/ex_athena/loop/mode.ex
@@ -1,0 +1,65 @@
+defmodule ExAthena.Loop.Mode do
+  @moduledoc """
+  Pluggable control-flow strategy for the agent loop.
+
+  Modes decide *what to do each turn*. The kernel handles everything else —
+  tool dispatch, permissions, hooks, events, accounting. Modes sit on top
+  and shape the iteration: ReAct is "infer → tool → loop", Plan-and-Solve
+  is "plan once → execute many", Reflexion adds a self-critique pass.
+
+  ## Writing a mode
+
+      defmodule MyMode do
+        @behaviour ExAthena.Loop.Mode
+
+        @impl true
+        def init(state), do: {:ok, state}
+
+        @impl true
+        def iterate(state) do
+          # Run inference, handle tool calls, update state, decide continue/halt.
+          # Return {:continue, state} to keep looping, {:halt, state} to stop.
+          {:continue, state}
+        end
+      end
+
+  The builtin `ExAthena.Modes.ReAct` is a reference implementation.
+
+  ## Atom shortcuts
+
+  `:react`, `:plan_and_solve`, `:reflexion` resolve to the builtin modules.
+  Any other atom or a module reference is used verbatim.
+  """
+
+  alias ExAthena.Loop.State
+
+  @doc "Called once before the first iteration. Use to prime mode-specific state."
+  @callback init(State.t()) :: {:ok, State.t()} | {:error, term()}
+
+  @doc """
+  Drive one iteration. Return one of:
+
+    * `{:continue, State.t()}` — keep looping (kernel checks caps + budget).
+    * `{:halt, State.t()}` — stop looping; the kernel produces a `Result`
+      from the terminal state's `finish_reason` (which the mode should set
+      via `ExAthena.Loop.set_finish_reason/2` before returning).
+    * `{:error, reason}` — abort with an unrecoverable error. The kernel
+      wraps this in `:error_during_execution`.
+  """
+  @callback iterate(State.t()) :: {:continue, State.t()} | {:halt, State.t()} | {:error, term()}
+
+  @builtins %{
+    react: ExAthena.Modes.ReAct,
+    plan_and_solve: ExAthena.Modes.PlanAndSolve,
+    reflexion: ExAthena.Modes.Reflexion
+  }
+
+  @doc "Resolve an atom shortcut or module to the Mode module."
+  @spec resolve(atom() | module()) :: module()
+  def resolve(mode) when is_atom(mode) do
+    case Map.fetch(@builtins, mode) do
+      {:ok, module} -> module
+      :error -> mode
+    end
+  end
+end

--- a/lib/ex_athena/loop/parallel.ex
+++ b/lib/ex_athena/loop/parallel.ex
@@ -1,0 +1,182 @@
+defmodule ExAthena.Loop.Parallel do
+  @moduledoc """
+  Parallel tool-call dispatcher.
+
+  When a model emits multiple tool calls in a single response, the kernel
+  groups them:
+
+    * **Read-only calls** (tool's `parallel_safe?/0` returns `true`) run
+      concurrently via `Task.async_stream/3`.
+    * **Mutating calls** run serially in the order the model emitted them,
+      to preserve deterministic side-effect ordering.
+
+  Regardless of execution order, results are returned in the same order as
+  the input tool calls — the model always sees results aligned with its
+  calls.
+  """
+
+  alias ExAthena.{Hooks, Permissions}
+  alias ExAthena.Loop.Events
+  alias ExAthena.Messages
+  alias ExAthena.Messages.ToolCall
+  alias ExAthena.Tools
+
+  @doc """
+  Execute a list of tool calls.
+
+  `runner_fn` is `(ToolCall.t(), state -> {result, updated_state})`. The
+  `result` is whatever the single-call runner returns (typically a
+  tool-result message tuple or a `:halt` tuple). Updated state threads the
+  phase transitions, mistake counter, and budget.
+
+  Returns `{:ok, results_in_order, final_state}` or
+  `{:halt, reason, final_state}` when any call returns a halt.
+
+  Ordering guarantee: `results_in_order` is ordered the same as the input
+  `calls`, even though parallel-safe calls may execute out-of-order.
+  """
+  @spec run([ToolCall.t()], map(), (ToolCall.t(), map() -> {term(), map()})) ::
+          {:ok, [term()], map()} | {:halt, term(), map()}
+  def run(calls, state, runner_fn) do
+    {parallel_safe, must_serial} = classify(calls, state.tool_modules)
+
+    # Mutations first, in order, so the filesystem state parallel tools see
+    # (if any) is the post-mutation state. This matches what a human would
+    # do when the model says "write file X; then grep it".
+    case run_serial(must_serial, state, runner_fn) do
+      {:ok, serial_results, state} ->
+        case run_concurrent(parallel_safe, state, runner_fn) do
+          {:ok, parallel_results, state} ->
+            merged = merge_in_order(calls, serial_results ++ parallel_results)
+            {:ok, merged, state}
+
+          {:halt, _reason, _state} = halt ->
+            halt
+        end
+
+      {:halt, _reason, _state} = halt ->
+        halt
+    end
+  end
+
+  # ── Classification ────────────────────────────────────────────────
+
+  defp classify(calls, tool_modules) do
+    Enum.split_with(calls, fn call ->
+      case Tools.find(tool_modules, call.name) do
+        nil -> false
+        mod -> parallel_safe?(mod)
+      end
+    end)
+  end
+
+  defp parallel_safe?(mod) do
+    function_exported?(mod, :parallel_safe?, 0) and mod.parallel_safe?()
+  end
+
+  # ── Serial execution ──────────────────────────────────────────────
+
+  defp run_serial(calls, state, runner_fn) do
+    Enum.reduce_while(calls, {:ok, [], state}, fn call, {:ok, acc, state} ->
+      case runner_fn.(call, state) do
+        {{:halt, reason}, new_state} -> {:halt, {:halt, reason, new_state}}
+        {result, new_state} -> {:cont, {:ok, acc ++ [{call.id, result}], new_state}}
+      end
+    end)
+  end
+
+  # ── Parallel execution ────────────────────────────────────────────
+
+  defp run_concurrent([], state, _runner_fn), do: {:ok, [], state}
+
+  defp run_concurrent(calls, state, runner_fn) do
+    concurrency = max(1, state.max_concurrency || 4)
+    timeout = state.tool_timeout_ms || 60_000
+
+    # Snapshot the state each task reads. Tasks do NOT mutate shared state —
+    # their `runner_fn` returns per-call state deltas we fold back in order
+    # afterwards. This avoids race conditions on things like the mistake
+    # counter, which we'd otherwise see interleaved.
+    calls
+    |> Task.async_stream(
+      fn call -> {call.id, runner_fn.(call, state)} end,
+      max_concurrency: concurrency,
+      timeout: timeout,
+      on_timeout: :kill_task,
+      ordered: false
+    )
+    |> Enum.reduce_while({:ok, [], state}, fn
+      {:ok, {call_id, {{:halt, reason}, _new_state}}}, {:ok, _acc, state} ->
+        {:halt, {:halt, reason, fold_halt(state, call_id, reason)}}
+
+      {:ok, {call_id, {result, deltas}}}, {:ok, acc, state} ->
+        {:cont, {:ok, acc ++ [{call_id, result}], fold_deltas(state, deltas)}}
+
+      {:exit, {reason, _}}, {:ok, acc, state} ->
+        # One task crashed or timed out — surface as an error result for the
+        # corresponding call but don't halt. The kernel converts it to a
+        # tool-error replay message.
+        err_result = Messages.tool_result("unknown", "parallel task failed: #{inspect(reason)}", true)
+        {:cont, {:ok, acc ++ [{nil, err_result}], state}}
+    end)
+  end
+
+  defp fold_halt(state, _call_id, _reason), do: state
+
+  # Each task returns its own fresh `state`; we only keep deltas that matter
+  # across concurrent tasks: the budget accumulator. Mistake counter and ctx
+  # phase belong to the sequential path.
+  defp fold_deltas(state, new_state) do
+    case new_state do
+      %{budget: b} when not is_nil(b) -> %{state | budget: b}
+      _ -> state
+    end
+  end
+
+  # ── Ordering ──────────────────────────────────────────────────────
+
+  # Results come back as `[{call_id, result}]` — one per input call. Re-sort
+  # them into the original call order.
+  defp merge_in_order(calls, results) do
+    by_id = Map.new(results, fn {id, r} -> {id, r} end)
+    Enum.map(calls, fn c -> Map.get(by_id, c.id) end)
+  end
+
+  # ── Permission/hook helpers (used by the kernel, exposed here so the
+  # serial + parallel paths share one implementation) ───────────────
+
+  @doc """
+  Run the pre-tool gate (permissions + PreToolUse hooks) for a single call.
+
+  Returns `:allow`, `{:deny, reason}`, or `{:halt, reason}`.
+  """
+  @spec pre_tool_gate(ToolCall.t(), map()) ::
+          :allow | {:deny, term()} | {:halt, term()}
+  def pre_tool_gate(%ToolCall{name: name, arguments: args, id: id}, state) do
+    case Permissions.check(%ToolCall{id: id, name: name, arguments: args}, state.ctx, state.permissions_opts) do
+      :allow ->
+        # Hooks.run_pre_tool_use returns :ok (continue), {:deny, reason}, or
+        # {:halt, reason}. Normalise :ok → :allow so the caller can match
+        # on one surface.
+        case Hooks.run_pre_tool_use(state.hooks, name, args, id) do
+          :ok -> :allow
+          {:deny, _} = deny -> deny
+          {:halt, _} = halt -> halt
+        end
+
+      {:deny, _reason} = deny ->
+        deny
+    end
+  end
+
+  @doc "Emit tool-call / tool-result events and update counters."
+  @spec emit_events(map(), ToolCall.t(), Messages.Message.t()) :: :ok
+  def emit_events(state, %ToolCall{} = call, tool_message) do
+    Events.emit(state.on_event, {:tool_call, call})
+
+    case tool_message.tool_results do
+      [tr | _] -> Events.emit(state.on_event, {:tool_result, tr})
+      _ -> :ok
+    end
+  end
+end

--- a/lib/ex_athena/loop/state.ex
+++ b/lib/ex_athena/loop/state.ex
@@ -1,0 +1,83 @@
+defmodule ExAthena.Loop.State do
+  @moduledoc """
+  Internal state of a running agent loop.
+
+  Opaque to consumers. `ExAthena.Loop.Mode` implementations receive and
+  return this struct as they drive iterations. The public result of a run
+  is `ExAthena.Result`, which is built from the terminal `State`.
+
+  ## Fields
+
+  - `messages` — running conversation history.
+  - `tool_modules` — resolved tool modules for this run.
+  - `capabilities` — provider capabilities map.
+  - `provider_mod`, `provider_opts` — inference entry point.
+  - `request_template` — base request overlaid each iteration with fresh
+    messages + tool schemas.
+  - `permissions_opts` — fed to `ExAthena.Permissions`.
+  - `hooks` — lifecycle matcher/callback sets.
+  - `ctx` — `ExAthena.ToolContext` threaded to every tool execution.
+  - `on_event` — user-supplied callback for stream events.
+  - `budget` — `ExAthena.Budget` accumulator.
+  - `max_iterations`, `max_consecutive_mistakes`, `max_budget_usd`,
+    `tool_timeout_ms`, `max_concurrency` — reliability knobs.
+  - `iterations`, `tool_calls_made`, `consecutive_mistakes` — counters.
+  - `mode`, `mode_state` — Mode module + its private state.
+  - `halted_reason` — populated when a tool / hook returns `:halt`.
+  - `meta` — free-form map for Mode-specific data that doesn't fit
+    anywhere else.
+  """
+
+  alias ExAthena.{Budget, ToolContext}
+  alias ExAthena.Messages.Message
+
+  defstruct messages: [],
+            tool_modules: [],
+            capabilities: %{},
+            provider_mod: nil,
+            provider_opts: [],
+            request_template: nil,
+            permissions_opts: %{},
+            hooks: %{},
+            ctx: nil,
+            on_event: nil,
+            budget: nil,
+            max_iterations: 25,
+            max_consecutive_mistakes: 3,
+            max_budget_usd: nil,
+            tool_timeout_ms: 60_000,
+            max_concurrency: 4,
+            iterations: 0,
+            tool_calls_made: 0,
+            consecutive_mistakes: 0,
+            mode: nil,
+            mode_state: %{},
+            halted_reason: nil,
+            meta: %{}
+
+  @type t :: %__MODULE__{
+          messages: [Message.t()],
+          tool_modules: [module()],
+          capabilities: map(),
+          provider_mod: module() | nil,
+          provider_opts: keyword(),
+          request_template: term(),
+          permissions_opts: map(),
+          hooks: map(),
+          ctx: ToolContext.t() | nil,
+          on_event: (term() -> term()) | nil,
+          budget: Budget.t() | nil,
+          max_iterations: non_neg_integer(),
+          max_consecutive_mistakes: non_neg_integer(),
+          max_budget_usd: float() | nil,
+          tool_timeout_ms: pos_integer(),
+          max_concurrency: pos_integer(),
+          iterations: non_neg_integer(),
+          tool_calls_made: non_neg_integer(),
+          consecutive_mistakes: non_neg_integer(),
+          mode: module() | nil,
+          mode_state: map(),
+          halted_reason: term() | nil,
+          meta: map()
+        }
+end

--- a/lib/ex_athena/modes/plan_and_solve.ex
+++ b/lib/ex_athena/modes/plan_and_solve.ex
@@ -1,0 +1,20 @@
+defmodule ExAthena.Modes.PlanAndSolve do
+  @moduledoc """
+  Plan-and-Solve mode (PR 3).
+
+  Two-phase operation: a planning turn writes a plan, then executor turns
+  follow the plan. Full implementation lands in PR 3. For now this module
+  exists so `ExAthena.Loop.Mode.resolve(:plan_and_solve)` returns a valid
+  module.
+
+  Falls back to `ExAthena.Modes.ReAct` if invoked.
+  """
+
+  @behaviour ExAthena.Loop.Mode
+
+  @impl true
+  def init(_state), do: {:error, :plan_and_solve_not_implemented_until_pr3}
+
+  @impl true
+  def iterate(_state), do: {:error, :plan_and_solve_not_implemented_until_pr3}
+end

--- a/lib/ex_athena/modes/react.ex
+++ b/lib/ex_athena/modes/react.ex
@@ -1,0 +1,219 @@
+defmodule ExAthena.Modes.ReAct do
+  @moduledoc """
+  Default mode: Reason-Act cycle.
+
+  Each iteration:
+
+    1. Build a Request from current messages + tools + system prompt.
+    2. Call the provider (one-shot, not streaming — streaming is an
+       optimisation landing in PR 4).
+    3. Extract tool calls (native, or TextTagged fallback via
+       `ExAthena.ToolCalls`).
+    4. If no tool calls: emit `{:content, text}`, set `finish_reason:
+       :stop`, and halt.
+    5. If tool calls: run them (parallel-safe ones concurrently, mutating
+       ones serially), append results, continue.
+
+  Budget + mistake-counter checks happen between iterations in the kernel.
+  This mode only implements the turn-by-turn behaviour.
+  """
+
+  @behaviour ExAthena.Loop.Mode
+
+  alias ExAthena.{Budget, Messages}
+  alias ExAthena.Loop.{Events, Parallel, State}
+  alias ExAthena.Messages.ToolCall
+  alias ExAthena.Tools
+
+  @impl true
+  def init(%State{} = state), do: {:ok, state}
+
+  @impl true
+  def iterate(%State{} = state) do
+    request = build_request(state)
+
+    case state.provider_mod.query(request, state.provider_opts) do
+      {:ok, response} ->
+        # Accumulate usage + cost before considering termination.
+        state = fold_usage(state, response)
+
+        case ExAthena.ToolCalls.extract(
+               %{tool_calls: response.tool_calls, text: response.text},
+               state.capabilities
+             ) do
+          {:ok, []} ->
+            # Terminal: model returned plain text with no tool calls.
+            Events.emit(state.on_event, {:content, response.text || ""})
+
+            state =
+              %{
+                state
+                | messages: state.messages ++ [Messages.assistant(response.text)]
+              }
+              |> set_finish_reason(:stop)
+
+            {:halt, state}
+
+          {:ok, tool_calls} ->
+            Events.emit(state.on_event, {:content, response.text || ""})
+
+            assistant_msg = Messages.assistant(response.text, tool_calls)
+            state = %{state | messages: state.messages ++ [assistant_msg]}
+
+            runner = fn call, st -> run_single_tool_call(call, st) end
+
+            case Parallel.run(tool_calls, state, runner) do
+              {:ok, tool_messages, state} ->
+                state = %{
+                  state
+                  | messages: state.messages ++ tool_messages,
+                    tool_calls_made: state.tool_calls_made + length(tool_calls)
+                }
+
+                {:continue, state}
+
+              {:halt, reason, state} ->
+                state =
+                  %{state | halted_reason: reason}
+                  |> set_finish_reason(:error_halted)
+
+                {:halt, state}
+            end
+
+          {:error, reason} ->
+            state =
+              %{state | halted_reason: {:tool_call_parse_failed, reason}}
+              |> set_finish_reason(:error_during_execution)
+
+            {:halt, state}
+        end
+
+      {:error, reason} ->
+        state =
+          %{state | halted_reason: reason}
+          |> set_finish_reason(:error_during_execution)
+
+        {:halt, state}
+    end
+  end
+
+  # ── Tool execution for one call ───────────────────────────────────
+
+  defp run_single_tool_call(%ToolCall{} = call, state) do
+    case Parallel.pre_tool_gate(call, state) do
+      :allow ->
+        do_execute(call, state)
+
+      {:deny, reason} ->
+        result = Messages.tool_result(call.id, "permission denied: #{inspect(reason)}", true)
+        state = bump_mistake(state)
+        Parallel.emit_events(state, call, result)
+        {result, state}
+
+      {:halt, reason} ->
+        {{:halt, reason}, state}
+    end
+  end
+
+  defp do_execute(%ToolCall{} = call, state) do
+    ctx = %{state.ctx | tool_call_id: call.id}
+
+    case Tools.find(state.tool_modules, call.name) do
+      nil ->
+        result = Messages.tool_result(call.id, "unknown tool: #{call.name}", true)
+        state = bump_mistake(state)
+        Parallel.emit_events(state, call, result)
+        {result, state}
+
+      mod ->
+        case mod.execute(call.arguments, ctx) do
+          {:ok, %{phase_transition: new_phase} = payload} ->
+            # Phase transition sentinel — special-case only in the single-tool runner.
+            msg = Map.get(payload, :message, "phase -> #{new_phase}")
+            state = %{state | ctx: %{state.ctx | phase: new_phase}} |> reset_mistakes()
+            result = Messages.tool_result(call.id, to_string(msg))
+            after_post_hook(state, call, result)
+
+          {:ok, payload} ->
+            result = Messages.tool_result(call.id, stringify(payload))
+            state = reset_mistakes(state)
+            after_post_hook(state, call, result)
+
+          {:error, reason} ->
+            result = Messages.tool_result(call.id, "error: #{stringify(reason)}", true)
+            state = bump_mistake(state)
+            after_post_hook(state, call, result)
+
+          {:halt, reason} ->
+            {{:halt, reason}, state}
+
+          other ->
+            result = Messages.tool_result(call.id, "invalid tool return: #{inspect(other)}", true)
+            state = bump_mistake(state)
+            after_post_hook(state, call, result)
+        end
+    end
+  end
+
+  # Run PostToolUse hooks then emit events.
+  defp after_post_hook(state, call, result) do
+    case ExAthena.Hooks.run_post_tool_use(state.hooks, call.name, %{result: result}, call.id) do
+      {:halt, reason} -> {{:halt, reason}, state}
+      _ -> emit_and_return(state, call, result)
+    end
+  end
+
+  defp emit_and_return(state, call, result) do
+    Parallel.emit_events(state, call, result)
+    {result, state}
+  end
+
+  # ── State helpers ─────────────────────────────────────────────────
+
+  defp bump_mistake(%State{consecutive_mistakes: n} = state),
+    do: %{state | consecutive_mistakes: n + 1}
+
+  defp reset_mistakes(state), do: %{state | consecutive_mistakes: 0}
+
+  defp set_finish_reason(state, reason) do
+    put_in(state.meta[:finish_reason], reason)
+  end
+
+  defp fold_usage(state, response) do
+    budget = state.budget || Budget.new()
+    new_budget = Budget.add(budget, response.usage, nil)
+
+    if response.usage do
+      Events.emit(state.on_event, {:usage, response.usage})
+    end
+
+    %{state | budget: new_budget}
+  end
+
+  # ── Request building ──────────────────────────────────────────────
+
+  defp build_request(state) do
+    %{
+      state.request_template
+      | messages: state.messages,
+        tools: tool_schemas(state.tool_modules, state.capabilities),
+        system_prompt: effective_system_prompt(state)
+    }
+  end
+
+  defp tool_schemas(modules, %{native_tool_calls: true}), do: Tools.describe_for_provider(modules)
+  defp tool_schemas(_modules, _caps), do: nil
+
+  defp effective_system_prompt(%State{capabilities: %{native_tool_calls: true}} = state),
+    do: state.request_template.system_prompt
+
+  defp effective_system_prompt(state) do
+    ExAthena.ToolCalls.augment_system_prompt(
+      state.request_template.system_prompt,
+      Tools.describe_for_prompt(state.tool_modules)
+    )
+  end
+
+  defp stringify(value) when is_binary(value), do: value
+  defp stringify(value), do: inspect(value, pretty: true, limit: :infinity)
+end

--- a/lib/ex_athena/modes/reflexion.ex
+++ b/lib/ex_athena/modes/reflexion.ex
@@ -1,0 +1,19 @@
+defmodule ExAthena.Modes.Reflexion do
+  @moduledoc """
+  Reflexion mode (PR 3).
+
+  After each tool-use round, a self-critique pass reflects on the outcome
+  before the next inference. Research caps this at ~3 iterations before
+  degeneration-of-thought kicks in. Full implementation lands in PR 3.
+
+  Falls back to `:not_implemented` errors today.
+  """
+
+  @behaviour ExAthena.Loop.Mode
+
+  @impl true
+  def init(_state), do: {:error, :reflexion_not_implemented_until_pr3}
+
+  @impl true
+  def iterate(_state), do: {:error, :reflexion_not_implemented_until_pr3}
+end

--- a/lib/ex_athena/tool.ex
+++ b/lib/ex_athena/tool.ex
@@ -60,4 +60,18 @@ defmodule ExAthena.Tool do
               {:ok, result :: term()}
               | {:error, reason :: term()}
               | {:halt, reason :: term()}
+
+  @doc """
+  Whether this tool is safe to run concurrently with siblings in the same
+  iteration.
+
+  Read-only tools (Read, Glob, Grep, WebFetch) return `true`. Mutating
+  tools (Write, Edit, Bash, TodoWrite) MUST return `false` so the loop
+  preserves their ordering.
+
+  Defaults to `false` (conservative) when the callback isn't implemented.
+  """
+  @callback parallel_safe?() :: boolean()
+
+  @optional_callbacks [parallel_safe?: 0]
 end

--- a/lib/ex_athena/tools/glob.ex
+++ b/lib/ex_athena/tools/glob.ex
@@ -35,6 +35,9 @@ defmodule ExAthena.Tools.Glob do
   end
 
   @impl true
+  def parallel_safe?, do: true
+
+  @impl true
   def execute(%{"pattern" => pattern} = args, %{cwd: cwd}) when is_binary(pattern) do
     max = clamp(Map.get(args, "max_results", @default_max))
 

--- a/lib/ex_athena/tools/grep.ex
+++ b/lib/ex_athena/tools/grep.ex
@@ -38,6 +38,9 @@ defmodule ExAthena.Tools.Grep do
   end
 
   @impl true
+  def parallel_safe?, do: true
+
+  @impl true
   def execute(%{"pattern" => pattern} = args, %{cwd: cwd}) when is_binary(pattern) do
     max = clamp(Map.get(args, "max_results", @default_max))
     glob = Map.get(args, "path_glob")

--- a/lib/ex_athena/tools/read.ex
+++ b/lib/ex_athena/tools/read.ex
@@ -39,6 +39,9 @@ defmodule ExAthena.Tools.Read do
   end
 
   @impl true
+  def parallel_safe?, do: true
+
+  @impl true
   def execute(args, %ToolContext{} = ctx) do
     with {:ok, path} <- fetch_path(args, ctx),
          {:ok, stat} <- File.stat(path),

--- a/lib/ex_athena/tools/web_fetch.ex
+++ b/lib/ex_athena/tools/web_fetch.ex
@@ -39,6 +39,9 @@ defmodule ExAthena.Tools.WebFetch do
   end
 
   @impl true
+  def parallel_safe?, do: true
+
+  @impl true
   def execute(%{"url" => url} = args, _ctx) when is_binary(url) do
     timeout = Map.get(args, "timeout_ms", @default_timeout)
 

--- a/mix.exs
+++ b/mix.exs
@@ -91,10 +91,19 @@ defmodule ExAthena.MixProject do
         ],
         "Agent loop": [
           ExAthena.Loop,
+          ExAthena.Loop.Mode,
+          ExAthena.Loop.Events,
+          ExAthena.Loop.Parallel,
+          ExAthena.Loop.State,
           ExAthena.Loop.Terminations,
           ExAthena.Session,
           ExAthena.Structured,
           ExAthena.Budget
+        ],
+        Modes: [
+          ExAthena.Modes.ReAct,
+          ExAthena.Modes.PlanAndSolve,
+          ExAthena.Modes.Reflexion
         ],
         Messages: [
           ExAthena.Messages,

--- a/test/ex_athena/loop/v03_test.exs
+++ b/test/ex_athena/loop/v03_test.exs
@@ -1,0 +1,264 @@
+defmodule ExAthena.Loop.V03Test do
+  @moduledoc """
+  Tests for the v0.3 loop kernel: Result struct, typed terminations,
+  parallel tool execution, mistake counter, Mode behaviour.
+  """
+  use ExUnit.Case, async: true
+
+  alias ExAthena.{Loop, Response, Result}
+  alias ExAthena.Messages.ToolCall
+
+  defp script(responses) do
+    counter = :counters.new(1, [:atomics])
+
+    fn _request ->
+      :counters.add(counter, 1, 1)
+      n = :counters.get(counter, 1)
+      Enum.at(responses, n - 1) || List.last(responses)
+    end
+  end
+
+  setup do
+    dir = Path.join(System.tmp_dir!(), "v03_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+    {:ok, dir: dir}
+  end
+
+  describe "Result struct return type" do
+    test "normal completion returns a %Result{} with :stop finish_reason", %{dir: dir} do
+      responses = [
+        %Response{text: "ok", tool_calls: [], finish_reason: :stop, provider: :mock}
+      ]
+
+      assert {:ok, %Result{} = r} =
+               Loop.run("hi",
+                 provider: :mock,
+                 mock: [responder: script(responses)],
+                 cwd: dir,
+                 tools: []
+               )
+
+      assert r.finish_reason == :stop
+      assert r.text == "ok"
+      assert r.iterations == 0
+      assert Result.success?(r)
+    end
+
+    test "max_iterations trips :error_max_turns", %{dir: dir} do
+      loop_response = %Response{
+        text: "",
+        tool_calls: [%ToolCall{id: "x", name: "glob", arguments: %{"pattern" => "**"}}],
+        finish_reason: :tool_calls,
+        provider: :mock
+      }
+
+      assert {:ok, %Result{finish_reason: :error_max_turns, iterations: 3} = r} =
+               Loop.run("spin",
+                 provider: :mock,
+                 mock: [responder: fn _ -> loop_response end],
+                 cwd: dir,
+                 tools: [ExAthena.Tools.Glob],
+                 max_iterations: 3
+               )
+
+      assert Result.category(r) == :capacity
+    end
+
+    test "Result carries usage and duration_ms accounting", %{dir: dir} do
+      response = %Response{
+        text: "ok",
+        tool_calls: [],
+        finish_reason: :stop,
+        provider: :mock,
+        usage: %{input_tokens: 10, output_tokens: 5, total_tokens: 15}
+      }
+
+      assert {:ok, %Result{usage: usage, duration_ms: ms}} =
+               Loop.run("hi",
+                 provider: :mock,
+                 mock: [responder: fn _ -> response end],
+                 cwd: dir,
+                 tools: []
+               )
+
+      assert usage == %{input_tokens: 10, output_tokens: 5, total_tokens: 15}
+      assert is_integer(ms) and ms >= 0
+    end
+  end
+
+  describe "mistake counter" do
+    test "consecutive tool errors trip :error_consecutive_mistakes", %{dir: dir} do
+      # Every turn the model calls a nonexistent tool — each call registers a
+      # mistake. With max_consecutive_mistakes=2, third turn terminates.
+      tool_call = %ToolCall{id: "nope", name: "nonexistent_tool", arguments: %{}}
+
+      response = %Response{
+        text: "",
+        tool_calls: [tool_call],
+        finish_reason: :tool_calls,
+        provider: :mock
+      }
+
+      assert {:ok, %Result{finish_reason: :error_consecutive_mistakes} = r} =
+               Loop.run("go",
+                 provider: :mock,
+                 mock: [responder: fn _ -> response end],
+                 cwd: dir,
+                 tools: [ExAthena.Tools.Read],
+                 max_consecutive_mistakes: 2,
+                 max_iterations: 10
+               )
+
+      assert Result.category(r) == :capacity
+    end
+
+    test "successful tool call resets the mistake counter", %{dir: dir} do
+      File.write!(Path.join(dir, "foo.txt"), "hello")
+
+      counter = :counters.new(1, [:atomics])
+
+      responder = fn _req ->
+        :counters.add(counter, 1, 1)
+        n = :counters.get(counter, 1)
+
+        case n do
+          # First turn: nonexistent tool (mistake 1)
+          1 ->
+            %Response{
+              text: "",
+              tool_calls: [%ToolCall{id: "c1", name: "nonexistent", arguments: %{}}],
+              finish_reason: :tool_calls,
+              provider: :mock
+            }
+
+          # Second turn: valid tool (resets counter)
+          2 ->
+            %Response{
+              text: "",
+              tool_calls: [%ToolCall{id: "c2", name: "read", arguments: %{"path" => "foo.txt"}}],
+              finish_reason: :tool_calls,
+              provider: :mock
+            }
+
+          # Third turn: final response
+          _ ->
+            %Response{text: "done", tool_calls: [], finish_reason: :stop, provider: :mock}
+        end
+      end
+
+      # max_consecutive_mistakes=1 would trip on turn 1 ... but the valid
+      # read on turn 2 resets the counter, so the loop completes normally.
+      assert {:ok, %Result{finish_reason: :stop, text: "done"}} =
+               Loop.run("mix",
+                 provider: :mock,
+                 mock: [responder: responder],
+                 cwd: dir,
+                 tools: [ExAthena.Tools.Read],
+                 max_consecutive_mistakes: 2,
+                 max_iterations: 10
+               )
+    end
+  end
+
+  describe "parallel tool execution" do
+    test "read-only tools run concurrently; results ordered by call order", %{dir: dir} do
+      File.write!(Path.join(dir, "a.txt"), "A")
+      File.write!(Path.join(dir, "b.txt"), "B")
+      File.write!(Path.join(dir, "c.txt"), "C")
+
+      call_a = %ToolCall{id: "a", name: "read", arguments: %{"path" => "a.txt"}}
+      call_b = %ToolCall{id: "b", name: "read", arguments: %{"path" => "b.txt"}}
+      call_c = %ToolCall{id: "c", name: "read", arguments: %{"path" => "c.txt"}}
+
+      responses = [
+        %Response{
+          text: "",
+          tool_calls: [call_a, call_b, call_c],
+          finish_reason: :tool_calls,
+          provider: :mock
+        },
+        %Response{text: "done", tool_calls: [], finish_reason: :stop, provider: :mock}
+      ]
+
+      assert {:ok, %Result{finish_reason: :stop, messages: messages}} =
+               Loop.run("read three",
+                 provider: :mock,
+                 mock: [responder: script(responses)],
+                 cwd: dir,
+                 tools: [ExAthena.Tools.Read]
+               )
+
+      tool_results =
+        messages
+        |> Enum.filter(&match?(%{role: :tool}, &1))
+        |> Enum.flat_map(fn m -> m.tool_results end)
+
+      assert length(tool_results) == 3
+
+      # Results must be in call order.
+      assert Enum.at(tool_results, 0).tool_call_id == "a"
+      assert Enum.at(tool_results, 1).tool_call_id == "b"
+      assert Enum.at(tool_results, 2).tool_call_id == "c"
+    end
+  end
+
+  describe "flat event tuples" do
+    test "emits :iteration, :content, :tool_call, :tool_result, :done", %{dir: dir} do
+      File.write!(Path.join(dir, "x.txt"), "x")
+
+      responses = [
+        %Response{
+          text: "reading",
+          tool_calls: [%ToolCall{id: "t1", name: "read", arguments: %{"path" => "x.txt"}}],
+          finish_reason: :tool_calls,
+          provider: :mock
+        },
+        %Response{text: "done", tool_calls: [], finish_reason: :stop, provider: :mock}
+      ]
+
+      test_pid = self()
+
+      {:ok, %Result{}} =
+        Loop.run("read",
+          provider: :mock,
+          mock: [responder: script(responses)],
+          cwd: dir,
+          tools: [ExAthena.Tools.Read],
+          on_event: fn e -> send(test_pid, {:evt, e}) end
+        )
+
+      assert_receive {:evt, {:iteration, 0}}
+      assert_receive {:evt, {:content, "reading"}}
+      assert_receive {:evt, {:tool_call, %ToolCall{id: "t1"}}}
+      assert_receive {:evt, {:tool_result, _}}
+      assert_receive {:evt, {:content, "done"}}
+      assert_receive {:evt, {:done, %Result{finish_reason: :stop}}}
+    end
+  end
+
+  describe "Mode behaviour" do
+    test "default mode is :react", %{dir: dir} do
+      responses = [%Response{text: "ok", tool_calls: [], finish_reason: :stop, provider: :mock}]
+
+      # No :mode opt — defaults to :react. Assert it works.
+      assert {:ok, %Result{finish_reason: :stop, text: "ok"}} =
+               Loop.run("hi",
+                 provider: :mock,
+                 mock: [responder: script(responses)],
+                 cwd: dir,
+                 tools: []
+               )
+    end
+
+    test "resolve/1 returns a module for atom shortcuts" do
+      assert ExAthena.Loop.Mode.resolve(:react) == ExAthena.Modes.ReAct
+      assert ExAthena.Loop.Mode.resolve(:plan_and_solve) == ExAthena.Modes.PlanAndSolve
+      assert ExAthena.Loop.Mode.resolve(:reflexion) == ExAthena.Modes.Reflexion
+    end
+
+    test "resolve/1 passes through unknown atoms as modules" do
+      assert ExAthena.Loop.Mode.resolve(SomeUserMode) == SomeUserMode
+    end
+  end
+end

--- a/test/ex_athena/loop_test.exs
+++ b/test/ex_athena/loop_test.exs
@@ -87,7 +87,7 @@ defmodule ExAthena.LoopTest do
 
     responder = fn _req -> loop_response end
 
-    assert {:error, {:max_iterations_exceeded, 3}} =
+    assert {:ok, %ExAthena.Result{finish_reason: :error_max_turns, iterations: 3}} =
              Loop.run("spin",
                provider: :mock,
                mock: [responder: responder],
@@ -151,7 +151,8 @@ defmodule ExAthena.LoopTest do
 
     tool_msg = Enum.find(result.messages, &match?(%{role: :tool}, &1))
     assert [%{is_error: true, content: content}] = tool_msg.tool_results
-    assert content =~ "unknown_tool"
+    assert content =~ "unknown tool"
+    assert content =~ "nonexistent_tool"
   end
 
   test "plan_mode tool changes the ctx phase mid-loop", %{dir: dir} do


### PR DESCRIPTION
## Summary

Second of four PRs rewriting the agent loop. **This is the breaking-change PR** — v0.2's `Loop.run/2` return map becomes `%ExAthena.Result{}`, and the event stream shape flips from `%Streaming.Event{}` struct to flat tuples. udin_code stays on v0.2 for now; migration happens in PR 4.

## Added

### Pluggable Mode behaviour (langchain `LLMChain.Mode`-inspired)

- `ExAthena.Loop.Mode` — behaviour with `init/1` + `iterate/1`.
- `ExAthena.Modes.ReAct` — default mode (reason → act → observe).
- `ExAthena.Modes.PlanAndSolve` + `Reflexion` — stubs, full impl in PR 3.
- `Loop.Mode.resolve/1` translates `:react`/`:plan_and_solve`/`:reflexion` atoms to modules.

### Reliability knobs

- `:max_consecutive_mistakes` (default 3) — Cline-style mistake counter trips `:error_consecutive_mistakes`; successful tool calls reset it.
- `:max_budget_usd` — trips `:error_max_budget_usd` when Budget accumulator crosses cap. Cost computation from provider metadata lands in PR 3.
- `:tool_timeout_ms` (default 60_000) — per-call timeout for parallel execution.
- `:max_concurrency` (default 4) — `Task.async_stream/3` concurrency cap.

### Parallel tool execution

- `ExAthena.Loop.Parallel` — splits a single iteration's tool calls into parallel-safe (read-only) and serial (mutating). Mutations run first in order; parallel-safe calls run concurrently via `Task.async_stream/3`. Result order always aligns with input call order so the model never sees scrambled results.
- `ExAthena.Tool.parallel_safe?/0` optional callback (default `false`).
- Read-only builtins (`Read`, `Glob`, `Grep`, `WebFetch`) declare `true`. Mutating builtins (`Write`, `Edit`, `Bash`, `TodoWrite`) stay serial.

## Breaking changes

### Return type: `{:ok, Result.t()}` instead of `{:ok, map()}`

Every termination — success or error — produces a `%Result{}` carrying:

    text, messages, finish_reason, halted_reason,
    iterations, tool_calls_made, usage, cost_usd,
    duration_ms, model, provider, telemetry

`finish_reason` is one of the typed subtypes from `ExAthena.Loop.Terminations` (`:stop`, `:error_max_turns`, `:error_max_budget_usd`, `:error_during_execution`, `:error_max_structured_output_retries`, `:error_consecutive_mistakes`, `:error_halted`, `:error_compaction_failed`).

Caps no longer return `{:error, {:max_iterations_exceeded, N}}` — they succeed with `{:ok, %Result{finish_reason: :error_max_turns}}`. Pattern-match on `finish_reason` or use `Result.category/1` (`:success | :retryable | :capacity | :fatal`).

### Event shape: flat tuples instead of struct

v0.2's `%ExAthena.Streaming.Event{type:, data:, index:}` becomes tuples (ash_ai-inspired, exhaustive, pattern-matchable):

```elixir
{:content, text}
{:tool_call, ToolCall.t()}
{:tool_result, ToolResult.t()}
{:iteration, integer()}
{:usage, usage_map}
{:error, term()}
{:done, Result.t()}
```

Consumers subscribing via `:on_event` need to update handlers. The same tuples feed PR 4's OTel GenAI-semconv span emitter.

### Error handling

Tool errors replay as `is_error: true` tool-results (Cline pattern) so the model can self-correct. Unknown tools + parse failures flow as error tool-results, not run-halting errors. Hook halts produce `:error_halted`.

## Tests

- **126 total** (up from 116 in PR 1). 10 new tests cover:
  - Result struct shape + termination subtypes
  - `max_iterations` → `:error_max_turns`
  - Mistake counter trip + reset-on-success
  - Parallel tool execution ordering (read-only concurrent, results aligned)
  - Flat event tuples emission
  - `Mode.resolve/1`
- Two v0.2 tests updated for the new Result shape and error-result wording.

## Roadmap

- **PR 3 — Reliability + intelligence**: context compaction at 60% threshold, full budget accounting from provider metadata, structured-output repair loop (instructor-style), PlanAndSolve + Reflexion mode implementations, subagent primitive upgrade.
- **PR 4 — Observability + udin migration**: OpenTelemetry GenAI semconv, udin_code migration to v0.3 including the 7 direct-SDK callers. Hex publish after this.

## Test plan

- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix test` — 126 passing, 0 failures
- [x] `mix hex.build` — clean
- [ ] **udin_code** — still on v0.2; no migration until PR 4. Path dep points at this branch; udin_code is expected to compile but any consumer that pattern-matches on the v0.2 Loop return shape will break. For this dogfood cycle udin_code stays pinned to a pre-PR-2 ref.