### PR TITLE
feat(tool_calls): compact tool-schema mode for weak open-weight models

### DIFF
--- a/.artifacts/adr-1-compact-tool-schema-mode.md
+++ b/.artifacts/adr-1-compact-tool-schema-mode.md
@@ -1,0 +1,47 @@
+# ADR 1: Compact tool-schema mode for weak open-weight models
+
+## Status
+
+Accepted
+
+## Context
+
+When `native_tool_calls: false` is in effect (typically forced for weak open-weight models per ex_athena#12), `ExAthena.ToolCalls.augment_system_prompt/2` injects the full JSON schema of every available tool into the system prompt. For a typical 10-tool runner this is 5–10 KB.
+
+Weak local models such as `qwen2.5-coder:14b` show measurable quality degradation past ~4 KB of system prompt: confused tool selection, and more cases where the model serializes JSON as prose instead of using the prescribed `~~~tool_call` fence. Strong hosted models (Claude, GPT-4) are unaffected because they receive tools structurally via native `tool_calls` rather than depending on the prompt schema dump.
+
+## Decision
+
+Add an opt-in compact format selected by `augment_system_prompt(prompt, tools, compact: true)`. The compact format emits one type-signature line per tool:
+
+```
+- read_file(path: string, content?: string) — read a file
+```
+
+Rules:
+- Required vs. optional marked with `?`.
+- Type compaction: `string|number|integer|boolean|array|object|null`. Scalar-item arrays render as `T[]`.
+- Nested object structure collapsed past depth 2.
+- Description truncated to first sentence, capped near 80 chars.
+- Tools without params render `tool_name() — desc`.
+
+The `~~~tool_call` invocation contract — what the response parser actually depends on — is preserved unchanged. This is purely a schema-presentation change.
+
+Providers advertise support via a static `compact_tool_schemas: true` capability flag on `ExAthena.Providers.ReqLLM.capabilities/0`. Downstream callers gate on this flag plus per-model heuristics to decide whether to pass `compact: true`.
+
+The existing `augment_system_prompt/2` signature widens to `/3` with `opts \\ []`, preserving all current 2-arity call sites.
+
+## Consequences
+
+**Positive**
+- Weak Ollama models become noticeably more reliable when forced into text-tagged mode.
+- Default behavior is byte-identical — no risk to existing callers or strong models.
+- Provider-agnostic implementation; one formatter serves every backend.
+- Acceptance threshold (≤ 80% byte size on a 10-tool fixture) is enforced by tests, so regressions are caught automatically.
+
+**Negative**
+- Compact format loses schema fidelity (enums, regex patterns, deep nesting). Acceptable because weak models couldn't reliably honor those constraints anyway.
+- Two formatter paths to maintain in `ExAthena.ToolCalls`.
+
+**Neutral**
+- Capability is static `true` regardless of underlying model. Per-model decisions (AthenaRunner gating on Ollama model id) live downstream — provider-level capabilities cannot enumerate every model.

--- a/lib/ex_athena/providers/req_llm.ex
+++ b/lib/ex_athena/providers/req_llm.ex
@@ -56,7 +56,8 @@ defmodule ExAthena.Providers.ReqLLM do
       max_tokens: 200_000,
       supports_resume: false,
       supports_system_prompt: true,
-      supports_temperature: true
+      supports_temperature: true,
+      compact_tool_schemas: true
     }
   end
 

--- a/lib/ex_athena/tool_calls.ex
+++ b/lib/ex_athena/tool_calls.ex
@@ -81,10 +81,21 @@ defmodule ExAthena.ToolCalls do
 
   The agent loop (Phase 2) calls this when the chosen provider lacks native
   tool-call support, or when the user has forced TextTagged mode.
+
+  ## Options
+
+    * `:compact` — when `true`, emits a one-line-per-tool signature instead
+      of the full JSON schema. Useful for weak open-weight models that degrade
+      past ~4 KB system prompts. Default: `false`.
   """
-  @spec augment_system_prompt(String.t() | nil, [map()]) :: String.t()
-  def augment_system_prompt(existing, tools) when is_list(tools) do
+  @spec augment_system_prompt(String.t() | nil, [map()], keyword()) :: String.t()
+  def augment_system_prompt(existing, tools, opts \\ []) when is_list(tools) do
     existing = existing || ""
+
+    formatter =
+      if Keyword.get(opts, :compact, false),
+        do: &format_tool_list_compact/1,
+        else: &format_tool_list/1
 
     preamble = """
     You have access to the following tools. When you want to call a tool,
@@ -101,7 +112,7 @@ defmodule ExAthena.ToolCalls do
 
     Available tools:
 
