### PR TITLE
fix(provider): route :ollama through req_llm's openai-compatible adapter (v0.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and ExAthena adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.4.1 — Ollama via OpenAI-compatible adapter
+
+### Fixed
+
+- `provider: :ollama` now talks to local Ollama through `req_llm`'s OpenAI
+  adapter instead of looking up an `:ollama` provider in `llm_db`'s
+  catalog. `llm_db` 2026.4.x removed first-class local-Ollama support
+  (it only catalogues `:ollama_cloud` now), so `"ollama:<model>"` model
+  specs were rejected with `{:error, :unknown_provider}` from
+  `LLMDB.Spec`. The fix routes `:ollama` (and `:llamacpp`) through the
+  `"openai:<model>"` tag and threads
+  `openai_compatible_backend: :ollama` so `req_llm` 1.10's openai
+  adapter tolerates the missing API key on unauthenticated local
+  deployments. Mirrors the recipe in `req_llm/guides/ollama.md`.
+- `base_url` for Ollama now auto-appends `/v1` when callers pass the
+  bare host (`http://localhost:11434`) — req_llm's openai adapter
+  expects the prefix to already include `/v1`.
+- A placeholder `api_key` (`"ollama"`) is substituted when the
+  `:ollama` backend marker is set and no key was supplied — Ollama
+  ignores the Authorization header but `req_llm`'s HTTP layer still
+  emits one, so a non-nil value is required.
+
+### Internal
+
+- `ExAthena.Config.@req_llm_provider_tag[:ollama]` now resolves to
+  `"openai"` (was `"ollama"`).
+- New `@local_openai_compatible_backends` map drives
+  `openai_compatible_backend` injection in `Config.pop_provider!/1`.
+- `ExAthena.Providers.ReqLLM.build_opts/2` reads the backend marker,
+  normalises base_url, and falls back to the placeholder api_key.
+
 ## v0.4.0 — operational harness (memory, skills, hooks, modes, agents, storage)
 
 The "1.6% reasoning, 98.4% harness" upgrade. Where v0.3 perfected the

--- a/lib/ex_athena/config.ex
+++ b/lib/ex_athena/config.ex
@@ -39,14 +39,26 @@ defmodule ExAthena.Config do
 
   # Map the ExAthena provider atom → the `req_llm` provider tag that belongs
   # in the `"tag:model-id"` spec. When an ExAthena caller says `:ollama`, the
