### PR TITLE
feat(tool_calls): RawJson fallback parser + per-request native_tool_calls override

### DIFF
--- a/.artifacts/adr-1-raw-json-tool-call-fallback-and-capability-override.md
+++ b/.artifacts/adr-1-raw-json-tool-call-fallback-and-capability-override.md
@@ -1,0 +1,35 @@
+# ADR 1: RawJson tool-call fallback and per-request capability override
+
+## Status
+
+Accepted
+
+## Context
+
+Weak open-weight models routed through ReqLLM/Ollama (e.g. `qwen2.5-coder:14b`) emit tool calls as bare JSON in assistant text rather than as a structured `tool_calls` array. ExAthena's current extraction pipeline has two parsers — `Native` and `TextTagged` — and an auto-fallback that triggers only on a `~~~tool_call` fence substring. Bare JSON is silently dropped and ReAct ends with `:stop` without firing any tool.
+
+Separately, `ExAthena.Providers.ReqLLM` statically declares `native_tool_calls: true` for every model it fronts, so `ReAct.effective_system_prompt/1` never augments the prompt with fence instructions. There is no per-request way to flip this for a known-weak model, so callers cannot opt those models into fenced prompting without forking the provider module.
+
+Together these gaps mean tool calls from weak Ollama models are dropped end-to-end, blocking downstream consumer udin-io/udin_code#1268.
+
+## Decision
+
+1. Introduce a third parser, `ExAthena.ToolCalls.RawJson`, that recognizes bare and ```json-fenced JSON objects with a `name`/`arguments` shape, using balanced-brace scanning (in-string state + backslash escapes). Wire it into `ToolCalls.extract/2` as a third fallback tier behind `Native` and `TextTagged`.
+2. Add a per-request capability override in `ExAthena.Loop`: `Map.merge(provider_mod.capabilities(), opts[:capabilities] || %{})`. Callers can pass `capabilities: %{native_tool_calls: false}` to flip ReAct into fence-augmented prompting per request, without changing the provider module.
+
+Neither change alters the parser contract (`{:ok, [ToolCall.t()]}`), introduces a new provider, or modifies caller-visible defaults.
+
+## Consequences
+
+**Positive**
+
+- Tool calls from weak models like `qwen2.5-coder:14b` are no longer silently dropped.
+- Downstream consumers can opt known-weak models into fenced prompting without forking provider modules.
+- Default behavior is unchanged; the new fallback is conservative and best-effort.
+- Unblocks udin-io/udin_code#1268.
+
+**Negative / risks**
+
+- A third extraction tier slightly increases parser pipeline surface area.
+- The balanced-brace scanner is hand-rolled; pathological input could in principle slow extraction. Mitigated by a cheap pre-check requiring both `"name"` and `"arguments"` substrings before scanning.
+- `:capabilities` becomes a public per-request opt; future capability flags must be designed to remain back-compatible under merge.

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ ex_athena-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
+# UdinCode planning artifacts
+.artifacts/*
+!.artifacts/adr-*.md
+.claude/

--- a/lib/ex_athena/compactors/context_collapse.ex
+++ b/lib/ex_athena/compactors/context_collapse.ex
@@ -130,7 +130,7 @@ defmodule ExAthena.Compactors.ContextCollapse do
           (sig = repeat_signature(msg)) && sig == last_sig ->
             {acc ++ [mark_repeat(msg)], sig}
 
-          (sig = repeat_signature(msg)) ->
+          sig = repeat_signature(msg) ->
             {acc ++ [msg], sig}
 
           true ->

--- a/lib/ex_athena/loop.ex
+++ b/lib/ex_athena/loop.ex
@@ -375,7 +375,9 @@ defmodule ExAthena.Loop do
     tool_modules = opts |> Tools.resolve() |> normalize_tool_list()
 
     with :ok <- validate_tools(tool_modules) do
-      capabilities = provider_mod.capabilities()
+      capabilities =
+        provider_mod.capabilities()
+        |> Map.merge(Keyword.get(opts, :capabilities, %{}))
 
       memory_messages = resolve_memory(cwd, opts)
       skills = resolve_skills(cwd, opts)

--- a/lib/ex_athena/modes/plan_and_solve.ex
+++ b/lib/ex_athena/modes/plan_and_solve.ex
@@ -71,8 +71,7 @@ defmodule ExAthena.Modes.PlanAndSolve do
         new_messages =
           state.messages ++ [ExAthena.Messages.assistant(response.text || "")]
 
-        {:continue,
-         %{state | messages: new_messages, mode_state: %{phase: :executing}}}
+        {:continue, %{state | messages: new_messages, mode_state: %{phase: :executing}}}
 
       {:error, reason} ->
         {:error, {:plan_and_solve_planning_failed, reason}}

--- a/lib/ex_athena/structured.ex
+++ b/lib/ex_athena/structured.ex
@@ -45,7 +45,9 @@ defmodule ExAthena.Structured do
     {provider_mod, opts} = Config.pop_provider!(opts)
     caps = provider_mod.capabilities()
 
-    {augmented_prompt, request_opts} = build_request_opts(prompt, schema, instructions, caps, opts)
+    {augmented_prompt, request_opts} =
+      build_request_opts(prompt, schema, instructions, caps, opts)
+
     request = Request.new(augmented_prompt, request_opts)
 
     provider_opts = Config.provider_opts(provider_mod, opts)
@@ -272,8 +274,13 @@ defmodule ExAthena.Structured do
       value = Map.get(json, key) || Map.get(json, to_string(key))
 
       case value do
-        nil -> {:cont, :ok}
-        v -> if validate_basic(v, prop_schema) == :ok, do: {:cont, :ok}, else: {:halt, {:error, {:property_invalid, key}}}
+        nil ->
+          {:cont, :ok}
+
+        v ->
+          if validate_basic(v, prop_schema) == :ok,
+            do: {:cont, :ok},
+            else: {:halt, {:error, {:property_invalid, key}}}
       end
     end)
   end

--- a/lib/ex_athena/tool_calls.ex
+++ b/lib/ex_athena/tool_calls.ex
@@ -21,7 +21,7 @@ defmodule ExAthena.ToolCalls do
   """
 
   alias ExAthena.Messages.ToolCall
-  alias ExAthena.ToolCalls.{Native, TextTagged}
+  alias ExAthena.ToolCalls.{Native, RawJson, TextTagged}
 
   @type provider_response :: %{
           optional(:text) => String.t() | nil,
@@ -43,20 +43,28 @@ defmodule ExAthena.ToolCalls do
   end
 
   def extract(%{text: text}, %{native_tool_calls: false}) when is_binary(text) do
-    TextTagged.parse(text)
+    with {:ok, []} <- TextTagged.parse(text) do
+      if looks_like_raw_json?(text), do: RawJson.parse(text), else: {:ok, []}
+    end
   end
 
   def extract(%{text: text}, _caps) when is_binary(text) do
-    # Native was claimed (or unknown) but came back empty — look for text-tagged
-    # blocks as an auto-fallback.
-    if String.contains?(text || "", "~~~tool_call") do
-      TextTagged.parse(text)
-    else
-      {:ok, []}
+    # Native was claimed (or unknown) but came back empty — cascade through
+    # text-tagged fences then bare-JSON as fallback tiers.
+    cond do
+      String.contains?(text, "~~~tool_call") -> TextTagged.parse(text)
+      looks_like_raw_json?(text) -> RawJson.parse(text)
+      true -> {:ok, []}
     end
   end
 
   def extract(_response, _caps), do: {:ok, []}
+
+  # Cheap pre-check before running the balanced-brace scanner. Both keys must
+  # appear in the text to be worth attempting full parse.
+  defp looks_like_raw_json?(text) do
+    String.contains?(text, ~s("name")) and String.contains?(text, ~s("arguments"))
+  end
 
   @doc """
   Append text-tagged tool-call instructions to a system prompt so

--- a/lib/ex_athena/tool_calls.ex
+++ b/lib/ex_athena/tool_calls.ex
@@ -2,22 +2,31 @@ defmodule ExAthena.ToolCalls do
   @moduledoc """
   Extracts tool calls from a provider response.
 
-  Two protocols, two parsers:
+  Three parsers:
 
     * `ExAthena.ToolCalls.Native` — structured `tool_calls` array from the
       provider (OpenAI-style `function` + `arguments`, Claude `tool_use`
       blocks, Ollama's OpenAI-compatible payload).
     * `ExAthena.ToolCalls.TextTagged` — prompt-engineered
       `~~~tool_call <json> ~~~` blocks embedded in the assistant's text.
+    * `ExAthena.ToolCalls.RawJson` — bare or `` ```json ``-fenced JSON objects
+      emitted by weak open-weight models that ignore both native tool-call
+      APIs and the `~~~tool_call` fence format.
 
   ## Auto-fallback
 
