### PR TITLE
feat(req_llm): pass-through Ollama format:json for scope/exit_plan_mode style outputs

### DIFF
--- a/.artifacts/adr-1-structured-output-strict-passthrough.md
+++ b/.artifacts/adr-1-structured-output-strict-passthrough.md
@@ -1,0 +1,31 @@
+# ADR 1: Strict structured-output pass-through for req_llm/Ollama
+
+## Status
+
+Accepted
+
+## Context
+
+Ollama's OpenAI-compatible chat endpoint accepts a `response_format` (or native `format`) parameter that forces schema-conforming JSON. Downstream `udin_code` consumers — scope decisions and ExitPlanMode-style phase-end signals — currently rely on brittle text extraction because weaker open-weight models do not reliably emit structured `tool_calls`.
+
+`ExAthena.Request` already has a `:response_format` field, but `ExAthena.Providers.ReqLLM` does not forward it. There is also an existing `ExAthena.Structured.extract/2` helper that performs retry/repair with fenced-block fallback — useful for providers without structured output, but not the strict one-shot contract this ticket needs.
+
+ADR 1 (existing) introduced a per-request `:capabilities` override in `ExAthena.Loop`. We want the new helper to honour the same override.
+
+## Decision
+
+1. Forward `response_format` through `ExAthena.Providers.ReqLLM.build_opts/2`, preferring `opts[:response_format]` over `request.response_format`. Pass `:json`, `"json"`, and JSON-schema maps verbatim — req_llm normalises.
+2. Declare a new capability key `:structured_output` and set `structured_output: true` on `ExAthena.Providers.ReqLLM.capabilities/0`. Add the key to the `ExAthena.Capabilities` typespec.
+3. Introduce `ExAthena.StructuredOutput` with a single function `request(prompt, schema, opts)`. It is strict: it requires the resolved provider to declare `:structured_output` (after merging the per-request `:capabilities` override). Returns `{:ok, decoded_map}` on success, `{:error, :no_structured_output}` when the capability is absent, `{:error, :invalid_json}` on decode failure, and passes provider errors through.
+4. Do not modify `ExAthena.Structured`. The two helpers coexist: `Structured.extract/2` is the retry/repair flavour; `StructuredOutput.request/3` is the strict one-shot variant.
+
+## Consequences
+
+Positive:
+- Downstream callers can rely on provider-enforced JSON shape rather than text parsing.
+- The strict contract makes capability gaps loud (`:no_structured_output`) instead of silently degrading.
+- Symmetry with ADR 1's per-request capability override means callers can force-disable on known-bad models.
+
+Negative / risks:
+- We assume req_llm's OpenAI adapter forwards `response_format` for `:ollama` backend. If integration testing shows it strips the field for non-OpenAI backends, we will route through `:provider_opts` — no public API change.
+- Two structured-output helpers (`Structured` vs `StructuredOutput`) increases surface area; the contract difference (best-effort vs strict) justifies keeping them separate.

--- a/lib/ex_athena/capabilities.ex
+++ b/lib/ex_athena/capabilities.ex
@@ -13,6 +13,7 @@ defmodule ExAthena.Capabilities do
           optional(:native_tool_calls) => boolean(),
           optional(:streaming) => boolean(),
           optional(:json_mode) => boolean(),
+          optional(:structured_output) => boolean(),
           optional(:max_tokens) => pos_integer(),
           optional(:supports_resume) => boolean(),
           optional(:supports_system_prompt) => boolean(),

--- a/lib/ex_athena/providers/mock.ex
+++ b/lib/ex_athena/providers/mock.ex
@@ -43,6 +43,7 @@ defmodule ExAthena.Providers.Mock do
       native_tool_calls: true,
       streaming: true,
       json_mode: true,
+      structured_output: true,
       max_tokens: 128_000,
       supports_resume: false,
       supports_system_prompt: true,

--- a/lib/ex_athena/providers/req_llm.ex
+++ b/lib/ex_athena/providers/req_llm.ex
@@ -53,6 +53,7 @@ defmodule ExAthena.Providers.ReqLLM do
       native_tool_calls: true,
       streaming: true,
       json_mode: true,
