### PR TITLE
fix(req_llm): substitute placeholder api_key for :llamacpp backend (parity with :ollama)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and ExAthena adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.4.7 — `:llamacpp` placeholder api_key (parity with `:ollama`)
+
+### Fixed
+
+- `ExAthena.Providers.ReqLLM.build_opts/2` now substitutes a placeholder
+  `api_key: "llamacpp"` when `provider: :llamacpp` is selected and no
+  `:api_key` is supplied. Mirrors the `:ollama` path added in v0.4.1.
+  Without this, `req_llm` 1.10/1.11's openai adapter rejected the
+  request with `Invalid parameter: :api_key option, ...` before any HTTP
+  call left the BEAM — manifesting downstream as
+  `ExAthena.Error{kind: :server_error, message: "{:http_streaming_failed,
+  {:provider_build_failed, ... 'Failed to build streaming request: ...'}}"}`,
+  which retry/recovery layers then classified as `:api_error` and
+  hammered every 3 minutes until the recovery budget exhausted.
+- `ExAthena.Config.@local_openai_compatible_backends` now includes
+  `llamacpp: :llamacpp` so the backend marker is threaded through
+  `Config.pop_provider!/1` for `provider: :llamacpp` as it already was
+  for `provider: :ollama`.
+
+### Why
+
+Local llama-server (the `:llamacpp` provider) accepts unauthenticated
+HTTP just like Ollama; the OpenAI-compatible adapter in `req_llm`
+nevertheless requires *some* non-nil `:api_key`. Both bugs (no backend
+marker + no placeholder) had to land together for `:llamacpp` to work
+end-to-end against an unauthenticated local server. Verified against
+udin_code's failing planning run on
+`http://localhost:8080` with model auto-detected from `/v1/models`.
+
 ## v0.4.6 — Weak-model reliability: raw-JSON tool calls, compact schemas, strict structured output
 
 ### Added — `ExAthena.ToolCalls.RawJson` (ADR 0001)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,91 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and ExAthena adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.4.6 — Weak-model reliability: raw-JSON tool calls, compact schemas, strict structured output
+
+### Added — `ExAthena.ToolCalls.RawJson` (ADR 0001)
+
+- Third tool-call extraction tier behind `Native` and `TextTagged`.
+  Recognises bare and ` ```json ` -fenced JSON objects with a
+  `name` / `arguments` shape using a balanced-brace scanner that tracks
+  in-string state and backslash escapes. Wired into
+  `ToolCalls.extract/2` as the final fallback so weak open-weight
+  models (e.g. `qwen2.5-coder:14b` on Ollama) that emit tool calls as
+  bare JSON in assistant prose are no longer silently dropped.
+- A cheap pre-check requires both `"name"` and `"arguments"`
+  substrings before the scanner runs, so non-tool prose is rejected in
+  O(n) without engaging the brace walker.
+
+### Added — per-request capability override (ADR 0001)
+
+- `ExAthena.Loop.run/2` now accepts a `:capabilities` opt that is
+  merged on top of `provider_mod.capabilities()` for the duration of
+  the run. Lets callers flip `native_tool_calls: false` for a single
+  request to force `Modes.ReAct` into fence-augmented prompting, with
+  no provider-module fork required. The merge is shallow and
+  forward-compatible: future capability flags slot in the same way.
+
+### Added — compact tool-schema mode (ADR 0002)
+
+- `ExAthena.ToolCalls.augment_system_prompt/3` (was `/2`) takes a new
+  `compact: true` opt that emits one type-signature line per tool
+  instead of dumping the full JSON schema, e.g.
+  `- read_file(path: string, content?: string) — read a file`.
+  Required vs optional marked with `?`; types compacted to
+  `string|number|integer|boolean|array|object|null`; scalar arrays
+  rendered as `T[]`; nested object structure collapsed past depth 2;
+  description truncated to first sentence and capped near 80 chars.
+- Default behaviour is byte-identical — `compact: true` is opt-in and
+  the existing 2-arity call sites still work unchanged.
+- New static capability `compact_tool_schemas: true` on
+  `ExAthena.Providers.ReqLLM.capabilities/0` so downstream callers can
+  gate per-model heuristics on it (e.g. AthenaRunner deciding to flip
+  on `compact: true` only for known-weak Ollama model ids).
+
+### Why (ADRs 0001 + 0002)
+
+Weak Ollama models such as `qwen2.5-coder:14b` show measurable quality
+degradation past ~4 KB of system prompt and don't reliably honour the
+`~~~tool_call` fence when given a 5–10 KB schema dump from
+`augment_system_prompt/2`. Together the two changes mean: (a) tool
+calls those models *do* emit (often as bare JSON) are now caught by
+`RawJson`, and (b) the prompt budget those models see drops by ~80%
+on a 10-tool fixture, raising fence compliance. Strong hosted models
+(Claude, GPT-4) are unaffected — they still receive tools structurally
+via native `tool_calls`. Unblocks `udin-io/udin_code#1268`.
+
+### Added — strict structured-output pass-through (ADR 0003)
+
+- `ExAthena.Providers.ReqLLM.build_opts/2` now forwards
+  `response_format` to req_llm, preferring `opts[:response_format]`
+  over `request.response_format`. Accepts `:json`, `"json"`, and
+  JSON-schema maps verbatim — req_llm normalises before hitting the
+  Ollama / OpenAI / etc. backend.
+- New `:structured_output` capability key on
+  `ExAthena.Capabilities` typespec; `Providers.ReqLLM.capabilities/0`
+  declares `structured_output: true`.
+- New module `ExAthena.StructuredOutput` with `request/3`. Strict
+  one-shot variant: requires the resolved provider (after merging the
+  per-request `:capabilities` override from ADR 0001) to declare
+  `:structured_output`. Returns `{:ok, decoded_map}` on success,
+  `{:error, :no_structured_output}` when the capability is absent,
+  `{:error, :invalid_json}` on decode failure, and passes provider
+  errors through.
+- The existing `ExAthena.Structured.extract/2` retry/repair flavour is
+  unchanged. The two helpers coexist by design — `Structured.extract/2`
+  for best-effort retry-with-validation, `StructuredOutput.request/3`
+  for the strict provider-enforced contract.
+
+### Why (ADR 0003)
+
+Downstream `udin_code` flows that need schema-conforming JSON (scope
+decisions, ExitPlanMode-style phase-end signals) currently rely on
+brittle text extraction because weaker open-weight models don't emit
+structured `tool_calls`. Now those flows can request provider-enforced
+JSON when the resolved provider supports it, and get a loud
+`:no_structured_output` error otherwise — never a silent text-parse
+fallback.
+
 ## v0.4.5 — Stream heartbeat + time-to-first-token (TTFT)
 
 ### Added

