### PR TITLE
fix(provider): convert tools to %ReqLLM.Tool{} structs at the adapter (v0.4.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and ExAthena adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.4.3 — Convert tools to %ReqLLM.Tool{} structs at the adapter boundary
+
+### Fixed
+
+- `ExAthena.Providers.ReqLLM.build_opts/2` now converts the modes' tool
+  list (OpenAI-format maps from `Tools.describe_for_provider/1`) into
+  `%ReqLLM.Tool{}` structs before forwarding to req_llm. Without this,
+  req_llm 1.10's openai adapter raised
+  `no function clause matching in ReqLLM.Tool.to_schema/2` while building
+  the streaming request — `to_schema/2` only matches `%ReqLLM.Tool{}`.
+  The conversion sets a stub callback because ex_athena executes tools
+  server-side via the loop, not via req_llm's client-side dispatch.
+  Already-formed `%ReqLLM.Tool{}` structs and string-keyed maps are
+  passed through unchanged for forward compatibility.
+
 ## v0.4.2 — Ollama tagged model spec follow-up
 
 ### Fixed

--- a/lib/ex_athena/providers/req_llm.ex
+++ b/lib/ex_athena/providers/req_llm.ex
@@ -205,7 +205,7 @@ defmodule ExAthena.Providers.ReqLLM do
         temperature: request.temperature,
         top_p: request.top_p,
         stop: request.stop,
-        tools: request.tools,
+        tools: to_req_llm_tools(request.tools),
         tool_choice: request.tool_choice,
         receive_timeout: request.timeout_ms
       ]
@@ -214,6 +214,45 @@ defmodule ExAthena.Providers.ReqLLM do
     provider_opts = Keyword.get(opts, :provider_opts, [])
     {:ok, Keyword.merge(base_opts, provider_opts)}
   end
+
+  # ex_athena's modes (see `Tools.describe_for_provider/1`) build OpenAI-format
+  # tool maps (`%{type: "function", function: %{name, description, parameters}}`)
+  # directly. req_llm 1.10 expects each entry in `:tools` to be a `%ReqLLM.Tool{}`
+  # struct so it can call `ReqLLM.Tool.to_schema/2` per provider — passing maps
+  # raises `no function clause matching in ReqLLM.Tool.to_schema/2`. Convert
+  # here. The callback is a stub: req_llm uses it only for client-side execution
+  # and ex_athena executes tools server-side via `ExAthena.Tool.execute/2`.
+  @doc false
+  def to_req_llm_tools(nil), do: nil
+  def to_req_llm_tools([]), do: []
+  def to_req_llm_tools(tools) when is_list(tools), do: Enum.map(tools, &to_req_llm_tool/1)
+
+  defp to_req_llm_tool(%ReqLLM.Tool{} = tool), do: tool
+
+  defp to_req_llm_tool(%{function: %{name: name, description: desc, parameters: params}}) do
+    build_req_llm_tool(name, desc, params)
+  end
+
+  defp to_req_llm_tool(%{
+         "function" => %{"name" => name, "description" => desc, "parameters" => params}
+       }) do
+    build_req_llm_tool(name, desc, params)
+  end
+
+  defp build_req_llm_tool(name, desc, params) do
+    %ReqLLM.Tool{
+      name: name,
+      description: desc,
+      parameter_schema: params || %{},
+      callback: &noop_callback/1,
+      strict: false,
+      compiled: nil,
+      provider_options: %{}
+    }
+  end
+
+  defp noop_callback(_args),
+    do: {:error, :tool_execution_handled_by_ex_athena}
 
   # Local OpenAI-compatible servers (Ollama, llama.cpp) commonly accept either
   # the bare host (`http://localhost:11434`) or the OpenAI prefix

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExAthena.MixProject do
   use Mix.Project
 
-  @version "0.4.2"
+  @version "0.4.3"
   @source_url "https://github.com/udin-io/ex_athena"
 
   def project do

--- a/test/ex_athena/providers/req_llm_test.exs
+++ b/test/ex_athena/providers/req_llm_test.exs
@@ -67,7 +67,9 @@ defmodule ExAthena.Providers.ReqLLMTest do
     alias ExAthena.Request
 
     test "prepends tag to bare model id" do
-      assert Adapter.resolve_model(%Request{messages: [], model: "gpt-4"}, req_llm_provider_tag: "openai") ==
+      assert Adapter.resolve_model(%Request{messages: [], model: "gpt-4"},
+               req_llm_provider_tag: "openai"
+             ) ==
                {:ok, "openai:gpt-4"}
     end
 
@@ -116,6 +118,74 @@ defmodule ExAthena.Providers.ReqLLMTest do
     test "errors when no model is supplied anywhere" do
       assert {:error, %ExAthena.Error{kind: :bad_request, message: "no model configured"}} =
                Adapter.resolve_model(%Request{messages: [], model: nil}, [])