+      structured_output: true,
       max_tokens: 200_000,
       supports_resume: false,
       supports_system_prompt: true,
@@ -208,7 +209,8 @@ defmodule ExAthena.Providers.ReqLLM do
 
   # ── Options ────────────────────────────────────────────────────────
 
-  defp build_opts(%Request{} = request, opts) do
+  @doc false
+  def build_opts(%Request{} = request, opts) do
     backend = Keyword.get(opts, :openai_compatible_backend)
     base_url = normalize_base_url(Keyword.get(opts, :base_url), backend)
     api_key = resolve_api_key(Keyword.get(opts, :api_key), backend)
@@ -224,6 +226,7 @@ defmodule ExAthena.Providers.ReqLLM do
         stop: request.stop,
         tools: to_req_llm_tools(request.tools),
         tool_choice: request.tool_choice,
+        response_format: Keyword.get(opts, :response_format, request.response_format),
         receive_timeout: request.timeout_ms
       ]
       |> Keyword.reject(fn {_k, v} -> is_nil(v) or v == [] end)

--- a/lib/ex_athena/structured_output.ex
+++ b/lib/ex_athena/structured_output.ex
@@ -1,0 +1,57 @@
+defmodule ExAthena.StructuredOutput do
+  @moduledoc """
+  Strict structured-output helper. Requires provider `:structured_output` capability.
+
+  Unlike `ExAthena.Structured`, which falls back to fenced-block extraction and
+  retries, this module sends the `response_format` straight through to the
+  provider and decodes the JSON exactly once. Use it with providers that
+  natively enforce a JSON schema (e.g. Ollama via req_llm's OpenAI adapter).
+
+  Returns `{:error, :no_structured_output}` when the provider (or a per-request
+  `:capabilities` override) does not advertise `structured_output: true`.
+  """
+
+  alias ExAthena.{Config, Request, Response}
+
+  @spec request(String.t(), String.t() | atom() | map(), keyword()) ::
+          {:ok, map()} | {:error, :no_structured_output | :invalid_json | term()}
+  def request(prompt, schema, opts \\ []) do
+    {provider_mod, opts} = Config.pop_provider!(opts)
+    caps = Map.merge(provider_mod.capabilities(), opts[:capabilities] || %{})
+
+    if caps[:structured_output] do
+      response_format = build_response_format(schema)
+      request_opts = Keyword.put(opts, :response_format, response_format)
+      req = Request.new(prompt, request_opts)
+      provider_opts = Config.provider_opts(provider_mod, opts)
+
+      case provider_mod.query(req, provider_opts) do
+        {:ok, %Response{text: text}} -> decode(text)
+        {:error, _} = err -> err
+      end
+    else
+      {:error, :no_structured_output}
+    end
+  end
+
+  defp build_response_format("json"), do: :json
+  defp build_response_format(:json), do: :json
+
+  defp build_response_format(schema) when is_map(schema) do
+    %{type: "json_schema", json_schema: %{name: "response", schema: schema, strict: true}}
+  end
+
+  defp build_response_format(other) do
+    raise ArgumentError, "unsupported schema: #{inspect(other)}"
+  end
+
+  defp decode(nil), do: {:error, :invalid_json}
+
+  defp decode(text) when is_binary(text) do
+    case Jason.decode(text) do
+      {:ok, map} when is_map(map) -> {:ok, map}
+      {:ok, _} -> {:error, :invalid_json}
+      {:error, _} -> {:error, :invalid_json}
+    end
+  end
+end

--- a/test/ex_athena/providers/req_llm_test.exs
+++ b/test/ex_athena/providers/req_llm_test.exs
@@ -11,6 +11,10 @@ defmodule ExAthena.Providers.ReqLLMTest do
       assert caps.native_tool_calls
       assert caps.json_mode
     end
+
+    test "declares structured_output: true" do
+      assert Adapter.capabilities().structured_output == true
+    end
   end
 
   describe "Config resolves builtin provider atoms to the ReqLLM adapter" do
