### PR TITLE
feat(v0.3): PR 4 — OpenTelemetry GenAI semconv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,37 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and ExAthena adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.3.0-dev — in progress (PR 3 landed)
+## v0.3.0 — PR 4 (observability) landed; Phase 4 closed
+
+### PR 4 — Observability
+
+#### Added — OpenTelemetry GenAI semconv telemetry
+
+- `ExAthena.Telemetry` — emits `:telemetry`-library events shaped to the
+  OpenTelemetry GenAI semantic conventions. Consumers bridge to OTel
+  via `opentelemetry_telemetry` (no direct OTel dep). Events:
+  - `[:ex_athena, :loop, :start | :stop | :exception]`
+  - `[:ex_athena, :chat, :start | :stop]`
+  - `[:ex_athena, :tool, :start | :stop]`
+  - `[:ex_athena, :compaction, :stop]`
+  - `[:ex_athena, :subagent, :spawn | :stop]`
+  - `[:ex_athena, :structured_retry]`
+- GenAI semconv metadata keys: `gen_ai_operation_name`,
+  `gen_ai_provider_name`, `gen_ai_request_model`, `gen_ai_agent_id`,
+  `gen_ai_conversation_id`, `gen_ai_tool_name`, `gen_ai_tool_call_id`,
+  `gen_ai_usage_input_tokens`, `gen_ai_usage_output_tokens`,
+  `gen_ai_response_finish_reasons`.
+- New `:conversation_id` / `:agent_id` opts on `Loop.run/2` — threaded
+  into every emitted event's metadata so OTel traces can stitch across
+  turns.
+- `Telemetry.span/3` helper wraps arbitrary work in a start/stop pair
+  with duration measurement + exception re-raising.
+
+#### Released
+
+- Version bump `0.3.0-dev` → `0.3.0`. Ready for Hex publish.
+
+## v0.3.0-dev — PR 3 landed
 
 ### PR 3 — Reliability + intelligence
 

