### PR TITLE
feat(v0.3.1): per-token streaming in the ReAct mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and ExAthena adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.3.1 — per-token streaming in the ReAct mode
+
+### Added
+
+- `Modes.ReAct` now dispatches to `provider_mod.stream/3` (instead of
+  `query/2`) whenever the caller registered an `on_event` callback on
+  `Loop.run/2`. Every `%Streaming.Event{type: :text_delta, data: ...}`
+  produced by the provider is forwarded to `on_event` in real time, so
+  consumers (e.g. a LiveView chat UI) get character-level deltas again
+  without having to drive streaming themselves.
+- When no `on_event` is set the behaviour is unchanged — the mode uses
+  the cheaper one-shot `query/2` path.
+- When the provider module does not implement `stream/3` (it is an
+  optional callback) the mode transparently falls back to `query/2`.
+
+### Changed
+
+- Docstring on `Modes.ReAct` now reflects the stream/query dispatch.
+
 ## v0.3.0 — PR 4 (observability) landed; Phase 4 closed
 
 ### PR 4 — Observability

--- a/lib/ex_athena/modes/react.ex
+++ b/lib/ex_athena/modes/react.ex
@@ -5,8 +5,10 @@ defmodule ExAthena.Modes.ReAct do
   Each iteration:
 
     1. Build a Request from current messages + tools + system prompt.
-    2. Call the provider (one-shot, not streaming — streaming is an
-       optimisation landing in PR 4).
+    2. Call the provider — uses `stream/3` when the loop was started with
+       `on_event:` set (so partial token deltas flow to the caller in
+       real time), falls back to one-shot `query/2` when no event
+       callback is registered.
     3. Extract tool calls (native, or TextTagged fallback via
        `ExAthena.ToolCalls`).
     4. If no tool calls: emit `{:content, text}`, set `finish_reason:
@@ -41,7 +43,7 @@ defmodule ExAthena.Modes.ReAct do
       )
 
     case Telemetry.span([:ex_athena, :chat], chat_meta, fn ->
-           state.provider_mod.query(request, state.provider_opts)
+           query_or_stream(state, request)
          end) do
       {:ok, response} ->
         # Accumulate usage + cost before considering termination.
@@ -236,6 +238,24 @@ defmodule ExAthena.Modes.ReAct do
       state.request_template.system_prompt,
       Tools.describe_for_prompt(state.tool_modules)
     )
+  end
+
+  # ── Provider dispatch: query vs stream ────────────────────────────
+
+  # When the caller registered `on_event`, stream the provider response and
+  # forward `:text_delta` events to it in real time. Otherwise fall back to
+  # a cheaper one-shot `query/2`.
+  defp query_or_stream(%State{on_event: nil} = state, request) do
+    state.provider_mod.query(request, state.provider_opts)
+  end
+
+  defp query_or_stream(%State{on_event: on_event} = state, request)
+       when is_function(on_event, 1) do
+    if function_exported?(state.provider_mod, :stream, 3) do
+      state.provider_mod.stream(request, on_event, state.provider_opts)
+    else
+      state.provider_mod.query(request, state.provider_opts)
+    end
   end
 
   defp stringify(value) when is_binary(value), do: value

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExAthena.MixProject do
   use Mix.Project
 
-  @version "0.3.0"
+  @version "0.3.1"
   @source_url "https://github.com/udin-io/ex_athena"
 
   def project do

--- a/test/ex_athena/modes/streaming_test.exs
+++ b/test/ex_athena/modes/streaming_test.exs
@@ -1,0 +1,56 @@
+defmodule ExAthena.Modes.StreamingTest do
+  @moduledoc """
+  Verifies that the ReAct mode dispatches to `provider_mod.stream/3` when
+  the caller registered an `on_event` callback, so per-token `:text_delta`
+  deltas reach the caller in real time.
+  """
+  use ExUnit.Case, async: true
+
+  alias ExAthena.{Loop, Result}
+  alias ExAthena.Streaming.Event
+
+  setup do
+    dir = Path.join(System.tmp_dir!(), "stream_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+    {:ok, dir: dir}
+  end
+
+  test "forwards provider text_delta events to on_event in order", %{dir: dir} do
+    test_pid = self()
+
+    on_event = fn event ->
+      send(test_pid, {:event, event})
+    end
+
+    assert {:ok, %Result{finish_reason: :stop}} =
+             Loop.run("hi",
+               provider: :mock,
+               mock: [text: "hello world"],
+               mock_events: [
+                 %Event{type: :text_delta, data: "hel"},
+                 %Event{type: :text_delta, data: "lo "},
+                 %Event{type: :text_delta, data: "world"}
+               ],
+               cwd: dir,
+               tools: [],
+               on_event: on_event
+             )
+
+    # Per-token deltas should arrive before the final :content event.
+    assert_receive {:event, %Event{type: :text_delta, data: "hel"}}
+    assert_receive {:event, %Event{type: :text_delta, data: "lo "}}
+    assert_receive {:event, %Event{type: :text_delta, data: "world"}}
+    assert_receive {:event, {:content, "hello world"}}
+  end
+
+  test "falls back to query/2 when on_event is nil", %{dir: dir} do
+    assert {:ok, %Result{finish_reason: :stop, text: "no stream needed"}} =
+             Loop.run("hi",
+               provider: :mock,
+               mock: [text: "no stream needed"],
+               cwd: dir,
+               tools: []
+             )
+  end
+end


### PR DESCRIPTION
## Summary

When a caller passes \`on_event:\` to \`Loop.run/2\`, \`Modes.ReAct\` now calls \`provider_mod.stream/3\` instead of \`query/2\` and forwards every \`%Streaming.Event{type: :text_delta}\` to the caller as it arrives.

This restores character-level streaming for downstream consumers (e.g. the FreeChat / PatchChat LiveViews in udin_code) without making them drive streaming themselves.

## Behaviour matrix

| \`on_event\` | provider has \`stream/3\` | path |
|---|---|---|
| \`nil\` | — | \`query/2\` (unchanged) |
| \`fn _ -> ... end\` | yes | \`stream/3\` + forward text_delta events |
| \`fn _ -> ... end\` | no | \`query/2\` (fallback) |

## Test plan

- [x] \`streaming_test.exs\` — on_event + text_delta events → forwarded in order
- [x] \`streaming_test.exs\` — no on_event → falls back to query, still terminates
- [x] \`mix test\`: 147 tests, 0 failures
- [x] \`mix compile --warnings-as-errors\` clean