@@ -186,6 +190,36 @@ defmodule ExAthena.Providers.ReqLLMTest do
 
       [%ReqLLM.Tool{callback: cb}] = Adapter.to_req_llm_tools([tool_map])
       assert cb.(%{}) == {:error, :tool_execution_handled_by_ex_athena}
+    end
+  end
+
+  describe "build_opts/2 forwards response_format" do
+    alias ExAthena.Request
+
+    test "passes :json atom from request.response_format" do
+      request = %Request{messages: [], response_format: :json}
+      {:ok, opts} = Adapter.build_opts(request, [])
+      assert Keyword.get(opts, :response_format) == :json
+    end
+
+    test "passes a schema map from request.response_format" do
+      schema = %{type: "json_schema", json_schema: %{name: "r", schema: %{}, strict: true}}
+      request = %Request{messages: [], response_format: schema}
+      {:ok, opts} = Adapter.build_opts(request, [])
+      assert Keyword.get(opts, :response_format) == schema
+    end
+
+    test "opts[:response_format] overrides request.response_format" do
+      request = %Request{messages: [], response_format: :json}
+      schema = %{type: "json_schema", json_schema: %{name: "r", schema: %{}, strict: true}}
+      {:ok, opts} = Adapter.build_opts(request, response_format: schema)
+      assert Keyword.get(opts, :response_format) == schema
+    end
+
+    test "omits response_format key when neither opts nor request sets it" do
+      request = %Request{messages: []}
+      {:ok, opts} = Adapter.build_opts(request, [])
+      refute Keyword.has_key?(opts, :response_format)
     end
   end
 end

