### PR TITLE
bug(tool_calls): Native.parse/1 rejects ReqLLM.StreamChunk tool-call shape (:unrecognised_tool_call)

### DIFF
--- a/.artifacts/adr-1-streamchunk-parser-clause.md
+++ b/.artifacts/adr-1-streamchunk-parser-clause.md
@@ -1,0 +1,15 @@
+# ADR 1: Add ReqLLM.StreamChunk clause to Native tool-call parser
+
+**Status:** Proposed
+
+## Context
+The req_llm provider streams tool calls and accumulates them as raw `%ReqLLM.StreamChunk{type: :tool_call, name:, arguments:, metadata:}` structs. `ExAthena.ToolCalls.Native.parse_one/1` recognises OpenAI, Claude, and generic id/name shapes but not StreamChunk, so calls reach the catch-all clause and fail with `{:unrecognised_tool_call, chunk}`. This halts planning sessions on the Ollama/req_llm path.
+
+## Decision
+Add a `parse_one/1` clause for `%ReqLLM.StreamChunk{type: :tool_call}` that extracts an optional id from `metadata["id"]` or `metadata[:id]` and delegates to the existing `build/3` helper. The parser remains the single source of truth for tool-call shapes; provider boundaries stay unaware of struct normalisation.
+
+## Consequences
+- StreamChunk-shaped tool calls dispatch correctly on the Ollama/req_llm path.
+- Future provider-specific shapes follow the same pattern: add a clause, reuse `build/3`.
+- No public API changes. No migration. Backwards compatible.
+- Aligns with existing ADR "RawJson tool-call fallback and per-request capability override".

--- a/.artifacts/adr-1-streamchunk-parser-clause.md
+++ b/.artifacts/adr-1-streamchunk-parser-clause.md
@@ -1,6 +1,6 @@
 # ADR 1: Add ReqLLM.StreamChunk clause to Native tool-call parser
 
-**Status:** Proposed
+**Status:** Accepted
 
 ## Context
 The req_llm provider streams tool calls and accumulates them as raw `%ReqLLM.StreamChunk{type: :tool_call, name:, arguments:, metadata:}` structs. `ExAthena.ToolCalls.Native.parse_one/1` recognises OpenAI, Claude, and generic id/name shapes but not StreamChunk, so calls reach the catch-all clause and fail with `{:unrecognised_tool_call, chunk}`. This halts planning sessions on the Ollama/req_llm path.