-    #{format_tool_list(tools)}
+    #{formatter.(tools)}
     """
 
     if String.trim(existing) == "" do
@@ -124,4 +135,86 @@ defmodule ExAthena.ToolCalls do
       """
     end)
   end
+
+  defp format_tool_list_compact(tools) do
+    Enum.map_join(tools, "\n", &compact_tool_line/1)
+  end
+
+  defp compact_tool_line(tool) do
+    name = Map.get(tool, :name) || Map.get(tool, "name") || "<unnamed>"
+    desc = Map.get(tool, :description) || Map.get(tool, "description") || ""
+    schema = Map.get(tool, :schema) || Map.get(tool, "schema") || %{}
+
+    sig = "#{name}(#{compact_params(schema)})"
+    short = short_desc(desc)
+
+    if short == "", do: "- #{sig}", else: "- #{sig} — #{short}"
+  end
+
+  defp compact_params(schema) do
+    properties = Map.get(schema, :properties) || Map.get(schema, "properties")
+
+    required =
+      (Map.get(schema, :required) || Map.get(schema, "required") || []) |> Enum.map(&to_string/1)
+
+    case properties do
+      nil ->
+        ""
+
+      props when map_size(props) == 0 ->
+        ""
+
+      props ->
+        props
+        |> Enum.sort_by(fn {k, _} -> {to_string(k) not in required, to_string(k)} end)
+        |> Enum.map(fn {k, v} ->
+          key = to_string(k)
+          type_str = compact_type(v)
+          if key in required, do: "#{key}: #{type_str}", else: "#{key}?: #{type_str}"
+        end)
+        |> Enum.join(", ")
+    end
+  end
+
+  defp compact_type(schema) when is_map(schema) do
+    type = Map.get(schema, :type) || Map.get(schema, "type")
+    items = Map.get(schema, :items) || Map.get(schema, "items")
+
+    cond do
+      type == "array" and is_map(items) ->
+        item_type = Map.get(items, :type) || Map.get(items, "type")
+
+        if item_type in ~w(string number integer boolean null),
+          do: "#{item_type}[]",
+          else: "array"
+
+      type in ~w(string number integer boolean null object) ->
+        type
+
+      true ->
+        "object"
+    end
+  end
+
+  defp compact_type(_), do: "object"
+
+  defp short_desc(desc) when is_binary(desc) do
+    cleaned = desc |> String.replace(~r/\s+/, " ") |> String.trim()
+
+    case cleaned do
+      "" ->
+        ""
+
+      s ->
+        sentence =
+          case String.split(s, ". ", parts: 2) do
+            [first, _rest] -> first <> "."
+            [only] -> only
+          end
+
+        if String.length(sentence) > 80, do: String.slice(sentence, 0, 80), else: sentence
+    end
+  end
+
+  defp short_desc(_), do: ""
 end

--- a/lib/ex_athena/tools.ex
+++ b/lib/ex_athena/tools.ex
@@ -73,7 +73,7 @@ defmodule ExAthena.Tools do
   end
 
   @doc """
-  Build the prompt-friendly list used by `ExAthena.ToolCalls.augment_system_prompt/2`
+  Build the prompt-friendly list used by `ExAthena.ToolCalls.augment_system_prompt/3`
   when we fall back to the TextTagged protocol.
   """
   @spec describe_for_prompt([module()]) :: [map()]

--- a/test/ex_athena/tool_calls_test.exs
+++ b/test/ex_athena/tool_calls_test.exs
@@ -209,4 +209,109 @@ defmodule ExAthena.ToolCallsTest do
       assert ToolCalls.augment_system_prompt(nil, []) =~ "~~~tool_call"
     end
   end