--- a/lib/ex_athena/loop.ex
+++ b/lib/ex_athena/loop.ex
@@ -58,7 +58,7 @@ defmodule ExAthena.Loop do
       (e.g. unknown provider, bad tool module).
   """
 
-  alias ExAthena.{Budget, Config, Error, Request, Result, Tools}
+  alias ExAthena.{Budget, Config, Error, Request, Result, Telemetry, Tools}
   alias ExAthena.Loop.{Events, Mode, State}
 
   @default_max_iterations 25
@@ -70,10 +70,21 @@ defmodule ExAthena.Loop do
   def run(prompt, opts \\ []) do
     started_at = System.monotonic_time(:millisecond)
 
-    with {:ok, state} <- build_initial_state(prompt, opts),
-         {:ok, state} <- state.mode.init(state) do
-      state |> loop() |> to_result(started_at)
-    end
+    meta =
+      Telemetry.genai_meta(
+        operation: "invoke_agent",
+        provider: Keyword.get(opts, :provider),
+        request_model: Keyword.get(opts, :model),
+        agent_id: Keyword.get(opts, :agent_id),
+        conversation_id: Keyword.get(opts, :conversation_id)
+      )
+
+    Telemetry.span([:ex_athena, :loop], meta, fn ->
+      with {:ok, state} <- build_initial_state(prompt, opts),
+           {:ok, state} <- state.mode.init(state) do
+        state |> loop() |> to_result(started_at)
+      end
+    end)
   end
 
   # ── Loop body ─────────────────────────────────────────────────────
@@ -137,6 +148,16 @@ defmodule ExAthena.Loop do
           new_budget = Map.get(metadata, :budget, state.budget)
 
           Events.emit(state.on_event, {:compaction, metadata})
+
+          Telemetry.event(
+            [:ex_athena, :compaction, :stop],
+            %{
+              before_tokens: Map.get(metadata, :before),
+              after_tokens: Map.get(metadata, :after),
+              dropped_count: Map.get(metadata, :dropped_count)
+            },
+            %{reason: Map.get(metadata, :reason)}
+          )
 
           {:ok, %{state | messages: new_messages, budget: new_budget}}
 
@@ -287,7 +308,14 @@ defmodule ExAthena.Loop do
   end
 
   defp compaction_meta(opts) do
-    [:compactor, :compact_at, :pinned_prefix_count, :live_suffix_count]
+    [
+      :compactor,
+      :compact_at,
+      :pinned_prefix_count,
+      :live_suffix_count,
+      :conversation_id,
+      :agent_id
+    ]
     |> Enum.reduce(%{}, fn key, acc ->
       case Keyword.get(opts, key) do
         nil -> acc

--- a/lib/ex_athena/modes/react.ex
+++ b/lib/ex_athena/modes/react.ex
@@ -20,7 +20,7 @@ defmodule ExAthena.Modes.ReAct do
 
   @behaviour ExAthena.Loop.Mode
 
-  alias ExAthena.{Budget, Messages}
+  alias ExAthena.{Budget, Messages, Telemetry}
   alias ExAthena.Loop.{Events, Parallel, State}
   alias ExAthena.Messages.ToolCall
   alias ExAthena.Tools
@@ -32,7 +32,17 @@ defmodule ExAthena.Modes.ReAct do
   def iterate(%State{} = state) do
     request = build_request(state)
 
-    case state.provider_mod.query(request, state.provider_opts) do
+    chat_meta =
+      Telemetry.genai_meta(
+        operation: "chat",
+        provider: state.provider_mod,
+        request_model: request.model,
+        conversation_id: Map.get(state.meta, :conversation_id)
+      )
+
+    case Telemetry.span([:ex_athena, :chat], chat_meta, fn ->
+           state.provider_mod.query(request, state.provider_opts)
+         end) do
       {:ok, response} ->
         # Accumulate usage + cost before considering termination.
         state = fold_usage(state, response)
@@ -118,6 +128,14 @@ defmodule ExAthena.Modes.ReAct do
   defp do_execute(%ToolCall{} = call, state) do
     ctx = %{state.ctx | tool_call_id: call.id}
 
+    tool_meta =
+      Telemetry.genai_meta(
+        operation: "execute_tool",
+        tool_name: call.name,
+        tool_call_id: call.id,
+        conversation_id: Map.get(state.meta, :conversation_id)
+      )
+
     case Tools.find(state.tool_modules, call.name) do
       nil ->
         result = Messages.tool_result(call.id, "unknown tool: #{call.name}", true)
@@ -126,7 +144,9 @@ defmodule ExAthena.Modes.ReAct do
         {result, state}
 
       mod ->
-        case mod.execute(call.arguments, ctx) do
+        case Telemetry.span([:ex_athena, :tool], tool_meta, fn ->
+               mod.execute(call.arguments, ctx)
+             end) do
           {:ok, %{phase_transition: new_phase} = payload} ->
             # Phase transition sentinel — special-case only in the single-tool runner.
             msg = Map.get(payload, :message, "phase -> #{new_phase}")

--- a/lib/ex_athena/structured.ex
+++ b/lib/ex_athena/structured.ex
@@ -133,10 +133,17 @@ defmodule ExAthena.Structured do
       "\n\nReturn only the JSON object (or a fenced ~~~json block)."
   end
 
-  defp emit_retry(nil, _attempt, _error), do: :ok
+  defp emit_retry(callback, attempt, error) do
+    ExAthena.Telemetry.event(
+      [:ex_athena, :structured_retry],
+      %{attempt: attempt},
+      %{error: error}
+    )
 
-  defp emit_retry(callback, attempt, error) when is_function(callback, 1) do
-    callback.({:structured_retry, %{attempt: attempt, error: error}})
+    if is_function(callback, 1) do
+      callback.({:structured_retry, %{attempt: attempt, error: error}})
+    end
+
     :ok
   end
 

--- a/lib/ex_athena/telemetry.ex
+++ b/lib/ex_athena/telemetry.ex
@@ -1,0 +1,132 @@
+defmodule ExAthena.Telemetry do
+  @moduledoc """
+  Telemetry emission for ExAthena, shaped to the OpenTelemetry GenAI
+  semantic conventions so consumers can plug directly into OTel without
+  a translation layer.
+
+  ## Events
+
+  All events use the standard `:telemetry` library — attach handlers with
+  `:telemetry.attach/4` or use `opentelemetry_telemetry` for OTel.
+
+    * `[:ex_athena, :loop, :start]` — a `Loop.run/2` began.
+    * `[:ex_athena, :loop, :stop]` — the loop terminated. Measurements
+      include `:duration_ms`, `:iterations`, `:tool_calls_made`,
+      `:cost_usd`. Metadata includes the full `%Result{}`.
+    * `[:ex_athena, :loop, :exception]` — an unhandled error bubbled out.
+    * `[:ex_athena, :chat, :start]` — a single provider call began.
+    * `[:ex_athena, :chat, :stop]` — the provider call returned.
+      Measurements include `:duration_ms`, `:input_tokens`,
+      `:output_tokens`, `:total_tokens`.
+    * `[:ex_athena, :tool, :start]` — a tool invocation began.
+    * `[:ex_athena, :tool, :stop]` — the tool invocation finished.
+      Measurements include `:duration_ms`. Metadata includes `:is_error`.
+    * `[:ex_athena, :compaction, :stop]` — a compaction pass completed.
+      Measurements include `:before_tokens`, `:after_tokens`,
+      `:dropped_count`.
+    * `[:ex_athena, :subagent, :spawn]` / `[:ex_athena, :subagent, :stop]`
+      — a subagent was spawned / returned.
+    * `[:ex_athena, :structured_retry]` — a structured-output repair
+      attempt fired. Measurements include `:attempt`.
+
+  ## GenAI semconv metadata
+
+  Event metadata uses GenAI semantic-convention attribute keys where they
+  apply. The key Elixir-atom form mirrors the OTel dotted-path form:
+
+    * `:gen_ai_operation_name` — `"chat"`, `"invoke_agent"`, `"execute_tool"`
+    * `:gen_ai_provider_name` — e.g. `"openai"`, `"anthropic"`, `"ollama"`
+    * `:gen_ai_request_model` — the model requested
+    * `:gen_ai_response_model` — the model the response identified as
+    * `:gen_ai_agent_id` — an optional agent identifier
+    * `:gen_ai_conversation_id` — stable per-session identifier
+    * `:gen_ai_usage_input_tokens`, `:gen_ai_usage_output_tokens`
+    * `:gen_ai_tool_name`, `:gen_ai_tool_call_id`
+    * `:gen_ai_response_finish_reasons` — list, e.g. `[:stop]`
+
+  Consumers bridging to OTel should translate these atoms to the dotted
+  OTel names (`gen_ai.operation.name`, etc.); `opentelemetry_telemetry`
+  handles this automatically if you point it at the events above.
+  """
+
+  @doc """
+  Execute `fun/0` inside a `[:ex_athena, name, ...]` span.
+
+  Emits `:start`, then `:stop` (or `:exception` on raise) with GenAI
+  metadata merged in. Returns `fun`'s result unchanged.
+  """
+  @spec span([atom()], map(), (-> term())) :: term()
+  def span(prefix, meta \\ %{}, fun) when is_list(prefix) and is_function(fun, 0) do
+    start_time = System.monotonic_time()
+    start_meta = Map.merge(meta, %{system_time: System.system_time()})
+
+    :telemetry.execute(prefix ++ [:start], %{system_time: start_meta.system_time}, meta)
+
+    try do
+      result = fun.()
+      duration_native = System.monotonic_time() - start_time
+      duration_ms = System.convert_time_unit(duration_native, :native, :millisecond)
+
+      :telemetry.execute(
+        prefix ++ [:stop],
+        %{duration_ms: duration_ms, duration_native: duration_native},
+        Map.put(meta, :result, result)
+      )
+
+      result
+    rescue
+      exc ->
+        duration_ms =
+          System.convert_time_unit(
+            System.monotonic_time() - start_time,
+            :native,
+            :millisecond
+          )
+
+        :telemetry.execute(
+          prefix ++ [:exception],
+          %{duration_ms: duration_ms},
+          Map.merge(meta, %{kind: :error, reason: exc, stacktrace: __STACKTRACE__})
+        )
+
+        reraise exc, __STACKTRACE__
+    end
+  end
+
+  @doc """
+  Emit a single telemetry event (no timing). Convenience for discrete
+  events like `:structured_retry`, `:subagent_spawn`, `:compaction_stop`.
+  """
+  @spec event([atom()], map(), map()) :: :ok
+  def event(name, measurements \\ %{}, meta \\ %{}) when is_list(name) do
+    :telemetry.execute(name, measurements, meta)
+  end
+
+  @doc """
+  Build a GenAI-semconv-shaped metadata map from common loop inputs.
+
+  Use this to produce a consistent metadata surface across emitters.
+  """
+  @spec genai_meta(keyword()) :: map()
+  def genai_meta(opts) do
+    opts
+    |> Enum.reduce(%{}, fn
+      {:operation, v}, acc -> Map.put(acc, :gen_ai_operation_name, v)
+      {:provider, v}, acc -> Map.put(acc, :gen_ai_provider_name, to_name(v))
+      {:request_model, v}, acc -> Map.put(acc, :gen_ai_request_model, v)
+      {:response_model, v}, acc -> Map.put(acc, :gen_ai_response_model, v)
+      {:agent_id, v}, acc -> Map.put(acc, :gen_ai_agent_id, v)
+      {:conversation_id, v}, acc -> Map.put(acc, :gen_ai_conversation_id, v)
+      {:tool_name, v}, acc -> Map.put(acc, :gen_ai_tool_name, v)
+      {:tool_call_id, v}, acc -> Map.put(acc, :gen_ai_tool_call_id, v)
+      {:input_tokens, v}, acc -> Map.put(acc, :gen_ai_usage_input_tokens, v)
+      {:output_tokens, v}, acc -> Map.put(acc, :gen_ai_usage_output_tokens, v)
+      {:finish_reasons, v}, acc -> Map.put(acc, :gen_ai_response_finish_reasons, List.wrap(v))
+      {k, v}, acc -> Map.put(acc, k, v)
+    end)
+  end
+
+  defp to_name(v) when is_atom(v), do: Atom.to_string(v)
+  defp to_name(v) when is_binary(v), do: v
+  defp to_name(v), do: inspect(v)
+end

--- a/lib/ex_athena/tools/spawn_agent.ex
+++ b/lib/ex_athena/tools/spawn_agent.ex
@@ -60,6 +60,12 @@ defmodule ExAthena.Tools.SpawnAgent do
 
     emit_event(ctx, {:subagent_spawn, %{id: sub_id, prompt: prompt}})
 
+    ExAthena.Telemetry.event(
+      [:ex_athena, :subagent, :spawn],
+      %{},
+      %{subagent_id: sub_id, parent_conversation_id: Map.get(ctx.assigns || %{}, :conversation_id)}
+    )
+
     # Run the sub-loop under a supervised Task so a crash doesn't bring
     # down the parent, and timeouts are enforceable. Task.Supervisor is
     # started by ExAthena.Application under `ExAthena.Tasks`.
@@ -72,6 +78,13 @@ defmodule ExAthena.Tools.SpawnAgent do
       case Task.yield(task, timeout) || Task.shutdown(task, :brutal_kill) do
         {:ok, {:ok, %{text: text}}} ->
           emit_event(ctx, {:subagent_result, %{id: sub_id, text: text || ""}})
+
+          ExAthena.Telemetry.event(
+            [:ex_athena, :subagent, :stop],
+            %{},
+            %{subagent_id: sub_id, outcome: :ok}
+          )
+
           {:ok, text || ""}
 
         {:ok, {:error, reason}} ->

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExAthena.MixProject do
   use Mix.Project
 
-  @version "0.3.0-dev"
+  @version "0.3.0"
   @source_url "https://github.com/udin-io/ex_athena"
 
   def project do

--- a/test/ex_athena/telemetry_test.exs
+++ b/test/ex_athena/telemetry_test.exs
@@ -1,0 +1,163 @@
+defmodule ExAthena.TelemetryTest do
+  use ExUnit.Case, async: false
+
+  alias ExAthena.{Loop, Response, Result, Telemetry}
+  alias ExAthena.Messages.ToolCall
+
+  setup tags do
+    # Each test attaches its own handler — `tags.test` gives a unique handler id.
+    test_pid = self()
+
+    handler_id = "test-#{inspect(tags.test)}"
+
+    events = [
+      [:ex_athena, :loop, :start],
+      [:ex_athena, :loop, :stop],
+      [:ex_athena, :loop, :exception],
+      [:ex_athena, :chat, :start],
+      [:ex_athena, :chat, :stop],
+      [:ex_athena, :tool, :start],
+      [:ex_athena, :tool, :stop],
+      [:ex_athena, :compaction, :stop],
+      [:ex_athena, :structured_retry]
+    ]
+
+    :telemetry.attach_many(
+      handler_id,
+      events,
+      fn name, measurements, meta, _ ->
+        send(test_pid, {:telemetry, name, measurements, meta})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    dir = Path.join(System.tmp_dir!(), "tel_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+
+    {:ok, dir: dir}
+  end
+
+  test "emits loop :start and :stop spans with GenAI-semconv metadata", %{dir: dir} do
+    responder = fn _req ->
+      %Response{text: "hello", finish_reason: :stop, provider: :mock}
+    end
+
+    assert {:ok, %Result{finish_reason: :stop}} =
+             Loop.run("go",
+               provider: :mock,
+               mock: [responder: responder],
+               cwd: dir,
+               tools: [],
+               conversation_id: "conv-abc",
+               model: "mock-1"
+             )
+
+    assert_receive {:telemetry, [:ex_athena, :loop, :start], _, start_meta}
+    assert start_meta.gen_ai_operation_name == "invoke_agent"
+    assert start_meta.gen_ai_conversation_id == "conv-abc"
+    assert start_meta.gen_ai_request_model == "mock-1"
+
+    assert_receive {:telemetry, [:ex_athena, :loop, :stop], measurements, stop_meta}
+    assert is_integer(measurements.duration_ms)
+    assert measurements.duration_ms >= 0
+    # the Result is passed as `:result` metadata from Telemetry.span/3
+    assert {:ok, %Result{}} = stop_meta.result
+  end
+
+  test "emits chat :start / :stop around each provider call", %{dir: dir} do
+    responder = fn _req ->
+      %Response{text: "done", finish_reason: :stop, provider: :mock}
+    end
+
+    assert {:ok, _r} =
+             Loop.run("go",
+               provider: :mock,
+               mock: [responder: responder],
+               cwd: dir,
+               tools: []
+             )
+
+    assert_receive {:telemetry, [:ex_athena, :chat, :start], _, meta}
+    assert meta.gen_ai_operation_name == "chat"
+
+    assert_receive {:telemetry, [:ex_athena, :chat, :stop], m, _}
+    assert is_integer(m.duration_ms)
+  end
+
+  test "emits tool :start / :stop around tool execution", %{dir: dir} do
+    File.write!(Path.join(dir, "a.txt"), "hi")
+    counter = :counters.new(1, [:atomics])
+
+    responder = fn _req ->
+      :counters.add(counter, 1, 1)
+
+      case :counters.get(counter, 1) do
+        1 ->
+          %Response{
+            text: "",
+            tool_calls: [%ToolCall{id: "t1", name: "read", arguments: %{"path" => "a.txt"}}],
+            finish_reason: :tool_calls,
+            provider: :mock
+          }
+
+        _ ->
+          %Response{text: "done", finish_reason: :stop, provider: :mock}
+      end
+    end
+
+    assert {:ok, %Result{finish_reason: :stop, tool_calls_made: 1}} =
+             Loop.run("go",
+               provider: :mock,
+               mock: [responder: responder],
+               cwd: dir,
+               tools: [ExAthena.Tools.Read]
+             )
+
+    assert_receive {:telemetry, [:ex_athena, :tool, :start], _, meta}
+    assert meta.gen_ai_operation_name == "execute_tool"
+    assert meta.gen_ai_tool_name == "read"
+    assert meta.gen_ai_tool_call_id == "t1"
+
+    assert_receive {:telemetry, [:ex_athena, :tool, :stop], m, _}
+    assert is_integer(m.duration_ms)
+  end
+
+  test "genai_meta/1 translates common keys to GenAI semconv atoms" do
+    meta =
+      Telemetry.genai_meta(
+        operation: "chat",
+        provider: :mock,
+        request_model: "x-1",
+        conversation_id: "c",
+        tool_name: "read",
+        finish_reasons: :stop,
+        unknown_key: "passthrough"
+      )
+
+    assert meta.gen_ai_operation_name == "chat"
+    assert meta.gen_ai_provider_name == "mock"
+    assert meta.gen_ai_request_model == "x-1"
+    assert meta.gen_ai_conversation_id == "c"
+    assert meta.gen_ai_tool_name == "read"
+    assert meta.gen_ai_response_finish_reasons == [:stop]
+    assert meta.unknown_key == "passthrough"
+  end
+
+  test "span/3 re-raises exceptions and emits :exception event" do
+    try do
+      Telemetry.span([:ex_athena, :loop], %{}, fn ->
+        raise "boom"
+      end)
+    rescue
+      e -> assert e.message == "boom"
+    end
+
+    assert_receive {:telemetry, [:ex_athena, :loop, :start], _, _}
+    assert_receive {:telemetry, [:ex_athena, :loop, :exception], _, meta}
+    assert meta.kind == :error
+    assert Exception.message(meta.reason) == "boom"
+  end
+end


### PR DESCRIPTION
## Summary

Fourth and final PR of the v0.3 rewrite. Ships the observability layer + bumps version to 0.3.0.

- **ExAthena.Telemetry** — emits :telemetry-library events shaped to the OpenTelemetry GenAI semantic conventions. Consumers bridge to OTel via opentelemetry_telemetry — no direct OTel dep.
- Events: `[:ex_athena, :loop, :start | :stop | :exception]`, `[:ex_athena, :chat, :start | :stop]`, `[:ex_athena, :tool, :start | :stop]`, `[:ex_athena, :compaction, :stop]`, `[:ex_athena, :subagent, :spawn | :stop]`, `[:ex_athena, :structured_retry]`.
- GenAI semconv metadata keys: `gen_ai_operation_name`, `gen_ai_provider_name`, `gen_ai_request_model`, `gen_ai_agent_id`, `gen_ai_conversation_id`, `gen_ai_tool_name`, `gen_ai_tool_call_id`, `gen_ai_usage_input_tokens`, `gen_ai_usage_output_tokens`, `gen_ai_response_finish_reasons`.
- New `:conversation_id` / `:agent_id` opts on `Loop.run/2` — threaded into every emitted event.
- `Telemetry.span/3` helper wraps arbitrary work in a start/stop pair with duration measurement + exception re-raising.
- Version bump `0.3.0-dev` → `0.3.0`. Ready for Hex publish.

## Test plan

- [x] `mix test` — 145 tests, 0 failures (140 from PR 3 + 5 new telemetry tests).
- [x] `mix compile --warnings-as-errors` — clean.
- [x] Spans carry GenAI semconv metadata (verified via `:telemetry.attach_many` in tests).
- [x] Spans emit `:exception` on raise and reraise the original error.

## Paired with

- udin_code PR #1038 migrates the 7 remaining direct-SDK callers to ExAthena, closing the original Phase 4 goal (zero `ClaudeCode.*` calls outside SdkRunner).