+    end
+  end
+
+  describe "to_req_llm_tools/1" do
+    test "returns nil and [] unchanged" do
+      assert Adapter.to_req_llm_tools(nil) == nil
+      assert Adapter.to_req_llm_tools([]) == []
+    end
+
+    test "passes through %ReqLLM.Tool{} structs unchanged (forward compat)" do
+      tool = %ReqLLM.Tool{
+        name: "passthrough",
+        description: "already a struct",
+        parameter_schema: %{},
+        callback: fn _ -> {:ok, ""} end
+      }
+
+      assert [^tool] = Adapter.to_req_llm_tools([tool])
+    end
+
+    test "converts atom-keyed OpenAI-format maps (the modes/react.ex shape) to ReqLLM.Tool" do
+      # Regression: req_llm 1.10's openai adapter calls
+      # ReqLLM.Tool.to_schema(tool, :openai) on each entry, which only
+      # matches %ReqLLM.Tool{}. Previously these maps reached req_llm raw
+      # and crashed with "no function clause matching".
+      tool_map = %{
+        type: "function",
+        function: %{
+          name: "read",
+          description: "Read a file",
+          parameters: %{
+            type: "object",
+            properties: %{path: %{type: "string"}},
+            required: ["path"]
+          }
+        }
+      }
+
+      assert [%ReqLLM.Tool{} = tool] = Adapter.to_req_llm_tools([tool_map])
+      assert tool.name == "read"
+      assert tool.description == "Read a file"
+      assert tool.parameter_schema == tool_map.function.parameters
+      assert is_function(tool.callback, 1)
+    end
+
+    test "also accepts string-keyed OpenAI-format maps" do
+      tool_map = %{
+        "type" => "function",
+        "function" => %{
+          "name" => "grep",
+          "description" => "Search files",
+          "parameters" => %{"type" => "object", "properties" => %{}}
+        }
+      }
+
+      assert [%ReqLLM.Tool{} = tool] = Adapter.to_req_llm_tools([tool_map])
+      assert tool.name == "grep"
+      assert tool.description == "Search files"
+    end
+
+    test "the stub callback returns a tagged error so accidental use is loud" do
+      tool_map = %{
+        type: "function",
+        function: %{name: "x", description: "y", parameters: %{}}
+      }
+
+      [%ReqLLM.Tool{callback: cb}] = Adapter.to_req_llm_tools([tool_map])
+      assert cb.(%{}) == {:error, :tool_execution_handled_by_ex_athena}
     end
   end
 end


### PR DESCRIPTION
## Summary

Follow-up to #7 and #8. After the routing/spec fixes landed, real Ollama planning still failed with:

\`\`\`
Failed to build streaming request: no function clause matching in ReqLLM.Tool.to_schema/2
\`\`\`

### Root cause

\`ExAthena.Tools.describe_for_provider/1\` builds tool entries as plain OpenAI-format maps (\`%{type: "function", function: %{name, description, parameters}}\`). The modes set those on \`request.tools\`. The ReqLLM adapter forwarded them raw. \`req_llm\` 1.10's openai adapter calls \`ReqLLM.Tool.to_schema(tool, :openai)\` on each entry, but \`to_schema/2\` only has a clause for \`%ReqLLM.Tool{}\` — passing maps raises.

### Fix

In \`ExAthena.Providers.ReqLLM.build_opts/2\`, convert each tool entry to a \`%ReqLLM.Tool{}\`. The callback is a stub (\`{:error, :tool_execution_handled_by_ex_athena}\`) because ex_athena executes tools server-side via its loop, not via req_llm's client-side dispatch. Already-formed \`%ReqLLM.Tool{}\` structs and string-keyed OpenAI maps pass through unchanged for forward compatibility.

\`to_req_llm_tools/1\` is exposed as \`@doc false def\` so the regression cases are directly testable.

## Test plan

- [x] \`mix test\` — 271 tests + 2 doctests, all passing in isolation. (One unrelated flaky pre-existing test in \`config_test.exs:48\` flips when other tests leak \`Application.put_env(:ex_athena, :model)\`; it passes when the file is run alone.)
- [x] New tests in \`test/ex_athena/providers/req_llm_test.exs\` covering:
  - nil and empty list pass-through
  - already-\`%ReqLLM.Tool{}\` structs unchanged (forward compat)
  - atom-keyed OpenAI map → struct (the modes/react.ex shape — regression)
  - string-keyed OpenAI map → struct
  - stub callback returns a tagged error so accidental client-side use is loud

## Bumps

\`0.4.2\` → \`0.4.3\`. Patch release: bug fix only, no API surface changes.