-  # ReqLLM adapter turns a raw `model: "llama3.1"` into `"ollama:llama3.1"`.
+  # ReqLLM adapter turns a raw `model: "qwen3-coder"` into `"openai:qwen3-coder"`.
+  #
+  # Local Ollama and llama.cpp expose OpenAI-compatible APIs and have no
+  # entries in req_llm's llm_db catalog, so they must route through the
+  # `:openai` tag with a custom base_url. See `req_llm/guides/ollama.md`.
   @req_llm_provider_tag %{
-    ollama: "ollama",
+    ollama: "openai",
     openai: "openai",
     openai_compatible: "openai",
-    llamacpp: "llamacpp",
+    llamacpp: "openai",
     claude: "anthropic",
     anthropic: "anthropic"
+  }
+
+  # Provider atoms that talk to a local OpenAI-compatible server. These
+  # 1) need `/v1` appended to base_url if the caller didn't, and
+  # 2) get `openai_compatible_backend: <atom>` so req_llm's openai adapter
+  #    allows missing API keys (unauthenticated local deployments).
+  @local_openai_compatible_backends %{
+    ollama: :ollama
   }
 
   @doc """
@@ -69,6 +81,12 @@ defmodule ExAthena.Config do
       case req_llm_provider_tag(provider) do
         nil -> rest
         tag -> Keyword.put_new(rest, :req_llm_provider_tag, tag)
+      end
+
+    rest =
+      case Map.get(@local_openai_compatible_backends, provider) do
+        nil -> rest
+        backend -> Keyword.put_new(rest, :openai_compatible_backend, backend)
       end
 
     {provider_module(provider), rest}

--- a/lib/ex_athena/providers/req_llm.ex
+++ b/lib/ex_athena/providers/req_llm.ex
@@ -90,7 +90,8 @@ defmodule ExAthena.Providers.ReqLLM do
   # Callers may pass a two-part string (`"ollama:llama3.1"`) OR a bare model
   # id (`"llama3.1"`); when bare, Config threads the provider's `req_llm`
   # tag through opts so we can build the full spec here.
-  defp resolve_model(%Request{model: model_str}, opts) when is_binary(model_str) and model_str != "" do
+  defp resolve_model(%Request{model: model_str}, opts)
+       when is_binary(model_str) and model_str != "" do
     if String.contains?(model_str, ":") do
       {:ok, model_str}
     else
@@ -116,7 +117,8 @@ defmodule ExAthena.Providers.ReqLLM do
 
   # ── Messages ──────────────────────────────────────────────────────
 
-  defp build_messages(%Request{messages: [], system_prompt: sp}) when is_binary(sp) and sp != "" do
+  defp build_messages(%Request{messages: [], system_prompt: sp})
+       when is_binary(sp) and sp != "" do
     # System-prompt-only request — req_llm requires at least one user msg.
     {:error, Error.new(:bad_request, "no messages supplied", provider: :req_llm)}
   end
@@ -165,6 +167,7 @@ defmodule ExAthena.Providers.ReqLLM do
 
   defp text_parts(nil), do: []
   defp text_parts(""), do: []
+
   defp text_parts(content) when is_binary(content),
     do: [ReqLLM.Message.ContentPart.text(content)]
 
@@ -181,10 +184,15 @@ defmodule ExAthena.Providers.ReqLLM do
   # ── Options ────────────────────────────────────────────────────────
 
   defp build_opts(%Request{} = request, opts) do
+    backend = Keyword.get(opts, :openai_compatible_backend)
+    base_url = normalize_base_url(Keyword.get(opts, :base_url), backend)
+    api_key = resolve_api_key(Keyword.get(opts, :api_key), backend)
+
     base_opts =
       [
-        api_key: Keyword.get(opts, :api_key),
-        base_url: Keyword.get(opts, :base_url),
+        api_key: api_key,
+        base_url: base_url,
+        openai_compatible_backend: backend,
         max_tokens: request.max_tokens,
         temperature: request.temperature,
         top_p: request.top_p,
@@ -198,6 +206,29 @@ defmodule ExAthena.Providers.ReqLLM do
     provider_opts = Keyword.get(opts, :provider_opts, [])
     {:ok, Keyword.merge(base_opts, provider_opts)}
   end
+
+  # Local OpenAI-compatible servers (Ollama, llama.cpp) commonly accept either
+  # the bare host (`http://localhost:11434`) or the OpenAI prefix
+  # (`http://localhost:11434/v1`). req_llm's openai adapter expects the prefix
+  # to already include `/v1`. Append it when the caller passed the bare host.
+  defp normalize_base_url(nil, _backend), do: nil
+  defp normalize_base_url(url, nil), do: url
+
+  defp normalize_base_url(url, _backend) when is_binary(url) do
+    trimmed = String.trim_trailing(url, "/")
+
+    cond do
+      String.ends_with?(trimmed, "/v1") -> trimmed
+      true -> trimmed <> "/v1"
+    end
+  end
+
+  # req_llm's openai adapter requires *some* api_key value even when
+  # `openai_compatible_backend: :ollama` allows missing auth — the underlying
+  # HTTP request still sets an Authorization header. Local servers ignore it,
+  # so substitute a placeholder when the caller didn't supply one.
+  defp resolve_api_key(nil, :ollama), do: "ollama"
+  defp resolve_api_key(key, _backend), do: key
 
   # ── Response mapping ──────────────────────────────────────────────
 
@@ -294,8 +325,9 @@ defmodule ExAthena.Providers.ReqLLM do
 
   defp handle_chunk(%{type: :usage, usage: usage}, _callback, acc), do: %{acc | usage: usage}
 
-  defp handle_chunk(%{type: :meta, finish_reason: reason}, _callback, acc) when not is_nil(reason),
-    do: %{acc | finish_reason: reason}
+  defp handle_chunk(%{type: :meta, finish_reason: reason}, _callback, acc)
+       when not is_nil(reason),
+       do: %{acc | finish_reason: reason}
 
   defp handle_chunk(_chunk, _callback, acc), do: acc
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExAthena.MixProject do
   use Mix.Project
 
-  @version "0.4.0"
+  @version "0.4.1"
   @source_url "https://github.com/udin-io/ex_athena"
 
   def project do

--- a/test/ex_athena/providers/req_llm_test.exs
+++ b/test/ex_athena/providers/req_llm_test.exs
@@ -27,9 +27,19 @@ defmodule ExAthena.Providers.ReqLLMTest do
   end
 
   describe "Config threads the req_llm provider tag into opts" do
-    test ":ollama + bare model gets prefixed to ollama:model" do
+    test ":ollama uses the openai tag (Ollama is OpenAI-compatible)" do
       {_mod, opts} = Config.pop_provider!(provider: :ollama)
-      assert Keyword.get(opts, :req_llm_provider_tag) == "ollama"
+      assert Keyword.get(opts, :req_llm_provider_tag) == "openai"
+    end
+
+    test ":ollama threads openai_compatible_backend so missing API keys are tolerated" do
+      {_mod, opts} = Config.pop_provider!(provider: :ollama)
+      assert Keyword.get(opts, :openai_compatible_backend) == :ollama
+    end
+
+    test ":llamacpp uses the openai tag (llama.cpp is OpenAI-compatible)" do
+      {_mod, opts} = Config.pop_provider!(provider: :llamacpp)
+      assert Keyword.get(opts, :req_llm_provider_tag) == "openai"
     end
 
     test ":claude translates to anthropic tag" do
@@ -40,6 +50,11 @@ defmodule ExAthena.Providers.ReqLLMTest do
     test ":openai_compatible uses openai tag" do
       {_mod, opts} = Config.pop_provider!(provider: :openai_compatible)
       assert Keyword.get(opts, :req_llm_provider_tag) == "openai"
+    end
+
+    test ":openai_compatible does NOT inject the ollama backend marker" do
+      {_mod, opts} = Config.pop_provider!(provider: :openai_compatible)
+      refute Keyword.has_key?(opts, :openai_compatible_backend)
     end
 
     test ":mock has no tag" do


### PR DESCRIPTION
## Summary

- `provider: :ollama` now routes through `req_llm`'s OpenAI-compatible adapter instead of looking up a non-existent `:ollama` provider in `llm_db`'s catalog.
- `req_llm` 1.10 + `llm_db` 2026.4.x removed first-class local-Ollama support — only `:ollama_cloud` (the hosted Turbo service) remains. \`\"ollama:<model>\"\` specs now fail with `{:error, :unknown_provider}` from `LLMDB.Spec.verify_provider_exists/1`.
- `req_llm`'s [official Ollama guide](https://hexdocs.pm/req_llm/ollama.html) says to use `provider: :openai` + `base_url` + `extra: %{openai_compatible_backend: :ollama}`. This PR aligns ExAthena with that recipe.

### What changed

- `ExAthena.Config.@req_llm_provider_tag[:ollama]` → `\"openai\"` (was `\"ollama\"`). Same for `:llamacpp`.
- New `@local_openai_compatible_backends` drives `openai_compatible_backend` injection in `Config.pop_provider!/1`.
- `ExAthena.Providers.ReqLLM.build_opts/2`:
  - Auto-appends `/v1` to `base_url` when the backend marker is set (req_llm's openai adapter expects the prefix to include `/v1`).
  - Substitutes a placeholder `api_key: \"ollama\"` when none is supplied for `:ollama` — req_llm still emits an Authorization header even when the backend marker tolerates missing auth, and Ollama ignores it server-side.
  - Threads `openai_compatible_backend` to req_llm so the openai adapter's auth bypass kicks in.

### Compatibility

Consumer-visible API is unchanged. Existing callers passing `provider: :ollama` continue to work — they now succeed instead of failing with `{:error, :unknown_provider}`.

## Test plan

- [x] `mix test` — 260 tests + 2 doctests, all passing.
- [x] New tests in `test/ex_athena/providers/req_llm_test.exs` covering the new tag/marker behaviour for `:ollama`, `:llamacpp`, and `:openai_compatible`.
- [ ] End-to-end verification against a local Ollama via the udin_code consumer (separate PR).

## Bumps

`0.4.0` → `0.4.1`. Patch release: only fixes a regression caused by upstream `req_llm` / `llm_db` changes, no API surface changes.