-  `extract/2` picks the protocol based on `provider_capabilities.native_tool_calls`.
-  If native is claimed but the parser finds no tool calls AND the assistant
-  text contains `~~~tool_call` fences, it falls back to TextTagged. Conversely,
-  if native returns tool calls, TextTagged is skipped. The agent loop (Phase 2)
-  uses `augment_system_prompt/2` to add text-tagged instructions when a
-  provider lacks native support.
+  `extract/2` cascades through three tiers based on the response content and
+  `provider_capabilities.native_tool_calls`:
+
+    1. Structured `tool_calls` present → `Native.parse/1`.
+    2. Text contains `~~~tool_call` fences, or provider declared no native
+       support → `TextTagged.parse/1`.
+    3. Text looks like a raw JSON tool call (has both `"name"` and
+       `"arguments"` substrings) → `RawJson.parse/1`.
+    4. No match → `{:ok, []}`.
+
+  The agent loop uses `augment_system_prompt/2` to add text-tagged instructions
+  when a provider lacks native support.
   """
 
   alias ExAthena.Messages.ToolCall

--- a/lib/ex_athena/tool_calls/native.ex
+++ b/lib/ex_athena/tool_calls/native.ex
@@ -34,7 +34,11 @@ defmodule ExAthena.ToolCalls.Native do
   end
 
   defp parse_one(%{type: "function", id: id, function: fun}) do
-    build(id, fetch(fun, :name) || fetch(fun, "name"), fetch(fun, :arguments) || fetch(fun, "arguments"))
+    build(
+      id,
+      fetch(fun, :name) || fetch(fun, "name"),
+      fetch(fun, :arguments) || fetch(fun, "arguments")
+    )
   end
 
   defp parse_one(%{"type" => "tool_use", "id" => id, "name" => name, "input" => input}) do

--- a/lib/ex_athena/tool_calls/raw_json.ex
+++ b/lib/ex_athena/tool_calls/raw_json.ex
@@ -45,12 +45,16 @@ defmodule ExAthena.ToolCalls.RawJson do
         Enum.reverse(acc)
 
       brace_pos ->
-        case scan_balanced(text, brace_pos) do
-          {:ok, end_pos} ->
-            candidate = binary_part(text, brace_pos, end_pos - brace_pos)
+        # Slice to the char after `{`; scan_balanced tracks depth from 1.
+        after_brace = binary_part(text, brace_pos + 1, byte_size(text) - brace_pos - 1)
+
+        case scan_balanced(after_brace, 1, false, false, 1) do
+          {:ok, length} ->
+            # length includes the leading `{` (consumed starts at 1).
+            candidate = binary_part(text, brace_pos, length)
 
             case decode_tool_call(candidate) do
-              {:ok, tc} -> scan_all(text, end_pos, [tc | acc])
+              {:ok, tc} -> scan_all(text, brace_pos + length, [tc | acc])
               :skip -> scan_all(text, brace_pos + 1, acc)
             end
 
@@ -69,46 +73,48 @@ defmodule ExAthena.ToolCalls.RawJson do
 
   defp find_open_brace(_text, _offset), do: nil
 
-  # Scan from the `{` at `brace_pos`; return {:ok, end_pos} (exclusive) or :error.
-  # Tracks in-string state and backslash escapes to avoid counting braces inside strings.
-  defp scan_balanced(text, brace_pos) do
-    scan_loop(text, brace_pos + 1, 1, false, false)
+  # Slice-and-pass balanced-brace scanner. `rest` is the binary starting at the
+  # character after the opening `{` (depth starts at 1, consumed starts at 1).
+  # Returns {:ok, total_bytes} where total_bytes includes the leading `{`.
+  # Tracks in-string state and backslash escapes to skip braces inside strings.
+  defp scan_balanced(<<>>, _depth, _in_string, _escaped, _consumed), do: :error
+
+  defp scan_balanced(<<_ch, rest::binary>>, depth, true, true, consumed) do
+    # Previous char was a backslash inside a string: skip this char, clear escape.
+    scan_balanced(rest, depth, true, false, consumed + 1)
   end
 
-  defp scan_loop(text, pos, depth, in_string, escaped) when pos < byte_size(text) do
-    <<_::binary-size(pos), ch, _::binary>> = text
-
-    cond do
-      escaped ->
-        scan_loop(text, pos + 1, depth, in_string, false)
-
-      in_string and ch == ?\\ ->
-        scan_loop(text, pos + 1, depth, true, true)
-
-      in_string and ch == ?" ->
-        scan_loop(text, pos + 1, depth, false, false)
-
-      in_string ->
-        scan_loop(text, pos + 1, depth, true, false)
-
-      ch == ?" ->
-        scan_loop(text, pos + 1, depth, true, false)
-
-      ch == ?{ ->
-        scan_loop(text, pos + 1, depth + 1, false, false)
-
-      ch == ?} and depth == 1 ->
-        {:ok, pos + 1}
-
-      ch == ?} ->
-        scan_loop(text, pos + 1, depth - 1, false, false)
-
-      true ->
-        scan_loop(text, pos + 1, depth, false, false)
-    end
+  defp scan_balanced(<<?\\, rest::binary>>, depth, true, false, consumed) do
+    scan_balanced(rest, depth, true, true, consumed + 1)
   end
 
-  defp scan_loop(_text, _pos, _depth, _in_string, _escaped), do: :error
+  defp scan_balanced(<<?", rest::binary>>, depth, true, false, consumed) do
+    scan_balanced(rest, depth, false, false, consumed + 1)
+  end
+
+  defp scan_balanced(<<_ch, rest::binary>>, depth, true, false, consumed) do
+    scan_balanced(rest, depth, true, false, consumed + 1)
+  end
+
+  defp scan_balanced(<<?", rest::binary>>, depth, false, false, consumed) do
+    scan_balanced(rest, depth, true, false, consumed + 1)
+  end
+
+  defp scan_balanced(<<?{, rest::binary>>, depth, false, false, consumed) do
+    scan_balanced(rest, depth + 1, false, false, consumed + 1)
+  end
+
+  defp scan_balanced(<<?}, _rest::binary>>, 1, false, false, consumed) do
+    {:ok, consumed + 1}
+  end
+
+  defp scan_balanced(<<?}, rest::binary>>, depth, false, false, consumed) do
+    scan_balanced(rest, depth - 1, false, false, consumed + 1)
+  end
+
+  defp scan_balanced(<<_ch, rest::binary>>, depth, false, false, consumed) do
+    scan_balanced(rest, depth, false, false, consumed + 1)
+  end
 
   defp decode_tool_call(json) do
     with {:ok, map} when is_map(map) <- Jason.decode(json),

--- a/lib/ex_athena/tool_calls/raw_json.ex
+++ b/lib/ex_athena/tool_calls/raw_json.ex
@@ -1,0 +1,143 @@
+defmodule ExAthena.ToolCalls.RawJson do
+  @moduledoc """
+  Best-effort parser for bare JSON tool calls embedded in assistant text.
+
+  Handles weak open-weight models (e.g. `qwen2.5-coder:14b` via Ollama) that
+  emit tool calls as raw JSON objects in the text rather than structured
+  `tool_calls` arrays or `~~~tool_call` fences.
+
+  A valid payload looks like:
+
+      {"name": "read_file", "arguments": {"path": "/tmp/foo"}}
+
+  or wrapped in a markdown code fence:
+
+      ```json
+      {"name": "read_file", "arguments": {"path": "/tmp/foo"}}
+      ```
+
+  The parser walks the text scanning for `{` characters, then uses a
+  balanced-brace scanner that respects JSON string boundaries (backslash
+  escapes, in-string state). Never raises — malformed input returns `{:ok, []}`.
+  """
+
+  alias ExAthena.Messages.ToolCall
+
+  @fence_regex ~r/\A\s*```(?:json)?\s*\n(.*?)\n\s*```\s*\z/s
+
+  @doc "Extract tool calls from assistant text. Always returns `{:ok, list}`."
+  @spec parse(String.t()) :: {:ok, [ToolCall.t()]}
+  def parse(text) when is_binary(text) do
+    text = strip_markdown_fence(text)
+    {:ok, scan_all(text, 0, [])}
+  end
+
+  defp strip_markdown_fence(text) do
+    case Regex.run(@fence_regex, text, capture: :all_but_first) do
+      [inner] -> String.trim(inner)
+      nil -> text
+    end
+  end
+
+  defp scan_all(text, offset, acc) do
+    case find_open_brace(text, offset) do
+      nil ->
+        Enum.reverse(acc)
+
+      brace_pos ->
+        case scan_balanced(text, brace_pos) do
+          {:ok, end_pos} ->
+            candidate = binary_part(text, brace_pos, end_pos - brace_pos)
+
+            case decode_tool_call(candidate) do
+              {:ok, tc} -> scan_all(text, end_pos, [tc | acc])
+              :skip -> scan_all(text, brace_pos + 1, acc)
+            end
+
+          :error ->
+            scan_all(text, brace_pos + 1, acc)
+        end
+    end
+  end
+
+  defp find_open_brace(text, offset) when offset < byte_size(text) do
+    case :binary.match(text, "{", scope: {offset, byte_size(text) - offset}) do
+      {pos, 1} -> pos
+      :nomatch -> nil
+    end
+  end
+
+  defp find_open_brace(_text, _offset), do: nil
+
+  # Scan from the `{` at `brace_pos`; return {:ok, end_pos} (exclusive) or :error.
+  # Tracks in-string state and backslash escapes to avoid counting braces inside strings.
+  defp scan_balanced(text, brace_pos) do
+    scan_loop(text, brace_pos + 1, 1, false, false)
+  end
+
+  defp scan_loop(text, pos, depth, in_string, escaped) when pos < byte_size(text) do
+    <<_::binary-size(pos), ch, _::binary>> = text
+
+    cond do
+      escaped ->
+        scan_loop(text, pos + 1, depth, in_string, false)
+
+      in_string and ch == ?\\ ->
+        scan_loop(text, pos + 1, depth, true, true)
+
+      in_string and ch == ?" ->
+        scan_loop(text, pos + 1, depth, false, false)
+
+      in_string ->
+        scan_loop(text, pos + 1, depth, true, false)
+
+      ch == ?" ->
+        scan_loop(text, pos + 1, depth, true, false)
+
+      ch == ?{ ->
+        scan_loop(text, pos + 1, depth + 1, false, false)
+
+      ch == ?} and depth == 1 ->
+        {:ok, pos + 1}
+
+      ch == ?} ->
+        scan_loop(text, pos + 1, depth - 1, false, false)
+
+      true ->
+        scan_loop(text, pos + 1, depth, false, false)
+    end
+  end
+
+  defp scan_loop(_text, _pos, _depth, _in_string, _escaped), do: :error
+
+  defp decode_tool_call(json) do
+    with {:ok, map} when is_map(map) <- Jason.decode(json),
+         name when is_binary(name) and name != "" <- Map.get(map, "name"),
+         {:ok, args} <- extract_arguments(map) do
+      {:ok,
+       %ToolCall{
+         id: Map.get(map, "id") || generate_id(),
+         name: name,
+         arguments: args
+       }}
+    else
+      _ -> :skip
+    end
+  end
+
+  defp extract_arguments(%{"arguments" => args}) when is_map(args), do: {:ok, args}
+  defp extract_arguments(%{"arguments" => nil}), do: {:ok, %{}}
+
+  defp extract_arguments(%{"arguments" => args}) when is_binary(args) do
+    case Jason.decode(args) do
+      {:ok, map} when is_map(map) -> {:ok, map}
+      _ -> :error
+    end
+  end
+
+  defp extract_arguments(_map), do: :error
+
+  defp generate_id do
+    "call_" <> Base.url_encode64(:crypto.strong_rand_bytes(9), padding: false)
+  end
+end

--- a/test/ex_athena/agents/worktree_test.exs
+++ b/test/ex_athena/agents/worktree_test.exs
@@ -64,7 +64,11 @@ defmodule ExAthena.Agents.WorktreeTest do
       _ = System.cmd("git", ["commit", "-q", "-m", "init"], cd: dir)
 
       assert {:worktree, info} =
-               Worktree.resolve(def_isolated(:worktree), dir, "session-test-#{System.unique_integer([:positive])}")
+               Worktree.resolve(
+                 def_isolated(:worktree),
+                 dir,
+                 "session-test-#{System.unique_integer([:positive])}"
+               )
 
       assert File.dir?(info.path)
       assert info.branch =~ "ex_athena/session-test-"

--- a/test/ex_athena/compactors/snip_test.exs
+++ b/test/ex_athena/compactors/snip_test.exs
@@ -41,9 +41,9 @@ defmodule ExAthena.Compactors.SnipTest do
   test "replaces stale tool-result bodies with a marker" do
     # Layout: pinned (1) + 8 turns including tool messages + 1 final assistant.
     # The early tool messages should be 4+ turns from the last assistant.
+    # Assistant + tool turn (these are old relative to last_assistant)
     messages =
       [Messages.system("sp")] ++
-        # Assistant + tool turn (these are old relative to last_assistant)
         for i <- 1..8 do
           if rem(i, 2) == 1 do
             Messages.assistant("turn #{i}")

--- a/test/ex_athena/config_test.exs
+++ b/test/ex_athena/config_test.exs
@@ -3,12 +3,25 @@ defmodule ExAthena.ConfigTest do
 
   alias ExAthena.Config
 
+  @all_provider_atoms [
+    :ollama,
+    :openai,
+    :openai_compatible,
+    :llamacpp,
+    :claude,
+    :anthropic,
+    :req_llm
+  ]
+
   setup do
+    # Clear any env leaked by Igniter-based tests (install task) that temporarily
+    # mutate Application env while writing config files.
+    for atom <- [:default_provider, :model | @all_provider_atoms],
+        do: Application.delete_env(:ex_athena, atom)
+
     on_exit(fn ->
-      Application.delete_env(:ex_athena, :default_provider)
-      Application.delete_env(:ex_athena, :ollama)
-      Application.delete_env(:ex_athena, :openai)
-      Application.delete_env(:ex_athena, :openai_compatible)
+      for atom <- [:default_provider, :model | @all_provider_atoms],
+          do: Application.delete_env(:ex_athena, atom)
     end)
 
     :ok
@@ -51,10 +64,7 @@ defmodule ExAthena.ConfigTest do
 
       # per-call wins
       assert "call-model" =
-               Config.get(ExAthena.Providers.ReqLLM, :model,
-                 [model: "call-model"],
-                 "default"
-               )
+               Config.get(ExAthena.Providers.ReqLLM, :model, [model: "call-model"], "default")
 
       # provider env wins over top-level
       assert "env-model" = Config.get(ExAthena.Providers.ReqLLM, :model, [], "default")

--- a/test/ex_athena/loop_test.exs
+++ b/test/ex_athena/loop_test.exs
@@ -28,7 +28,9 @@ defmodule ExAthena.LoopTest do
   end
 
   test "plain text response: loop terminates in one iteration", %{dir: dir} do
-    responses = [%Response{text: "no tools needed", tool_calls: [], finish_reason: :stop, provider: :mock}]
+    responses = [
+      %Response{text: "no tools needed", tool_calls: [], finish_reason: :stop, provider: :mock}
+    ]
 
     assert {:ok, result} =
              Loop.run("hi",
@@ -80,7 +82,13 @@ defmodule ExAthena.LoopTest do
     # Responder that always calls a tool — infinite loop if not capped
     loop_response = %Response{
       text: "",
-      tool_calls: [%ToolCall{id: "c#{System.unique_integer([:positive])}", name: "glob", arguments: %{"pattern" => "**"}}],
+      tool_calls: [
+        %ToolCall{
+          id: "c#{System.unique_integer([:positive])}",
+          name: "glob",
+          arguments: %{"pattern" => "**"}
+        }
+      ],
       finish_reason: :tool_calls,
       provider: :mock
     }
@@ -155,6 +163,76 @@ defmodule ExAthena.LoopTest do
     assert content =~ "nonexistent_tool"
   end
 
+  test "capabilities: %{native_tool_calls: false} injects ~~~tool_call preamble into system prompt",
+       %{dir: dir} do
+    test_pid = self()
+
+    responder = fn request ->
+      send(test_pid, {:system_prompt, request.system_prompt})
+      %Response{text: "done", tool_calls: [], finish_reason: :stop, provider: :mock}
+    end
+
+    assert {:ok, _} =
+             Loop.run("hi",
+               provider: :mock,
+               mock: [responder: responder],
+               cwd: dir,
+               tools: [],
+               capabilities: %{native_tool_calls: false}
+             )
+
+    assert_receive {:system_prompt, sp}
+    assert sp =~ "~~~tool_call"
+  end
+
+  test "without capabilities override, native Mock provider does NOT get the preamble",
+       %{dir: dir} do
+    test_pid = self()
+
+    responder = fn request ->
+      send(test_pid, {:system_prompt, request.system_prompt})
+      %Response{text: "done", tool_calls: [], finish_reason: :stop, provider: :mock}
+    end
+
+    assert {:ok, _} =
+             Loop.run("hi",
+               provider: :mock,
+               mock: [responder: responder],
+               cwd: dir,
+               tools: []
+             )
+
+    assert_receive {:system_prompt, sp}
+    refute (sp || "") =~ "~~~tool_call"
+  end
+
+  test "capabilities override: fenced tool call in text is parsed and dispatched", %{dir: dir} do
+    File.write!(Path.join(dir, "hello.txt"), "hello world")
+
+    responses = [
+      %Response{
+        text: "~~~tool_call\n{\"name\": \"read\", \"arguments\": {\"path\": \"hello.txt\"}}\n~~~",
+        tool_calls: [],
+        finish_reason: :stop,
+        provider: :mock
+      },
+      %Response{text: "file read ok", tool_calls: [], finish_reason: :stop, provider: :mock}
+    ]
+
+    assert {:ok, result} =
+             Loop.run("read hello.txt",
+               provider: :mock,
+               mock: [responder: script(responses)],
+               cwd: dir,
+               tools: [ExAthena.Tools.Read],
+               capabilities: %{native_tool_calls: false}
+             )
+
+    assert result.text == "file read ok"
+    assert result.iterations == 1
+    assert Enum.any?(result.messages, &match?(%{role: :tool}, &1))
+  end
+
   test "plan_mode tool changes the ctx phase mid-loop", %{dir: dir} do
     responses = [
       %Response{
@@ -165,7 +243,9 @@ defmodule ExAthena.LoopTest do
       },
       %Response{
         text: "now I can write",
-        tool_calls: [%ToolCall{id: "c2", name: "write", arguments: %{"path" => "new.txt", "content" => "hi"}}],
+        tool_calls: [
+          %ToolCall{id: "c2", name: "write", arguments: %{"path" => "new.txt", "content" => "hi"}}
+        ],
         finish_reason: :tool_calls,
         provider: :mock
       },

--- a/test/ex_athena/modes/reflexion_test.exs
+++ b/test/ex_athena/modes/reflexion_test.exs
@@ -21,9 +21,10 @@ defmodule ExAthena.Modes.ReflexionTest do
       n = :counters.get(counter, 1)
 
       # Assert: reflection requests have no tools.
-      is_reflection = Enum.any?(request.messages, fn m ->
-        is_binary(m.content) and String.contains?(m.content || "", "Reflect on your last step")
-      end)
+      is_reflection =
+        Enum.any?(request.messages, fn m ->
+          is_binary(m.content) and String.contains?(m.content || "", "Reflect on your last step")
+        end)
 
       cond do
         # Turn 1: tool call. Turn 2: reflection. Turn 3: tool call. Turn 4: reflection.

--- a/test/ex_athena/structured_test.exs
+++ b/test/ex_athena/structured_test.exs
@@ -18,8 +18,11 @@ defmodule ExAthena.StructuredTest do
     }
 
     assert {:ok, %{"name" => "Ada", "age" => 36}} =
-             Structured.extract("tell me about Ada", schema: schema, provider: :mock,
-               mock: [responder: responder])
+             Structured.extract("tell me about Ada",
+               schema: schema,
+               provider: :mock,
+               mock: [responder: responder]
+             )
   end
 
   test "extracts JSON from a fenced block when not in JSON mode" do
@@ -43,8 +46,11 @@ defmodule ExAthena.StructuredTest do
     }
 
     assert {:ok, %{"status" => "ok", "count" => 3}} =
-             Structured.extract("hi", schema: schema, provider: :mock,
-               mock: [responder: responder])
+             Structured.extract("hi",
+               schema: schema,
+               provider: :mock,
+               mock: [responder: responder]
+             )
   end
 
   test "validates required keys" do
@@ -116,8 +122,11 @@ defmodule ExAthena.StructuredTest do
         :counters.add(counter, 1, 1)
 
         case :counters.get(counter, 1) do
-          1 -> %Response{text: ~s({"name": "Ada"}), provider: :mock, finish_reason: :stop}
-          _ -> %Response{text: ~s({"name": "Ada", "age": 36}), provider: :mock, finish_reason: :stop}
+          1 ->
+            %Response{text: ~s({"name": "Ada"}), provider: :mock, finish_reason: :stop}
+
+          _ ->
+            %Response{text: ~s({"name": "Ada", "age": 36}), provider: :mock, finish_reason: :stop}
         end
       end
 

--- a/test/ex_athena/tool_calls/raw_json_test.exs
+++ b/test/ex_athena/tool_calls/raw_json_test.exs
@@ -1,0 +1,98 @@
+defmodule ExAthena.ToolCalls.RawJsonTest do
+  use ExUnit.Case, async: true
+
+  alias ExAthena.Messages.ToolCall
+  alias ExAthena.ToolCalls.RawJson
+
+  describe "parse/1" do
+    test "bare JSON tool call" do
+      assert {:ok, [%ToolCall{name: "foo", arguments: %{}}]} =
+               RawJson.parse(~s({"name":"foo","arguments":{}}))
+    end
+
+    test "markdown-fenced JSON tool call" do
+      text = """
+      ```json
+      {"name":"read_file","arguments":{"path":"/tmp/foo"}}
+      ```
+      """
+
+      assert {:ok, [%ToolCall{name: "read_file", arguments: %{"path" => "/tmp/foo"}}]} =
+               RawJson.parse(text)
+    end
+
+    test "nested arguments are fully decoded" do
+      json = ~s({"name":"x","arguments":{"path":"/tmp","opts":{"recursive":true}}})
+
+      assert {:ok,
+              [
+                %ToolCall{
+                  name: "x",
+                  arguments: %{"path" => "/tmp", "opts" => %{"recursive" => true}}
+                }
+              ]} =
+               RawJson.parse(json)
+    end
+
+    test "prose preamble before JSON is handled" do
+      text = ~s(I will call the tool now.\n{"name":"ping","arguments":{}})
+
+      assert {:ok, [%ToolCall{name: "ping"}]} = RawJson.parse(text)
+    end
+
+    test "text with no JSON returns empty list" do
+      assert {:ok, []} = RawJson.parse("just some plain text with no JSON")
+    end
+
+    test "unclosed brace returns empty list without raising" do
+      assert {:ok, []} = RawJson.parse(~s({"name":"foo","arguments":{))
+    end
+
+    test "non-tool-call JSON missing name returns empty list" do
+      assert {:ok, []} = RawJson.parse(~s({"foo":"bar"}))
+    end
+
+    test "non-tool-call JSON missing arguments returns empty list" do
+      assert {:ok, []} = RawJson.parse(~s({"name":"ping"}))
+    end
+
+    test "id field passed through when present" do
+      assert {:ok, [%ToolCall{id: "my-id"}]} =
+               RawJson.parse(~s({"id":"my-id","name":"t","arguments":{}}))
+    end
+
+    test "auto-generates a call_* id when id is absent" do
+      assert {:ok, [%ToolCall{id: "call_" <> _}]} =
+               RawJson.parse(~s({"name":"t","arguments":{}}))
+    end
+
+    test "nil arguments treated as empty map" do
+      assert {:ok, [%ToolCall{name: "t", arguments: %{}}]} =
+               RawJson.parse(~s({"name":"t","arguments":null}))
+    end
+
+    test "string-encoded arguments are decoded" do
+      json = ~s({"name":"t","arguments":"{\\"x\\":1}"})
+
+      assert {:ok, [%ToolCall{name: "t", arguments: %{"x" => 1}}]} = RawJson.parse(json)
+    end
+
+    test "markdown fence without json label" do
+      text = "```\n{\"name\":\"ping\",\"arguments\":{}}\n```"
+      assert {:ok, [%ToolCall{name: "ping"}]} = RawJson.parse(text)
+    end
+
+    test "empty string returns empty list" do
+      assert {:ok, []} = RawJson.parse("")
+    end
+
+    test "multiple JSON objects extracts all valid tool calls" do
+      text = """
+      {"name":"first","arguments":{"a":1}}
+      {"name":"second","arguments":{"b":2}}
+      """
+
+      assert {:ok, [%ToolCall{name: "first"}, %ToolCall{name: "second"}]} = RawJson.parse(text)
+    end
+  end
+end

--- a/test/ex_athena/tool_calls_test.exs
+++ b/test/ex_athena/tool_calls_test.exs
@@ -19,7 +19,8 @@ defmodule ExAthena.ToolCallsTest do
                  }
                ])
 
-      assert %ToolCall{id: "call_123", name: "read_file", arguments: %{"path" => "/tmp/foo"}} = call
+      assert %ToolCall{id: "call_123", name: "read_file", arguments: %{"path" => "/tmp/foo"}} =
+               call
     end
 
     test "parses Claude-style tool_use blocks" do
@@ -33,7 +34,8 @@ defmodule ExAthena.ToolCallsTest do
                  }
                ])
 
-      assert %ToolCall{id: "toolu_abc", name: "read_file", arguments: %{"path" => "/tmp/bar"}} = call
+      assert %ToolCall{id: "toolu_abc", name: "read_file", arguments: %{"path" => "/tmp/bar"}} =
+               call
     end
 
     test "handles empty/missing arguments" do
@@ -118,7 +120,13 @@ defmodule ExAthena.ToolCallsTest do
   describe "extract/2 dispatch + auto-fallback" do
     test "picks Native when tool_calls are present" do
       response = %{
-        tool_calls: [%{"type" => "function", "id" => "1", "function" => %{"name" => "t", "arguments" => "{}"}}],
+        tool_calls: [
+          %{
+            "type" => "function",
+            "id" => "1",
+            "function" => %{"name" => "t", "arguments" => "{}"}
+          }
+        ],
         text: ""
       }
 
@@ -131,7 +139,8 @@ defmodule ExAthena.ToolCallsTest do
         text: "~~~tool_call\n{\"name\": \"t\", \"arguments\": {}}\n~~~"
       }
 
-      assert {:ok, [%ToolCall{name: "t"}]} = ToolCalls.extract(response, %{native_tool_calls: true})
+      assert {:ok, [%ToolCall{name: "t"}]} =
+               ToolCalls.extract(response, %{native_tool_calls: true})
     end
 
     test "uses TextTagged when provider declares no native tool calls" do
@@ -140,11 +149,46 @@ defmodule ExAthena.ToolCallsTest do
         text: "~~~tool_call\n{\"name\": \"t\", \"arguments\": {}}\n~~~"
       }
 
-      assert {:ok, [%ToolCall{name: "t"}]} = ToolCalls.extract(response, %{native_tool_calls: false})
+      assert {:ok, [%ToolCall{name: "t"}]} =
+               ToolCalls.extract(response, %{native_tool_calls: false})
     end
 
     test "returns empty list when no tool calls anywhere" do
       assert {:ok, []} = ToolCalls.extract(%{tool_calls: nil, text: "just text"})
+    end
+
+    test "falls back to RawJson when native was claimed and text has bare JSON" do
+      response = %{
+        tool_calls: nil,
+        text: ~s({"name":"t","arguments":{"x":1}})
+      }
+
+      assert {:ok, [%ToolCall{name: "t", arguments: %{"x" => 1}}]} =
+               ToolCalls.extract(response, %{native_tool_calls: true})
+    end
+
+    test "TextTagged tier still wins over RawJson when fence is present" do
+      response = %{
+        tool_calls: nil,
+        text: "~~~tool_call\n{\"name\": \"t\", \"arguments\": {}}\n~~~"
+      }
+
+      assert {:ok, [%ToolCall{name: "t"}]} =
+               ToolCalls.extract(response, %{native_tool_calls: true})
+    end
+
+    test "RawJson fallback also active when native_tool_calls is false" do
+      response = %{
+        tool_calls: nil,
+        text: ~s({"name":"t","arguments":{}})
+      }
+
+      assert {:ok, [%ToolCall{name: "t"}]} =
+               ToolCalls.extract(response, %{native_tool_calls: false})
+    end
+
+    test "empty text and empty tool_calls returns empty list" do
+      assert {:ok, []} = ToolCalls.extract(%{tool_calls: nil, text: ""})
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes silent tool-call drops when using weak open-weight models (e.g. `qwen2.5-coder:14b`) via ReqLLM/Ollama. These models often emit tool calls as bare JSON in the assistant text instead of a structured `tool_calls` array. Because the existing fallback parser only recognized `~~~tool_call` fences, those calls were silently discarded and the ReAct loop terminated prematurely with `finish_reason: :stop`. This PR adds a third-tier raw-JSON parser and a per-request capability override so callers can opt weak models into the prompt-engineered fence flow.

## Key Changes

- **New parser `ExAthena.ToolCalls.RawJson`** (`lib/ex_athena/tool_calls/raw_json.ex`): recognizes bare JSON objects and `` ```json `` -fenced variants whose top-level keys include `"name"` (string) and `"arguments"` (map). Uses balanced-brace scanning to handle arbitrarily nested argument objects. Returns `{:ok, [%ToolCall{}]}` on match, `{:ok, []}` on no match — consistent with the existing parser contract.

- **Three-tier fallback in `ToolCalls.extract/2`**: the auto-detection chain is now:
  1. Structured `tool_calls` → `Native.parse/1`
  2. Text contains `~~~tool_call` → `TextTagged.parse/1`
  3. Text looks like a raw-JSON tool call → `RawJson.parse/1`
  4. `{:ok, []}`

- **Per-request capability override in `Loop`** (`lib/ex_athena/loop.ex:378`): user-supplied `capabilities:` opts are now merged on top of the provider's static capabilities map, allowing callers to pass `capabilities: %{native_tool_calls: false}` to `ExAthena.run/2`. When `native_tool_calls: false`, the existing `ReAct.effective_system_prompt/1` logic already augments the system prompt with the `~~~tool_call` fence preamble — no further changes needed inside the loop. Default behavior is fully preserved.

- **Minor formatting fixes**: parenthesized pattern match in `ContextCollapse`, multi-line pipeline in `Structured`, and a couple of long `case` branches reformatted for readability. No logic changes.

## Implementation Notes

The raw-JSON parser is intentionally best-effort: malformed or unclosed JSON returns `{:ok, []}` rather than an error, matching the "never crash the loop" contract of `TextTagged`. It only fires when neither native structured calls nor fence markers are present, so there is no risk of double-parsing on well-behaved providers.

The capability merge (`Map.merge/2`) is order-sensitive — caller overrides win. Because the default `Keyword.get(opts, :capabilities, %{})` is an empty map, existing callers see zero behavior change.

Closes https://github.com/udin-io/ex_athena/issues/12