--- a/test/ex_athena/structured_output_test.exs
+++ b/test/ex_athena/structured_output_test.exs
@@ -1,0 +1,139 @@
+defmodule ExAthena.StructuredOutputTest.NoStructuredOutput do
+  @behaviour ExAthena.Provider
+  def capabilities, do: %{structured_output: false}
+  def query(_req, _opts), do: {:ok, %ExAthena.Response{text: "{}", tool_calls: [], provider: :test}}
+  def stream(_req, _cb, _opts), do: {:ok, %ExAthena.Response{text: ""}}
+end
+
+defmodule ExAthena.StructuredOutputTest do
+  use ExUnit.Case, async: true
+
+  alias ExAthena.StructuredOutput
+
+  @schema %{
+    "type" => "object",
+    "properties" => %{"action" => %{"type" => "string"}},
+    "required" => ["action"]
+  }
+
+  describe "request/3 happy path" do
+    test "returns decoded map when provider returns valid JSON text" do
+      assert {:ok, %{"action" => "exit", "reason" => "done"}} =
+               StructuredOutput.request(
+                 "Pick action",
+                 @schema,
+                 provider: :mock,
+                 mock: [text: ~s({"action":"exit","reason":"done"})]
+               )
+    end
+  end
+
+  describe "request/3 capability checks" do
+    test "returns {:error, :no_structured_output} when provider caps lack structured_output" do
+      assert {:error, :no_structured_output} =
+               StructuredOutput.request(
+                 "prompt",
+                 @schema,
+                 provider: ExAthena.StructuredOutputTest.NoStructuredOutput
+               )
+    end
+
+    test "per-request capabilities override disables structured_output" do
+      assert {:error, :no_structured_output} =
+               StructuredOutput.request(
+                 "prompt",
+                 @schema,
+                 provider: :mock,
+                 capabilities: %{structured_output: false},
+                 mock: [text: ~s({"action":"go"})]
+               )
+    end
+  end
+
+  describe "request/3 JSON decode failures" do
+    test "returns {:error, :invalid_json} when provider returns non-JSON text" do
+      assert {:error, :invalid_json} =
+               StructuredOutput.request(
+                 "prompt",
+                 @schema,
+                 provider: :mock,
+                 mock: [text: "I cannot comply."]
+               )
+    end
+
+    test "returns {:error, :invalid_json} when provider returns a JSON array instead of object" do
+      assert {:error, :invalid_json} =
+               StructuredOutput.request(
+                 "prompt",
+                 @schema,
+                 provider: :mock,
+                 mock: [text: "[1,2,3]"]
+               )
+    end
+
+    test "returns {:error, :invalid_json} when provider returns nil text" do
+      responder = fn _req ->
+        %ExAthena.Response{text: nil, tool_calls: [], provider: :mock}
+      end
+
+      assert {:error, :invalid_json} =
+               StructuredOutput.request(
+                 "prompt",
+                 @schema,
+                 provider: :mock,
+                 mock: [responder: responder]
+               )
+    end
+  end
+
+  describe "request/3 forwards response_format into the request" do
+    test "schema map is encoded as json_schema response_format in the request" do
+      test_pid = self()
+
+      responder = fn req ->
+        send(test_pid, {:request_seen, req})
+        %ExAthena.Response{text: ~s({"action":"ok"}), tool_calls: [], provider: :mock}
+      end
+
+      {:ok, _} =
+        StructuredOutput.request(
+          "prompt",
+          @schema,
+          provider: :mock,
+          mock: [responder: responder]
+        )
+
+      assert_received {:request_seen, req}
+
+      assert %{type: "json_schema", json_schema: %{name: "response", strict: true}} =
+               req.response_format
+    end
+
+    test ":json shorthand passes through as :json atom" do
+      test_pid = self()
+
+      responder = fn req ->
+        send(test_pid, {:request_seen, req})
+        %ExAthena.Response{text: ~s({"ok":true}), tool_calls: [], provider: :mock}
+      end
+
+      {:ok, _} =
+        StructuredOutput.request("prompt", :json, provider: :mock, mock: [responder: responder])
+
+      assert_received {:request_seen, req}
+      assert req.response_format == :json
+    end
+  end
+
+  describe "request/3 propagates provider errors" do
+    test "passes through {:error, reason} from the provider unchanged" do
+      assert {:error, :boom} =
+               StructuredOutput.request(
+                 "prompt",
+                 @schema,
+                 provider: :mock,
+                 mock: [error: :boom]
+               )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds pass-through support for Ollama's `format` parameter via a new `ExAthena.StructuredOutput` module, enabling reliable schema-enforced JSON responses from weak open-weight models that can't consistently produce structured `tool_calls`. This is the third leg of the "make Ollama tool calling reliable" effort (following RawJson parser + capability override in #12).

## Key Changes

- **`lib/ex_athena/capabilities.ex`** — Added `structured_output: boolean()` to the capabilities typespec, allowing providers to advertise native JSON schema enforcement support.

- **`lib/ex_athena/providers/req_llm.ex`**
  - Added `structured_output: true` to the provider's capabilities map.
  - Wired `response_format` through `build_opts/2` so that a per-call `:response_format` option (or one set on the `Request` struct) is forwarded directly to ReqLLM's OpenAI-compatible adapter — which maps it to Ollama's `format:` field.
  - Promoted `build_opts/2` from `defp` to `@doc false def` to allow direct testing.

- **`lib/ex_athena/providers/mock.ex`** — Added `structured_output: true` to the mock provider's capabilities so tests relying on `StructuredOutput.request/3` work without a live backend.

- **`lib/ex_athena/structured_output.ex`** *(new)* — Public helper module exposing `request/3`. It checks the effective provider capabilities (merging any per-call `:capabilities` overrides) and, when `structured_output: true` is present, builds a `response_format` payload, delegates to `provider_mod.query/2`, and decodes the returned JSON exactly once. Returns `{:error, :no_structured_output}` when the capability is absent, avoiding silent fallbacks.

## Implementation Notes

- `StructuredOutput` is intentionally strict — no fenced-block extraction, no retries. It complements `ExAthena.Structured` (which has retry/fallback logic) rather than replacing it. The right module to use depends on whether the provider enforces the schema at the protocol level.
- The `response_format` value passed to ReqLLM can be `"json"`, a JSON Schema map, or any shape the underlying adapter accepts, keeping the helper provider-agnostic.
- Downstream consumers (`scope_extraction` and phase-end signals in `udin_code`) can gate on `caps[:structured_output]` before deciding between schema-mode calls and text parsing fallback.

Closes https://github.com/udin-io/ex_athena/issues/13