### PR TITLE
fix(provider): always prefix req_llm tag, even when model id has a colon (v0.4.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and ExAthena adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.4.2 — Ollama tagged model spec follow-up
+
+### Fixed
+
+- `ExAthena.Providers.ReqLLM.resolve_model/2` no longer skips the
+  provider-tag prefix when the model id contains a colon. Ollama model
+  ids legitimately use `:` as the version separator
+  (`qwen2.5-coder:14b`, `qwen3-coder:30b`), so the previous "model
+  contains `:` ⇒ already tagged" heuristic shipped bare names like
+  `"qwen2.5-coder:14b"` to req_llm, which then split on the first
+  colon and tried to validate `"qwen2.5-coder"` as a provider name —
+  failing the `^[a-z0-9_-]+$` regex (rejects `.`) with
+  `{:error, :bad_provider}`. Now always prepends the tag unless the
+  model already starts with `"<tag>:"` (caller passed a fully-formed
+  spec).
+
 ## v0.4.1 — Ollama via OpenAI-compatible adapter
 
 ### Fixed

--- a/lib/ex_athena/providers/req_llm.ex
+++ b/lib/ex_athena/providers/req_llm.ex
@@ -87,31 +87,39 @@ defmodule ExAthena.Providers.ReqLLM do
   # ── Model resolution ──────────────────────────────────────────────
 
   # Translate ExAthena-side provider atoms into req_llm model specs.
-  # Callers may pass a two-part string (`"ollama:llama3.1"`) OR a bare model
-  # id (`"llama3.1"`); when bare, Config threads the provider's `req_llm`
-  # tag through opts so we can build the full spec here.
-  defp resolve_model(%Request{model: model_str}, opts)
-       when is_binary(model_str) and model_str != "" do
-    if String.contains?(model_str, ":") do
-      {:ok, model_str}
-    else
-      case Keyword.get(opts, :req_llm_provider_tag) do
-        tag when is_binary(tag) and tag != "" -> {:ok, tag <> ":" <> model_str}
-        _ -> {:ok, model_str}
-      end
-    end
+  # Callers may pass a two-part string (`"openai:gpt-4"`) OR a bare model
+  # id (`"qwen2.5-coder:14b"`). When bare, Config threads the provider's
+  # `req_llm` tag through opts so we can build the full spec here.
+  #
+  # Note: bare Ollama model ids legitimately contain `:` (the version
+  # separator, e.g. `"qwen2.5-coder:14b"`) so we cannot use the presence
+  # of a colon as a "spec already tagged" signal — the tag is the source
+  # of truth. We only skip prefixing when the model string already begins
+  # with the same tag (caller passed a fully-formed spec).
+  @doc false
+  def resolve_model(%Request{model: model_str}, opts)
+      when is_binary(model_str) and model_str != "" do
+    {:ok, prepend_tag(model_str, opts)}
   end
 
-  defp resolve_model(_request, opts) do
+  def resolve_model(_request, opts) do
     case Keyword.get(opts, :model) do
       m when is_binary(m) and m != "" ->
-        case Keyword.get(opts, :req_llm_provider_tag) do
-          tag when is_binary(tag) and tag != "" -> {:ok, tag <> ":" <> m}
-          _ -> {:ok, m}
-        end
+        {:ok, prepend_tag(m, opts)}
 
       _ ->
         {:error, Error.new(:bad_request, "no model configured", provider: :req_llm)}
+    end
+  end
+
+  defp prepend_tag(model, opts) do
+    case Keyword.get(opts, :req_llm_provider_tag) do
+      tag when is_binary(tag) and tag != "" ->
+        prefix = tag <> ":"
+        if String.starts_with?(model, prefix), do: model, else: prefix <> model
+
+      _ ->
+        model
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExAthena.MixProject do
   use Mix.Project
 
-  @version "0.4.1"
+  @version "0.4.2"
   @source_url "https://github.com/udin-io/ex_athena"
 
   def project do

--- a/test/ex_athena/providers/req_llm_test.exs
+++ b/test/ex_athena/providers/req_llm_test.exs
@@ -62,4 +62,60 @@ defmodule ExAthena.Providers.ReqLLMTest do
       refute Keyword.has_key?(opts, :req_llm_provider_tag)
     end
   end
+
+  describe "resolve_model/2 prefixes the provider tag correctly" do
+    alias ExAthena.Request
+
+    test "prepends tag to bare model id" do
+      assert Adapter.resolve_model(%Request{messages: [], model: "gpt-4"}, req_llm_provider_tag: "openai") ==
+               {:ok, "openai:gpt-4"}
+    end
+
+    test "prepends tag even when model id contains a colon (Ollama version separator)" do
+      # Regression: Ollama model ids use `:` as the version separator
+      # (`qwen2.5-coder:14b`). The previous heuristic treated the colon as
+      # "already tagged" and shipped the bare name to req_llm, which then
+      # parsed `qwen2.5-coder` as a provider name and failed validation
+      # with `{:error, :bad_provider}` because of the `.`.
+      assert Adapter.resolve_model(
+               %Request{messages: [], model: "qwen2.5-coder:14b"},
+               req_llm_provider_tag: "openai"
+             ) == {:ok, "openai:qwen2.5-coder:14b"}
+
+      assert Adapter.resolve_model(
+               %Request{messages: [], model: "qwen3-coder:30b"},
+               req_llm_provider_tag: "openai"
+             ) == {:ok, "openai:qwen3-coder:30b"}
+    end
+
+    test "does not double-prefix when model already starts with the tag" do
+      assert Adapter.resolve_model(
+               %Request{messages: [], model: "openai:gpt-4"},
+               req_llm_provider_tag: "openai"
+             ) == {:ok, "openai:gpt-4"}
+
+      assert Adapter.resolve_model(
+               %Request{messages: [], model: "openai:qwen2.5-coder:14b"},
+               req_llm_provider_tag: "openai"
+             ) == {:ok, "openai:qwen2.5-coder:14b"}
+    end
+
+    test "passes the model through unchanged when no tag is set" do
+      assert Adapter.resolve_model(%Request{messages: [], model: "qwen2.5-coder:14b"}, []) ==
+               {:ok, "qwen2.5-coder:14b"}
+    end
+
+    test "falls back to opts[:model] when the request has no model and prefixes the tag" do
+      assert Adapter.resolve_model(
+               %Request{messages: [], model: nil},
+               model: "qwen2.5-coder:14b",
+               req_llm_provider_tag: "openai"
+             ) == {:ok, "openai:qwen2.5-coder:14b"}
+    end
+
+    test "errors when no model is supplied anywhere" do
+      assert {:error, %ExAthena.Error{kind: :bad_request, message: "no model configured"}} =
+               Adapter.resolve_model(%Request{messages: [], model: nil}, [])
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Follow-up to #7. After 0.4.1 routed `:ollama` through req_llm's openai-compatible adapter, real-world Ollama model ids (`qwen2.5-coder:14b`, `qwen3-coder:30b`) still failed with `{:error, :bad_provider}`.

### Root cause

`ExAthena.Providers.ReqLLM.resolve_model/2` had a "model contains `:` ⇒ already tagged" heuristic. Ollama model ids legitimately use `:` as the version separator, so the bare id was shipped to req_llm, which split on the first colon and ran `qwen2.5-coder` through llm_db's provider regex (`^[a-z0-9_-]+\$`). The `.` failed validation → `:bad_provider`.

### Fix

When a `req_llm_provider_tag` is set, always prepend it — unless the model already begins with `<tag>:` (no double-prefixing). Otherwise pass through unchanged.

`resolve_model/2` is now `@doc false def` so the regression case is directly testable.

## Test plan

- [x] `mix test` — 266 tests + 2 doctests, all passing.
- [x] New `describe "resolve_model/2 prefixes the provider tag correctly"` block in `test/ex_athena/providers/req_llm_test.exs` covering:
  - bare model id → prefixed
  - **model id with version separator (`qwen2.5-coder:14b`) → still prefixed (regression)**
  - already-prefixed model → not double-prefixed
  - no tag → pass through unchanged
  - fallback to `opts[:model]` when request has no model
  - error when no model anywhere
- [x] Verified end-to-end via direct `ReqLLM.generate_text("openai:qwen2.5-coder:14b", …)` against local Ollama — returns a `chat.completion` response.

## Bumps

`0.4.1` → `0.4.2`. Patch release: bug fix only, no API surface changes.