--- a/lib/ex_athena/tool_calls/native.ex
+++ b/lib/ex_athena/tool_calls/native.ex
@@ -2,7 +2,7 @@ defmodule ExAthena.ToolCalls.Native do
   @moduledoc """
   Parses native tool-call structures from provider responses.
 
-  Handles the three common shapes:
+  Handles the four common shapes:
 
     1. OpenAI / Ollama — `%{id:, type: "function", function: %{name:, arguments: "json"}}`.
        `arguments` is almost always a JSON-encoded string.
@@ -10,6 +10,9 @@ defmodule ExAthena.ToolCalls.Native do
     2. Claude — `%{type: "tool_use", id:, name:, input: map()}`.
 
     3. Pre-parsed — already-parsed `%{id:, name:, arguments: map()}`. No-op.
+
+    4. ReqLLM streaming — `%ReqLLM.StreamChunk{type: :tool_call, name:, arguments:, metadata:}`.
+       An optional id is read from `metadata["id"]` or `metadata[:id]`; if absent, one is generated.
 
   Tolerant of both atom and string keys, and tolerant of either a JSON string
   or a decoded map for `arguments`.
@@ -55,6 +58,11 @@ defmodule ExAthena.ToolCalls.Native do
 
   defp parse_one(%{id: id, name: name} = map) do
     build(id, name, Map.get(map, :arguments) || Map.get(map, :input) || %{})
+  end
+
+  defp parse_one(%ReqLLM.StreamChunk{type: :tool_call, name: name, arguments: args} = chunk) do
+    id = chunk.metadata && (chunk.metadata["id"] || chunk.metadata[:id])
+    build(id, name, args)
   end
 
   defp parse_one(other), do: {:error, {:unrecognised_tool_call, other}}

--- a/test/ex_athena/tool_calls/native_test.exs
+++ b/test/ex_athena/tool_calls/native_test.exs
@@ -37,7 +37,9 @@ defmodule ExAthena.ToolCalls.NativeTest do
         metadata: %{}
       }
 
-      assert {:ok, [%ToolCall{name: "glob", id: id}]} = Native.parse([chunk])
+      assert {:ok, [%ToolCall{name: "glob", id: id, arguments: %{"pattern" => "**/*.ex"}}]} =
+               Native.parse([chunk])
+
       assert is_binary(id) and byte_size(id) > 0
     end
 

--- a/test/ex_athena/tool_calls/native_test.exs
+++ b/test/ex_athena/tool_calls/native_test.exs
@@ -1,0 +1,55 @@
+defmodule ExAthena.ToolCalls.NativeTest do
+  use ExUnit.Case, async: true
+
+  alias ExAthena.Messages.ToolCall
+  alias ExAthena.ToolCalls.Native
+
+  describe "parse/1 — ReqLLM.StreamChunk shapes" do
+    test "parses StreamChunk with string-keyed id in metadata" do
+      chunk = %ReqLLM.StreamChunk{
+        type: :tool_call,
+        name: "glob",
+        arguments: %{"pattern" => "**/*.ex"},
+        metadata: %{"id" => "call_123"}
+      }
+
+      assert {:ok,
+              [%ToolCall{name: "glob", id: "call_123", arguments: %{"pattern" => "**/*.ex"}}]} =
+               Native.parse([chunk])
+    end
+
+    test "parses StreamChunk with atom-keyed id in metadata" do
+      chunk = %ReqLLM.StreamChunk{
+        type: :tool_call,
+        name: "glob",
+        arguments: %{"pattern" => "**/*.ex"},
+        metadata: %{id: "call_atom_456"}
+      }
+
+      assert {:ok, [%ToolCall{name: "glob", id: "call_atom_456"}]} = Native.parse([chunk])
+    end
+
+    test "parses StreamChunk without id — auto-generates one" do
+      chunk = %ReqLLM.StreamChunk{
+        type: :tool_call,
+        name: "glob",
+        arguments: %{"pattern" => "**/*.ex"},
+        metadata: %{}
+      }
+
+      assert {:ok, [%ToolCall{name: "glob", id: id}]} = Native.parse([chunk])
+      assert is_binary(id) and byte_size(id) > 0
+    end
+
+    test "returns error for StreamChunk with nil name" do
+      chunk = %ReqLLM.StreamChunk{
+        type: :tool_call,
+        name: nil,
+        arguments: %{},
+        metadata: %{}
+      }
+
+      assert {:error, :missing_tool_name} = Native.parse([chunk])
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes a parser gap in `ExAthena.ToolCalls.Native` that caused planning sessions routed through the `req_llm` provider to fail mid-stream with `{:unrecognised_tool_call, #StreamChunk<:tool_call ...>}`. The parser had no clause for `%ReqLLM.StreamChunk{}` structs, so all tool calls arriving via the streaming Ollama path hit the catch-all error clause and exhausted the retry policy before any tool could be dispatched.

## Root Cause

`Native.parse_one/1` matched four shapes (OpenAI map, Claude map, pre-parsed map, `%ToolCall{}`) but not the `%ReqLLM.StreamChunk{}` struct emitted by the req_llm accumulator. StreamChunks differ in two ways that prevented any existing clause from matching:

- `:type` is the atom `:tool_call`, not the strings `"function"` or `"tool_use"`.
- There is no top-level `:id` field — the id, when present, lives inside `:metadata`.

## Changes

- **`lib/ex_athena/tool_calls/native.ex`** — adds a `parse_one/1` clause for `%ReqLLM.StreamChunk{type: :tool_call}`, inserted above the catch-all. The clause extracts the id from `metadata["id"]` or `metadata[:id]` (tolerating both key forms), then delegates to the existing `build/3` helper. If no id is present, `build/3`'s existing `generate_id/0` path produces one automatically. The module doc is updated to list this as the fourth supported shape.

- **`test/ex_athena/tool_calls/native_test.exs`** — new test file covering: string-keyed metadata id, atom-keyed metadata id, missing id (auto-generation), and nil tool name (error path).

## Implementation Notes

The fix is intentionally contained to the parser. An alternative of normalising `StreamChunk` structs into a plain map inside `req_llm.ex` before accumulation was considered but rejected — it would spread parser concerns into the provider boundary and require changes in a second location. Keeping all shape-matching inside `Native` preserves the single-source-of-truth invariant for tool-call parsing.

Closes https://github.com/udin-io/ex_athena/issues/22