--- a/lib/ex_athena/config.ex
+++ b/lib/ex_athena/config.ex
@@ -58,7 +58,8 @@ defmodule ExAthena.Config do
   # 2) get `openai_compatible_backend: <atom>` so req_llm's openai adapter
   #    allows missing API keys (unauthenticated local deployments).
   @local_openai_compatible_backends %{
-    ollama: :ollama
+    ollama: :ollama,
+    llamacpp: :llamacpp
   }
 
   @doc """

--- a/lib/ex_athena/providers/req_llm.ex
+++ b/lib/ex_athena/providers/req_llm.ex
@@ -291,10 +291,11 @@ defmodule ExAthena.Providers.ReqLLM do
   end
 
   # req_llm's openai adapter requires *some* api_key value even when
-  # `openai_compatible_backend: :ollama` allows missing auth — the underlying
-  # HTTP request still sets an Authorization header. Local servers ignore it,
-  # so substitute a placeholder when the caller didn't supply one.
+  # `openai_compatible_backend: :ollama | :llamacpp` allows missing auth — the
+  # underlying HTTP request still sets an Authorization header. Local servers
+  # ignore it, so substitute a placeholder when the caller didn't supply one.
   defp resolve_api_key(nil, :ollama), do: "ollama"
+  defp resolve_api_key(nil, :llamacpp), do: "llamacpp"
   defp resolve_api_key(key, _backend), do: key
 
   # ── Response mapping ──────────────────────────────────────────────

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExAthena.MixProject do
   use Mix.Project
 
-  @version "0.4.6"
+  @version "0.4.7"
   @source_url "https://github.com/udin-io/ex_athena"
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExAthena.MixProject do
   use Mix.Project
 
-  @version "0.4.5"
+  @version "0.4.6"
   @source_url "https://github.com/udin-io/ex_athena"
 
   def project do

--- a/test/ex_athena/providers/req_llm_test.exs
+++ b/test/ex_athena/providers/req_llm_test.exs
@@ -46,6 +46,11 @@ defmodule ExAthena.Providers.ReqLLMTest do
       assert Keyword.get(opts, :req_llm_provider_tag) == "openai"
     end
 
+    test ":llamacpp threads openai_compatible_backend so missing API keys are tolerated" do
+      {_mod, opts} = Config.pop_provider!(provider: :llamacpp)
+      assert Keyword.get(opts, :openai_compatible_backend) == :llamacpp
+    end
+
     test ":claude translates to anthropic tag" do
       {_mod, opts} = Config.pop_provider!(provider: :claude)
       assert Keyword.get(opts, :req_llm_provider_tag) == "anthropic"
@@ -190,6 +195,37 @@ defmodule ExAthena.Providers.ReqLLMTest do
 
       [%ReqLLM.Tool{callback: cb}] = Adapter.to_req_llm_tools([tool_map])
       assert cb.(%{}) == {:error, :tool_execution_handled_by_ex_athena}
+    end
+  end
+
+  describe "build_opts/2 substitutes a placeholder api_key for backends that ignore auth" do
+    alias ExAthena.Request
+
+    test ":ollama backend with no api_key gets the \"ollama\" placeholder" do
+      request = %Request{messages: []}
+      {:ok, opts} = Adapter.build_opts(request, openai_compatible_backend: :ollama)
+      assert Keyword.get(opts, :api_key) == "ollama"
+    end
+
+    test ":llamacpp backend with no api_key gets the \"llamacpp\" placeholder" do
+      request = %Request{messages: []}
+      {:ok, opts} = Adapter.build_opts(request, openai_compatible_backend: :llamacpp)
+      assert Keyword.get(opts, :api_key) == "llamacpp"
+    end
+
+    test "explicit api_key wins over the placeholder for :llamacpp" do
+      request = %Request{messages: []}
+
+      {:ok, opts} =
+        Adapter.build_opts(request, openai_compatible_backend: :llamacpp, api_key: "real-key")
+
+      assert Keyword.get(opts, :api_key) == "real-key"
+    end
+
+    test "no backend marker means no placeholder substitution" do
+      request = %Request{messages: []}
+      {:ok, opts} = Adapter.build_opts(request, [])
+      refute Keyword.has_key?(opts, :api_key)
     end
   end
 


### PR DESCRIPTION
## Summary

- Adds the `:llamacpp` provider to `@local_openai_compatible_backends` and adds the corresponding `resolve_api_key(nil, :llamacpp)` placeholder clause.
- Mirrors the `:ollama` path that landed in v0.4.1 — both bugs (no backend marker + no placeholder) had to land together for `:llamacpp` to work end-to-end against an unauthenticated local llama-server.
- Backfills the v0.4.6 release artifacts (CHANGELOG entry + mix.exs version bump) that were published to Hex but never committed.
- Bumps to v0.4.7 with a focused changelog entry.

## Problem

`req_llm` 1.10/1.11's openai adapter requires *some* non-nil `:api_key` even when `openai_compatible_backend` allows missing auth (the underlying HTTP request still emits an Authorization header which local servers ignore). Until this PR, selecting `provider: :llamacpp` without explicitly supplying an `api_key` produced:

\`\`\`
ExAthena.Error{kind: :server_error,
  message: "{:http_streaming_failed, {:provider_build_failed,
    %ReqLLM.Error.API.Request{reason: \"Failed to build streaming request:
      Invalid parameter: :api_key option, config :req_llm, openai_api_key,
      or OPENAI_API_KEY env var (.env via dotenvy)\"}}}"}
\`\`\`

before any HTTP call left the BEAM. Downstream retry layers in `udin_code` then classified this as `:api_error` and hammered the same failing request every 3 minutes until the recovery budget exhausted.

Reproduced today against a live `llama-server` on `http://localhost:8080` with model auto-detected from `/v1/models` — model resolved correctly, request building failed at `req_llm`.

## Test plan

- [x] New tests in `test/ex_athena/providers/req_llm_test.exs`:
  - `Config.pop_provider!(provider: :llamacpp)` threads `openai_compatible_backend: :llamacpp` (parity with the existing `:ollama` test).
  - `build_opts/2` substitutes `api_key: "llamacpp"` when `openai_compatible_backend: :llamacpp` and no key is supplied.
  - Explicit `api_key:` wins over the placeholder.
  - No backend marker → no placeholder substitution (regression guard).
- [x] `mix test` — 320 tests + 2 doctests, 0 failures.
- [x] `mix format --check-formatted` clean (only the changed files).

## Downstream impact

Once tagged on Hex, `udin_code` can `mix igniter.upgrade ex_athena` to 0.4.7 and the existing failing planning run on the Udin project (`provider=:llamacpp, api_key=nil`) should proceed past `:scope_assessment` without the user needing to set a placeholder `api_key` manually.

Tracks udin-io/udin_code#1288 (root cause confirmed; this PR is the upstream half).