+
+  describe "augment_system_prompt/3 compact: true" do
+    @tool_with_params %{
+      name: "read_file",
+      description: "Read a file from the filesystem. Returns its content.",
+      schema: %{
+        type: "object",
+        properties: %{
+          path: %{type: "string"},
+          content: %{type: "string"}
+        },
+        required: ["path"]
+      }
+    }
+
+    @tool_no_params %{
+      name: "ping",
+      description: "Check if the service is alive.",
+      schema: %{}
+    }
+
+    @tool_array_params %{
+      name: "list_files",
+      description: "List files in directories.",
+      schema: %{
+        type: "object",
+        properties: %{
+          paths: %{type: "array", items: %{type: "string"}}
+        },
+        required: ["paths"]
+      }
+    }
+
+    test "renders one-line-per-tool signature" do
+      result = ToolCalls.augment_system_prompt(nil, [@tool_with_params], compact: true)
+      assert result =~ "read_file("
+      assert result =~ "path: string"
+      assert result =~ "content?: string"
+    end
+
+    test "marks non-required params with ?" do
+      result = ToolCalls.augment_system_prompt(nil, [@tool_with_params], compact: true)
+      assert result =~ "content?: string"
+      refute result =~ "path?:"
+    end
+
+    test "handles tools with no params" do
+      result = ToolCalls.augment_system_prompt(nil, [@tool_no_params], compact: true)
+      assert result =~ "ping()"
+    end
+
+    test "handles array params with scalar items" do
+      result = ToolCalls.augment_system_prompt(nil, [@tool_array_params], compact: true)
+      assert result =~ "paths: string[]"
+    end
+
+    test "truncates multi-sentence descriptions to first sentence" do
+      result = ToolCalls.augment_system_prompt(nil, [@tool_with_params], compact: true)
+      refute result =~ "Returns its content."
+      assert result =~ "Read a file from the filesystem."
+    end
+
+    test "compact output is <= 80% bytes of non-compact for a 10-tool fixture" do
+      tools = build_10_tool_fixture()
+      compact = ToolCalls.augment_system_prompt(nil, tools, compact: true)
+      full = ToolCalls.augment_system_prompt(nil, tools)
+      assert byte_size(compact) <= byte_size(full) * 0.80
+    end
+
+    test "default (compact omitted) is byte-identical to pre-change behavior" do
+      tools = [@tool_with_params]
+
+      assert ToolCalls.augment_system_prompt(nil, tools) ==
+               ToolCalls.augment_system_prompt(nil, tools, [])
+
+      assert ToolCalls.augment_system_prompt(nil, tools) ==
+               ToolCalls.augment_system_prompt(nil, tools, compact: false)
+    end
+
+    test "output contains ~~~tool_call fence instructions" do
+      result = ToolCalls.augment_system_prompt(nil, [@tool_with_params], compact: true)
+      assert result =~ "~~~tool_call"
+    end
+
+    defp build_10_tool_fixture do
+      Enum.map(1..10, fn i ->
+        %{
+          name: "tool_#{i}",
+          description:
+            "Does thing number #{i} in the system. Extra details about tool #{i} that are not needed.",
+          schema: %{
+            type: "object",
+            properties: %{
+              param_a: %{type: "string"},
+              param_b: %{type: "integer"},
+              param_c: %{type: "boolean"},
+              param_d: %{type: "object", properties: %{nested: %{type: "string"}}},
+              param_e: %{type: "array", items: %{type: "string"}}
+            },
+            required: ["param_a", "param_b"]
+          }
+        }
+      end)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Adds a `compact: true` option to `ExAthena.ToolCalls.augment_system_prompt/2` that emits a terse one-liner-per-tool format instead of full JSON schemas. This reduces system prompt size for weak open-weight models (e.g. `qwen2.5-coder:14b`) that degrade in quality past ~4 KB, while leaving the full-schema path untouched for capable models.

Closes #14. Related to #12 (the `native_tool_calls: false` flag that makes this relevant).

## Key Changes

- **`lib/ex_athena/tool_calls.ex`**
  - `augment_system_prompt/2` gains an optional `opts` keyword list; signature updated to `/3` with a default of `[]`.
  - When `compact: true` is passed, a new `format_tool_list_compact/1` formatter is selected in place of the existing `format_tool_list/1`.
  - `compact_tool_line/1` renders each tool as `- name(param: type, optional?: type) — short description`.
  - `compact_params/1` sorts required parameters first, marks optional parameters with `?`, and resolves types via `compact_type/1`.
  - `compact_type/1` handles primitives, `array` with a simple item type (rendered as `type[]`), and falls back to `"object"` for nested/complex schemas.
  - `short_desc/1` collapses whitespace and truncates the description to the first sentence (up to ~80 chars), keeping the one-liner tight.

- **`lib/ex_athena/providers/req_llm.ex`**
  - Adds `compact_tool_schemas: true` to the `ReqLLM` capability map, signalling to callers (e.g. `AthenaRunner`) that this provider supports and benefits from compact mode.

## Implementation Notes

- The compact formatter is purely additive — no existing codepath is altered. Callers that omit `opts` get the original full-JSON-schema output unchanged.
- Parameter ordering: required params always precede optional ones within the signature; within each group, keys are sorted alphabetically for determinism.
- Type rendering deliberately stays shallow (max one level of array nesting). Deeply nested object schemas collapse to `"object"` to keep lines short — the goal is model guidance, not full type fidelity.
- The `compact_tool_schemas: true` capability flag is intentionally a passive signal; routing logic (opt-in per model) lives in the consumer.

Closes https://github.com/udin-io/ex_athena/issues/14