### PR TITLE
feat(provider): stream heartbeat + TTFT log for cold-load visibility (v0.4.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and ExAthena adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.4.5 — Stream heartbeat + time-to-first-token (TTFT)
+
+### Added
+
+- `ExAthena.Providers.ReqLLM.consume_stream/3` now emits a heartbeat
+  log every 10 s while no chunk has arrived yet, and a one-time
+  TTFT line on the first content/tool_call chunk:
+  - `[ExAthena.ReqLLM] ⋯ waiting on stream (Ns elapsed)` (info,
+    repeats every 10 s during the prompt-processing phase, stops
+    automatically once chunks start flowing).
+  - `[ExAthena.ReqLLM] ←first_chunk after Yms (TTFT)` (info, fires
+    exactly once per stream).
+
+### Why
+
+Local Ollama / llama.cpp on a 14 B+ model regularly spends 30–120 s
+processing the prompt before emitting the first chunk. Until 0.4.5
+nothing surfaced on the wire during that wait — callers had no way
+to distinguish "slow but alive" from "stalled and silent". The
+heartbeat closes that gap with a single info-level line every 10 s,
+and the TTFT log captures the latency once tokens start flowing so
+operators can compare cold vs. warm runs. The heartbeat process
+exits as soon as the reduce returns (success or crash) via
+`try/after`, and self-checks `Process.alive?(parent)` before
+emitting in case the calling process was killed mid-stream.
+
 ## v0.4.4 — Adapter-boundary message logging (Claude Code-style)
 
 ### Added

--- a/lib/ex_athena/providers/req_llm.ex
+++ b/lib/ex_athena/providers/req_llm.ex
@@ -358,12 +358,27 @@ defmodule ExAthena.Providers.ReqLLM do
   # ── Streaming ─────────────────────────────────────────────────────
 
   defp consume_stream(%ReqLLM.StreamResponse{stream: stream}, callback, request) do
-    state = %{text: [], tool_calls: [], model: request.model, finish_reason: nil, usage: nil}
+    state = %{
+      text: [],
+      tool_calls: [],
+      model: request.model,
+      finish_reason: nil,
+      usage: nil,
+      first_chunk_logged: false,
+      stream_started_ms: System.monotonic_time(:millisecond)
+    }
+
+    heartbeat_pid = start_heartbeat(state.stream_started_ms)
 
     final =
-      Enum.reduce(stream, state, fn chunk, acc ->
-        handle_chunk(chunk, callback, acc)
-      end)
+      try do
+        Enum.reduce(stream, state, fn chunk, acc ->
+          acc = maybe_log_first_chunk(chunk, acc)
+          handle_chunk(chunk, callback, acc)
+        end)
+      after
+        stop_heartbeat(heartbeat_pid)
+      end
 
     ExAthena.Streaming.stop(callback, final.finish_reason || :stop)
 
@@ -376,6 +391,53 @@ defmodule ExAthena.Providers.ReqLLM do
       usage: final.usage
     }
   end
+
+  # ── Heartbeat / TTFT (visibility while Ollama is processing) ──────────
+  #
+  # Local Ollama on a 14B+ model can spend 30–120s processing the prompt
+  # before emitting the first chunk. Without any signal on the wire,
+  # callers can't tell a slow-but-alive request from a stalled one. Emit a
+  # `⋯ waiting on stream (Ns elapsed)` heartbeat every 10s until the first
+  # content/tool_call chunk arrives, then log the TTFT exactly once.
+
+  @heartbeat_interval_ms 10_000
+
+  defp start_heartbeat(start_ms) do
+    parent = self()
+
+    spawn(fn ->
+      heartbeat_loop(parent, start_ms)
+    end)
+  end
+
+  defp heartbeat_loop(parent, start_ms) do
+    receive do
+      :stop -> :ok
+    after
+      @heartbeat_interval_ms ->
+        if Process.alive?(parent) do
+          elapsed_s = div(System.monotonic_time(:millisecond) - start_ms, 1000)
+          Logger.info("#{@log_prefix} ⋯ waiting on stream (#{elapsed_s}s elapsed)")
+          heartbeat_loop(parent, start_ms)
+        else
+          :ok
+        end
+    end
+  end
+
+  defp stop_heartbeat(pid) when is_pid(pid) do
+    send(pid, :stop)
+    :ok
+  end
+
+  defp maybe_log_first_chunk(%{type: type}, %{first_chunk_logged: false} = acc)
+       when type in [:content, :tool_call] do
+    elapsed_ms = System.monotonic_time(:millisecond) - acc.stream_started_ms
+    Logger.info("#{@log_prefix} ←first_chunk after #{elapsed_ms}ms (TTFT)")
+    %{acc | first_chunk_logged: true}
+  end
+
+  defp maybe_log_first_chunk(_chunk, acc), do: acc
 
   defp handle_chunk(%{type: :content, text: text}, callback, acc) when is_binary(text) do
     Logger.debug(fn ->

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExAthena.MixProject do
   use Mix.Project
 
-  @version "0.4.4"
+  @version "0.4.5"
   @source_url "https://github.com/udin-io/ex_athena"
 
   def project do


### PR DESCRIPTION
## Summary

Closes the visibility gap between \`→stream\` and the first \`←text_delta\` for slow providers (Ollama / llama.cpp). On a cold-loaded 14B+ model, prompt processing can take 30–120s before any chunk hits the wire — until 0.4.5 the log went silent during that window and operators had no way to tell a slow-but-alive request from a stalled one.

## What you'll see

\`\`\`text
[info] [ExAthena.ReqLLM] →stream model=\"openai:qwen2.5-coder:14b\" msgs=3 tools=10 base_url=http://localhost:11434/v1 backend=:ollama
[info] [ExAthena.ReqLLM] ⋯ waiting on stream (10s elapsed)
[info] [ExAthena.ReqLLM] ⋯ waiting on stream (20s elapsed)
[info] [ExAthena.ReqLLM] ⋯ waiting on stream (30s elapsed)
[info] [ExAthena.ReqLLM] ←first_chunk after 34218ms (TTFT)
[info] [ExAthena.ReqLLM] ←done finish_reason=:stop text_chars=1080 tool_calls=0 usage=…
\`\`\`

The heartbeat fires every 10 s while no \`:content\` / \`:tool_call\` chunk has arrived; it stops automatically once chunks start flowing. The TTFT line fires exactly once. Heartbeat process is spawned before \`Enum.reduce\` and torn down via \`try/after\` so it exits on both success and crash; the loop also self-checks \`Process.alive?(parent)\` before emitting in case the calling process was killed mid-stream.

## Test plan

- [x] \`mix test test/ex_athena/providers/req_llm_test.exs test/ex_athena/config_test.exs\` — 29 tests, 0 failures.
- [x] Full \`mix test\` — 271 tests + 2 doctests; one pre-existing flaky test in \`config_test.exs:48\` fails only when other suites leak \`Application.put_env(:ex_athena, :model)\`. Same flake we saw in 0.4.2 and 0.4.4 — passes in isolation.
- [ ] Manual: trigger an Ollama planning ticket, expect heartbeat lines while the model warms, then \`←first_chunk after Yms (TTFT)\` once tokens flow.

## Bump

\`0.4.4\` → \`0.4.5\`.