### PR TITLE
feat(provider): add Claude Code-style adapter-boundary message logging (v0.4.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and ExAthena adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.4.4 — Adapter-boundary message logging (Claude Code-style)
+
+### Added
+
+- `ExAthena.Providers.ReqLLM` now emits structured Logger messages at
+  the adapter boundary, mirroring the Claude Code SDK's `[SDK]` log
+  style for parity with consumers that already grep for that prefix:
+  - `[ExAthena.ReqLLM] →query|→stream model=… msgs=N tools=K base_url=… backend=…`
+    (info level, one line per request).
+  - `[ExAthena.ReqLLM] →query system_prompt=…\n  msg[i] role: <preview>`
+    (debug level, full message body previews with whitespace collapsed
+    and capped at 200B/message).
+  - `[ExAthena.ReqLLM] ←text_delta NB: <preview>` per streamed chunk
+    (debug level).
+  - `[ExAthena.ReqLLM] ←tool_call name=… args=…` per tool call
+    (debug level).
+  - `[ExAthena.ReqLLM] ←meta finish_reason=…` and `←usage …`
+    (debug level).
+  - `[ExAthena.ReqLLM] ←done finish_reason=… text_chars=N tool_calls=K usage=…`
+    on completion (info level).
+  - `[ExAthena.ReqLLM] ←error …` when req_llm returns an error
+    (warning level).
+- All debug-level lines wrap their message construction in
+  `Logger.debug(fn -> … end)` so log assembly is skipped at higher
+  log levels — zero overhead in production.
+
+### Why
+
+Until 0.4.4 the adapter forwarded request/response data to req_llm
+without leaving any breadcrumb in the host application's log. When a
+streaming run stalled or the LLM returned unexpected content, callers
+had no way to see what was sent or what came back without attaching a
+telemetry handler. The new lines give the same kind of visibility
+ClaudeCode's SDK provides, so debugging Ollama/OpenAI/llama.cpp flows
+is a `tail -f phoenix_output.log | grep '\[ExAthena.ReqLLM\]'` away.
+
 ## v0.4.3 — Convert tools to %ReqLLM.Tool{} structs at the adapter boundary
 
 ### Fixed

--- a/lib/ex_athena/providers/req_llm.ex
+++ b/lib/ex_athena/providers/req_llm.ex
@@ -38,8 +38,14 @@ defmodule ExAthena.Providers.ReqLLM do
 
   @behaviour ExAthena.Provider
 
+  require Logger
+
   alias ExAthena.{Error, Request, Response}
   alias ExAthena.Messages.{Message, ToolResult}
+
+  # Claude Code-style log prefix so callers can filter/tail the adapter
+  # boundary independently of other ex_athena components.
+  @log_prefix "[ExAthena.ReqLLM]"
 
   @impl ExAthena.Provider
   def capabilities do
@@ -59,11 +65,16 @@ defmodule ExAthena.Providers.ReqLLM do
     with {:ok, model_spec} <- resolve_model(request, opts),
          {:ok, messages} <- build_messages(request),
          {:ok, req_opts} <- build_opts(request, opts) do
+      log_request(:query, model_spec, request, messages, req_opts)
+
       case ReqLLM.generate_text(model_spec, messages, req_opts) do
         {:ok, %ReqLLM.Response{} = resp} ->
-          {:ok, to_response(resp, request)}
+          response = to_response(resp, request)
+          log_response(response)
+          {:ok, response}
 
         {:error, reason} ->
+          log_error(reason)
           {:error, to_error(reason)}
       end
     end
@@ -74,11 +85,16 @@ defmodule ExAthena.Providers.ReqLLM do
     with {:ok, model_spec} <- resolve_model(request, opts),
          {:ok, messages} <- build_messages(request),
          {:ok, req_opts} <- build_opts(request, opts) do
+      log_request(:stream, model_spec, request, messages, req_opts)
+
       case ReqLLM.stream_text(model_spec, messages, req_opts) do
         {:ok, %ReqLLM.StreamResponse{} = sr} ->
-          {:ok, consume_stream(sr, callback, request)}
+          response = consume_stream(sr, callback, request)
+          log_response(response)
+          {:ok, response}
 
         {:error, reason} ->
+          log_error(reason)
           {:error, to_error(reason)}
       end
     end
@@ -362,21 +378,103 @@ defmodule ExAthena.Providers.ReqLLM do
   end
 
   defp handle_chunk(%{type: :content, text: text}, callback, acc) when is_binary(text) do
+    Logger.debug(fn ->
+      "#{@log_prefix} ←text_delta #{byte_size(text)}B: #{preview(text, 80)}"
+    end)
+
     ExAthena.Streaming.text_delta(callback, text)
     %{acc | text: [text | acc.text]}
   end
 
   defp handle_chunk(%{type: :tool_call} = tc, _callback, acc) do
+    Logger.debug(fn ->
+      name = Map.get(tc, :name) || Map.get(tc, "name") || "<unknown>"
+      args = Map.get(tc, :arguments) || Map.get(tc, "arguments") || %{}
+
+      "#{@log_prefix} ←tool_call name=#{inspect(name)} args=#{inspect(args, limit: 3, printable_limit: 200)}"
+    end)
+
     %{acc | tool_calls: acc.tool_calls ++ [tc]}
   end
 
-  defp handle_chunk(%{type: :usage, usage: usage}, _callback, acc), do: %{acc | usage: usage}
+  defp handle_chunk(%{type: :usage, usage: usage}, _callback, acc) do
+    Logger.debug(fn -> "#{@log_prefix} ←usage #{inspect(usage)}" end)
+    %{acc | usage: usage}
+  end
 
   defp handle_chunk(%{type: :meta, finish_reason: reason}, _callback, acc)
-       when not is_nil(reason),
-       do: %{acc | finish_reason: reason}
+       when not is_nil(reason) do
+    Logger.debug(fn -> "#{@log_prefix} ←meta finish_reason=#{inspect(reason)}" end)
+    %{acc | finish_reason: reason}
+  end
 
   defp handle_chunk(_chunk, _callback, acc), do: acc
+
+  # ── Logging helpers (Claude Code-style adapter-boundary breadcrumbs) ──
+
+  defp log_request(kind, model_spec, %Request{} = request, messages, req_opts) do
+    base_url = Keyword.get(req_opts, :base_url) || "<provider default>"
+    backend = Keyword.get(req_opts, :openai_compatible_backend)
+    n_msgs = length(messages)
+    n_tools = length(Keyword.get(req_opts, :tools, []) || [])
+
+    Logger.info(
+      "#{@log_prefix} →#{kind} model=#{inspect(model_spec)} msgs=#{n_msgs} tools=#{n_tools} " <>
+        "base_url=#{base_url}#{if backend, do: " backend=#{inspect(backend)}", else: ""}"
+    )
+
+    Logger.debug(fn ->
+      sp_preview =
+        case request.system_prompt do
+          nil -> "nil"
+          "" -> "\"\""
+          str when is_binary(str) -> "#{byte_size(str)}B: #{preview(str, 200)}"
+        end
+
+      msg_lines =
+        messages
+        |> Enum.with_index()
+        |> Enum.map(fn {%ReqLLM.Message{role: role, content: parts}, i} ->
+          text = parts |> Enum.map(&content_part_text/1) |> Enum.join(" ")
+          "  msg[#{i}] #{role}: #{preview(text, 200)}"
+        end)
+        |> Enum.join("\n")
+
+      "#{@log_prefix} →#{kind} system_prompt=#{sp_preview}\n#{msg_lines}"
+    end)
+  end
+
+  defp log_response(%Response{} = resp) do
+    text_chars = byte_size(resp.text || "")
+    n_tool_calls = length(resp.tool_calls || [])
+
+    Logger.info(
+      "#{@log_prefix} ←done finish_reason=#{inspect(resp.finish_reason)} " <>
+        "text_chars=#{text_chars} tool_calls=#{n_tool_calls} " <>
+        "usage=#{inspect(resp.usage, limit: 5)}"
+    )
+
+    Logger.debug(fn ->
+      "#{@log_prefix} ←done text_preview=#{preview(resp.text || "", 300)}"
+    end)
+  end
+
+  defp log_error(reason) do
+    Logger.warning("#{@log_prefix} ←error #{inspect(reason, limit: 5, printable_limit: 500)}")
+  end
+
+  defp content_part_text(%ReqLLM.Message.ContentPart{text: text}) when is_binary(text), do: text
+  defp content_part_text(_), do: ""
+
+  defp preview(str, max) when is_binary(str) do
+    cleaned = String.replace(str, ~r/\s+/, " ")
+
+    if byte_size(cleaned) <= max do
+      inspect(cleaned)
+    else
+      inspect(binary_part(cleaned, 0, max) <> "…")
+    end
+  end
 
   # ── Error mapping ─────────────────────────────────────────────────
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExAthena.MixProject do
   use Mix.Project
 
-  @version "0.4.3"
+  @version "0.4.4"
   @source_url "https://github.com/udin-io/ex_athena"
 
   def project do


### PR DESCRIPTION
## Summary

Adds Logger breadcrumbs at the same boundaries Claude Code's SDK emits its \`[SDK]\` lines, so consumers can see request/response flow without attaching a custom telemetry handler.

## Output examples

\`\`\`text
[ExAthena.ReqLLM] →stream model=\"openai:qwen2.5-coder:14b\" msgs=2 tools=10 base_url=http://localhost:11434/v1 backend=:ollama
[ExAthena.ReqLLM] ←text_delta 142B: \"I will start by reading the plan file…\"
[ExAthena.ReqLLM] ←tool_call name=\"read\" args=%{path: \"./AGENTS.md\"}
[ExAthena.ReqLLM] ←meta finish_reason=:stop
[ExAthena.ReqLLM] ←done finish_reason=:stop text_chars=812 tool_calls=1 usage=%{input_tokens: 4012, output_tokens: 198, …}
\`\`\`

\`info\` for request/response/error one-liners; \`debug\` for per-chunk and per-message previews. All debug-level lines use \`Logger.debug(fn -> … end)\` so log assembly is skipped at higher levels — zero overhead in production.

## Test plan

- [x] \`mix test\` — 271 tests + 2 doctests, all passing.
- [ ] Manual: tail \`phoenix_output.log\` while running an Ollama-backed planning ticket; expect to see \`[ExAthena.ReqLLM]\` lines for both directions.

## Bump

\`0.4.3\` → \`0.4.4\`.