### PR TITLE
feat(tools): apply_patch tool for unified-diff edits across multiple regions/files

### DIFF
--- a/.artifacts/adr-1-apply-patch-tool-with-git-and-elixir-backends.md
+++ b/.artifacts/adr-1-apply-patch-tool-with-git-and-elixir-backends.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/.artifacts/adr-1-apply-patch-tool-with-git-and-elixir-backends.md
+++ b/.artifacts/adr-1-apply-patch-tool-with-git-and-elixir-backends.md
@@ -1,0 +1,41 @@
+# ADR: ApplyPatch tool with git-apply backend and bounded Elixir fallback
+
+## Status
+
+Proposed
+
+## Context
+
+The existing `ExAthena.Tools.Edit` tool handles a single contiguous change per call. Multi-region or multi-file refactors require N sequential tool calls, each a network roundtrip. On a recent 7-file conflict resolution this cost ~297s, dominated by sequencing rather than reasoning. Modern LLMs natively emit unified diffs when asked to refactor; the current toolset forces them to translate diffs into discrete edits.
+
+OpenCode ships an `apply_patch` tool with the same shape we want: a single unified-diff input applied atomically across one or more files. Git's `git apply` already understands the format and provides high-quality error messages on context mismatch.
+
+## Decision
+
+1. Add `ExAthena.Tools.ApplyPatch` accepting `{patch: string, dry_run?: boolean}` in unified-diff format.
+2. Apply atomically: any hunk failing context match aborts the entire patch with no on-disk side effects.
+3. Backend selection at execution time:
+   - When `cwd` is inside a git work tree (probed with `git rev-parse --is-inside-work-tree`), shell out to `git apply --whitespace=nowarn` (and `--check` for dry-run). Atomicity comes from `git apply` itself.
+   - Otherwise, a pure-Elixir parser/applier scoped to standard unified-diff hunks. Two-pass design: compute new contents for every file in memory; only write when every hunk validates.
+4. v1 explicitly does not support binary diffs, `/dev/null` create/delete, rename detection beyond what unified-diff carries, or fuzzy context matching. Unsupported features return a structured error so the model can retry.
+5. Path safety, snapshot, and permission/hook integration reuse existing infrastructure (`ToolContext.resolve_path/2`, `ExAthena.Checkpoint.snapshot/3`, the loop's tool dispatch). No new wiring inside ex_athena.
+
+## Consequences
+
+### Positive
+
+- One tool call replaces N edits for multi-file refactors. Direct latency win on the SDK conflict-resolution path.
+- The git backend leverages a battle-tested parser and produces high-quality error messages.
+- Atomic semantics avoid half-applied refactors.
+- The Elixir fallback keeps the tool usable in non-git working directories without a hard dependency on git.
+- Reuses existing path safety and snapshot mechanisms — no new attack surface.
+
+### Negative
+
+- Two backends to maintain. Mitigated by keeping the Elixir backend deliberately small (no fuzz, no binary, no rename, no /dev/null).
+- Hosts (e.g., `udin_code`) must extend any `Edit|Write` matchers in permission rules and hooks to include `ApplyPatch`. Tracked as a separate ticket.
+- `git apply` error output format is not stable across git versions; we surface it verbatim rather than parsing it.
+
+### Neutral
+
+- No conflict with existing ADRs (tool-call parsing, schema compaction, structured output, assistant-message replay).

--- a/lib/ex_athena/tools.ex
+++ b/lib/ex_athena/tools.ex
@@ -23,6 +23,7 @@ defmodule ExAthena.Tools do
     ExAthena.Tools.Grep,
     ExAthena.Tools.Write,
     ExAthena.Tools.Edit,
+    ExAthena.Tools.ApplyPatch,
     ExAthena.Tools.Bash,
     ExAthena.Tools.WebFetch,
     ExAthena.Tools.TodoWrite,

--- a/lib/ex_athena/tools/apply_patch.ex
+++ b/lib/ex_athena/tools/apply_patch.ex
@@ -16,6 +16,8 @@ defmodule ExAthena.Tools.ApplyPatch do
 
   @behaviour ExAthena.Tool
 
+  require Logger
+
   alias ExAthena.ToolContext
 
   @impl true
@@ -244,7 +246,9 @@ defmodule ExAthena.Tools.ApplyPatch do
     _ = ExAthena.Checkpoint.snapshot(cwd, sid, path)
     :ok
   rescue
-    _ -> :ok
+    e ->
+      Logger.error("[ApplyPatch] checkpoint snapshot failed for #{path}: #{Exception.message(e)}")
+      :ok
   end
 
   defp maybe_snapshot(_, _), do: :ok
@@ -261,12 +265,19 @@ defmodule ExAthena.Tools.ApplyPatch do
     end
   end
 
+  @git_timeout 30_000
+
   defp git_repo?(cwd) do
-    case System.cmd("git", ["rev-parse", "--is-inside-work-tree"],
-           cd: cwd,
-           stderr_to_stdout: true
-         ) do
-      {"true\n", 0} -> true
+    task =
+      Task.async(fn ->
+        System.cmd("git", ["rev-parse", "--is-inside-work-tree"],
+          cd: cwd,
+          stderr_to_stdout: true
+        )
+      end)
+
+    case Task.yield(task, @git_timeout) || Task.shutdown(task, :brutal_kill) do
+      {:ok, {"true\n", 0}} -> true
       _ -> false
     end
   rescue
@@ -294,8 +305,10 @@ defmodule ExAthena.Tools.ApplyPatch do
           ["apply", "--whitespace=nowarn", tmp]
         end
 
-      case System.cmd("git", args, cd: cwd, stderr_to_stdout: true) do
-        {_, 0} ->
+      task = Task.async(fn -> System.cmd("git", args, cd: cwd, stderr_to_stdout: true) end)
+
+      case Task.yield(task, @git_timeout) || Task.shutdown(task, :brutal_kill) do
+        {:ok, {_, 0}} ->
           results =
             Enum.map(file_sections, fn s ->
               %{path: s.path, hunks_applied: s.hunk_count, hunks_skipped: 0}
@@ -303,8 +316,11 @@ defmodule ExAthena.Tools.ApplyPatch do
 
           {:ok, results}
 
-        {stderr, _} ->
+        {:ok, {stderr, _}} ->
           {:error, {:git_apply_failed, String.trim(stderr)}}
+
+        nil ->
+          {:error, :git_timeout}
       end
     after
       File.rm(tmp)

--- a/lib/ex_athena/tools/apply_patch.ex
+++ b/lib/ex_athena/tools/apply_patch.ex
@@ -1,0 +1,394 @@
+defmodule ExAthena.Tools.ApplyPatch do
+  @moduledoc """
+  Apply a unified diff patch across one or more files atomically.
+
+  All hunks across all files are validated in memory first (pure-Elixir backend)
+  before any file is written to disk — partial mutations on error are impossible.
+
+  Backend selection:
+  - Inside a git work-tree: delegates to `git apply --whitespace=nowarn`, which
+    is itself atomic on failure.
+  - Otherwise: pure-Elixir two-pass parser/applier.
+
+  v1 limitations: no binary diffs, no `/dev/null` create/delete hunks, no fuzzy
+  context matching.
+  """
+
+  @behaviour ExAthena.Tool
+
+  alias ExAthena.ToolContext
+
+  @impl true
+  def name, do: "apply_patch"
+
+  @impl true
+  def description,
+    do:
+      "Apply a unified diff patch across one or more files atomically. " <>
+        "All hunks either succeed or none are written to disk."
+
+  @impl true
+  def schema do
+    %{
+      type: "object",
+      properties: %{
+        patch: %{
+          type: "string",
+          description: "Unified diff in git-apply format."
+        },
+        dry_run: %{
+          type: "boolean",
+          description: "Validate the patch without writing to disk. Default false."
+        }
+      },
+      required: ["patch"]
+    }
+  end
+
+  @impl true
+  def execute(args, %ToolContext{} = ctx) do
+    with {:ok, patch} <- fetch_patch(args),
+         dry_run? = Map.get(args, "dry_run", false),
+         {:ok, file_sections} <- parse_diff(patch),
+         {:ok, resolved} <- resolve_paths(file_sections, ctx),
+         :ok <- maybe_snapshot_all(ctx, resolved),
+         {:ok, results} <- dispatch(patch, resolved, dry_run?, ctx) do
+      llm =
+        Enum.map_join(results, "\n", fn %{path: p, hunks_applied: h} ->
+          rel = Path.relative_to(p, ctx.cwd)
+          "applied #{h} hunk#{if h == 1, do: "", else: "s"} to #{rel}"
+        end)
+
+      ui = %{kind: :patch, payload: %{files: results}}
+      {:ok, llm, ui}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Fetch
+  # ---------------------------------------------------------------------------
+
+  defp fetch_patch(%{"patch" => patch}) when is_binary(patch) and patch != "",
+    do: {:ok, patch}
+
+  defp fetch_patch(%{"patch" => ""}), do: {:error, :empty_patch}
+  defp fetch_patch(%{"patch" => _}), do: {:error, :invalid_patch}
+  defp fetch_patch(_), do: {:error, :missing_patch}
+
+  # ---------------------------------------------------------------------------
+  # Diff parser
+  # ---------------------------------------------------------------------------
+
+  @doc false
+  def parse_diff(patch) do
+    lines = String.split(patch, "\n")
+    sections = group_into_file_sections(lines)
+
+    if sections == [] do
+      {:error, :no_file_sections_found}
+    else
+      Enum.reduce_while(sections, {:ok, []}, fn section, {:ok, acc} ->
+        case parse_file_section(section) do
+          {:ok, fs} -> {:cont, {:ok, [fs | acc]}}
+          {:error, _} = err -> {:halt, err}
+        end
+      end)
+      |> case do
+        {:ok, list} -> {:ok, Enum.reverse(list)}
+        err -> err
+      end
+    end
+  end
+
+  # Split a flat line list into per-file chunks. Each file's diff starts with
+  # "--- "; anything before the first such line (git preamble) is discarded.
+  defp group_into_file_sections(lines) do
+    lines
+    |> Enum.chunk_while(
+      [],
+      fn line, acc ->
+        if String.starts_with?(line, "--- ") and acc != [] do
+          {:cont, Enum.reverse(acc), [line]}
+        else
+          {:cont, [line | acc]}
+        end
+      end,
+      fn
+        [] -> {:cont, []}
+        acc -> {:cont, Enum.reverse(acc), []}
+      end
+    )
+    |> Enum.filter(fn section ->
+      Enum.any?(section, &String.starts_with?(&1, "--- "))
+    end)
+  end
+
+  defp parse_file_section(lines) do
+    with {:ok, raw_path} <- extract_target_path(lines),
+         {:ok, hunks} <- parse_hunks(lines) do
+      {:ok, %{raw_path: raw_path, hunks: hunks, hunk_count: length(hunks)}}
+    end
+  end
+
+  defp extract_target_path(lines) do
+    plus_line = Enum.find(lines, &String.starts_with?(&1, "+++ "))
+    minus_line = Enum.find(lines, &String.starts_with?(&1, "--- "))
+
+    cond do
+      is_nil(plus_line) ->
+        {:error, :no_target_path}
+
+      String.starts_with?(plus_line, "+++ /dev/null") ->
+        {:error, {:unsupported_diff_feature, :file_deletion}}
+
+      not is_nil(minus_line) and String.starts_with?(minus_line, "--- /dev/null") ->
+        {:error, {:unsupported_diff_feature, :file_creation}}
+
+      String.starts_with?(plus_line, "+++ b/") ->
+        {:ok, plus_line |> String.slice(6, String.length(plus_line)) |> tab_strip()}
+
+      true ->
+        {:ok, plus_line |> String.slice(4, String.length(plus_line)) |> tab_strip()}
+    end
+  end
+
+  # Strip optional tab-separated timestamp that some diff tools append.
+  defp tab_strip(s), do: s |> String.split("\t") |> hd() |> String.trim()
+
+  defp parse_hunks(lines) do
+    indexed = Enum.with_index(lines)
+
+    hunk_starts =
+      Enum.filter(indexed, fn {line, _} -> String.starts_with?(line, "@@ ") end)
+
+    if hunk_starts == [] do
+      {:error, :no_hunks_found}
+    else
+      total = length(lines)
+
+      hunks =
+        hunk_starts
+        |> Enum.with_index()
+        |> Enum.map(fn {{header, start_idx}, hunk_idx} ->
+          next_start =
+            case Enum.at(hunk_starts, hunk_idx + 1) do
+              nil -> total
+              {_, idx} -> idx
+            end
+
+          body = Enum.slice(lines, (start_idx + 1)..(next_start - 1))
+          parse_hunk_header(header, body)
+        end)
+
+      errors = Enum.filter(hunks, &match?({:error, _}, &1))
+
+      if errors == [] do
+        {:ok, Enum.map(hunks, fn {:ok, h} -> h end)}
+      else
+        hd(errors)
+      end
+    end
+  end
+
+  @hunk_re ~r/^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/
+
+  defp parse_hunk_header(header, body_lines) do
+    case Regex.run(@hunk_re, header) do
+      [_, old_start_s, old_count_s, new_start_s, new_count_s] ->
+        {:ok,
+         %{
+           old_start: String.to_integer(old_start_s),
+           old_count: parse_count(old_count_s),
+           new_start: String.to_integer(new_start_s),
+           new_count: parse_count(new_count_s),
+           lines: body_lines
+         }}
+
+      _ ->
+        {:error, {:invalid_hunk_header, header}}
+    end
+  end
+
+  defp parse_count(nil), do: 1
+  defp parse_count(""), do: 1
+  defp parse_count(s), do: String.to_integer(s)
+
+  # ---------------------------------------------------------------------------
+  # Path resolution
+  # ---------------------------------------------------------------------------
+
+  defp resolve_paths(file_sections, ctx) do
+    Enum.reduce_while(file_sections, {:ok, []}, fn section, {:ok, acc} ->
+      case ToolContext.resolve_path(ctx, section.raw_path) do
+        {:ok, abs_path} -> {:cont, {:ok, [Map.put(section, :path, abs_path) | acc]}}
+        {:error, _} = err -> {:halt, err}
+      end
+    end)
+    |> case do
+      {:ok, list} -> {:ok, Enum.reverse(list)}
+      err -> err
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Snapshot
+  # ---------------------------------------------------------------------------
+
+  defp maybe_snapshot_all(ctx, file_sections) do
+    Enum.each(file_sections, fn section -> maybe_snapshot(ctx, section.path) end)
+    :ok
+  end
+
+  defp maybe_snapshot(%ToolContext{session_id: sid, cwd: cwd}, path)
+       when is_binary(sid) and sid != "" do
+    _ = ExAthena.Checkpoint.snapshot(cwd, sid, path)
+    :ok
+  rescue
+    _ -> :ok
+  end
+
+  defp maybe_snapshot(_, _), do: :ok
+
+  # ---------------------------------------------------------------------------
+  # Backend dispatch
+  # ---------------------------------------------------------------------------
+
+  defp dispatch(patch, file_sections, dry_run?, ctx) do
+    if git_repo?(ctx.cwd) do
+      apply_with_git(patch, file_sections, dry_run?, ctx.cwd)
+    else
+      apply_with_elixir(file_sections, dry_run?)
+    end
+  end
+
+  defp git_repo?(cwd) do
+    case System.cmd("git", ["rev-parse", "--is-inside-work-tree"],
+           cd: cwd,
+           stderr_to_stdout: true
+         ) do
+      {"true\n", 0} -> true
+      _ -> false
+    end
+  rescue
+    _ -> false
+  end
+
+  # ---------------------------------------------------------------------------
+  # Git backend
+  # ---------------------------------------------------------------------------
+
+  defp apply_with_git(patch, file_sections, dry_run?, cwd) do
+    tmp =
+      Path.join(
+        System.tmp_dir!(),
+        "apply_patch_#{System.unique_integer([:positive])}.patch"
+      )
+
+    try do
+      File.write!(tmp, patch)
+
+      args =
+        if dry_run? do
+          ["apply", "--check", "--whitespace=nowarn", tmp]
+        else
+          ["apply", "--whitespace=nowarn", tmp]
+        end
+
+      case System.cmd("git", args, cd: cwd, stderr_to_stdout: true) do
+        {_, 0} ->
+          results =
+            Enum.map(file_sections, fn s ->
+              %{path: s.path, hunks_applied: s.hunk_count, hunks_skipped: 0}
+            end)
+
+          {:ok, results}
+
+        {stderr, _} ->
+          {:error, {:git_apply_failed, String.trim(stderr)}}
+      end
+    after
+      File.rm(tmp)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Pure-Elixir backend (two-pass: validate all in memory, then write all)
+  # ---------------------------------------------------------------------------
+
+  defp apply_with_elixir(file_sections, dry_run?) do
+    computed =
+      Enum.reduce_while(file_sections, {:ok, []}, fn section, {:ok, acc} ->
+        case compute_new_content(section) do
+          {:ok, new_content} -> {:cont, {:ok, [{section, new_content} | acc]}}
+          {:error, _} = err -> {:halt, err}
+        end
+      end)
+
+    case computed do
+      {:error, _} = err ->
+        err
+
+      {:ok, pairs} ->
+        pairs = Enum.reverse(pairs)
+
+        unless dry_run? do
+          Enum.each(pairs, fn {section, new_content} ->
+            File.mkdir_p!(Path.dirname(section.path))
+            File.write!(section.path, new_content)
+          end)
+        end
+
+        results =
+          Enum.map(pairs, fn {section, _} ->
+            %{path: section.path, hunks_applied: section.hunk_count, hunks_skipped: 0}
+          end)
+
+        {:ok, results}
+    end
+  end
+
+  defp compute_new_content(%{path: path, hunks: hunks}) do
+    raw =
+      case File.read(path) do
+        {:ok, content} -> content
+        {:error, :enoent} -> ""
+      end
+
+    file_lines = String.split(raw, "\n", trim: false)
+
+    # Apply in reverse order so earlier hunks' line numbers remain valid
+    Enum.reduce_while(Enum.reverse(hunks), {:ok, file_lines}, fn hunk, {:ok, lines} ->
+      case apply_hunk(hunk, lines) do
+        {:ok, new_lines} -> {:cont, {:ok, new_lines}}
+        {:error, _} = err -> {:halt, err}
+      end
+    end)
+    |> case do
+      {:ok, final_lines} -> {:ok, Enum.join(final_lines, "\n")}
+      err -> err
+    end
+  end
+
+  defp apply_hunk(%{old_start: old_start, old_count: old_count, lines: hunk_lines}, file_lines) do
+    expected =
+      hunk_lines
+      |> Enum.filter(&(String.starts_with?(&1, " ") or String.starts_with?(&1, "-")))
+      |> Enum.map(&String.slice(&1, 1, String.length(&1)))
+
+    start_idx = old_start - 1
+    actual = Enum.slice(file_lines, start_idx, old_count)
+
+    if actual != expected do
+      {:error, {:context_mismatch, expected: expected, actual: actual, old_start: old_start}}
+    else
+      replacement =
+        hunk_lines
+        |> Enum.filter(&(String.starts_with?(&1, " ") or String.starts_with?(&1, "+")))
+        |> Enum.map(&String.slice(&1, 1, String.length(&1)))
+
+      before = Enum.slice(file_lines, 0, start_idx)
+      rest = Enum.slice(file_lines, start_idx + old_count, length(file_lines))
+      {:ok, before ++ replacement ++ rest}
+    end
+  end
+end

--- a/test/ex_athena/tools/apply_patch_test.exs
+++ b/test/ex_athena/tools/apply_patch_test.exs
@@ -1,0 +1,252 @@
+defmodule ExAthena.Tools.ApplyPatchTest do
+  use ExUnit.Case, async: true
+
+  alias ExAthena.ToolContext
+  alias ExAthena.Tools.ApplyPatch
+
+  setup do
+    dir = Path.join(System.tmp_dir!(), "applypatch_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+    {:ok, dir: dir, ctx: ToolContext.new(cwd: dir)}
+  end
+
+  describe "single-file single-hunk apply" do
+    test "applies cleanly and reports hunks", %{dir: dir, ctx: ctx} do
+      File.write!(Path.join(dir, "test.txt"), "line1\nline2\nline3\n")
+
+      patch = """
+      --- a/test.txt
+      +++ b/test.txt
+      @@ -1,3 +1,3 @@
+       line1
+      -line2
+      +line2_new
+       line3
+      """
+
+      assert {:ok, msg, ui} = ApplyPatch.execute(%{"patch" => patch}, ctx)
+      assert msg =~ "1 hunk"
+      assert File.read!(Path.join(dir, "test.txt")) == "line1\nline2_new\nline3\n"
+      assert [%{hunks_applied: 1, hunks_skipped: 0}] = ui.payload.files
+      assert ui.kind == :patch
+    end
+  end
+
+  describe "multi-file atomic apply" do
+    test "applies all files and reports each", %{dir: dir, ctx: ctx} do
+      File.write!(Path.join(dir, "file_a.txt"), "aaa\nbbb\nccc\n")
+      File.write!(Path.join(dir, "file_b.txt"), "ddd\neee\nfff\n")
+      File.write!(Path.join(dir, "file_c.txt"), "ggg\nhhh\niii\n")
+
+      patch = """
+      --- a/file_a.txt
+      +++ b/file_a.txt
+      @@ -1,3 +1,3 @@
+       aaa
+      -bbb
+      +BBB
+       ccc
+      --- a/file_b.txt
+      +++ b/file_b.txt
+      @@ -1,3 +1,3 @@
+       ddd
+      -eee
+      +EEE
+       fff
+      --- a/file_c.txt
+      +++ b/file_c.txt
+      @@ -1,3 +1,3 @@
+       ggg
+      -hhh
+      +HHH
+       iii
+      """
+
+      assert {:ok, _msg, ui} = ApplyPatch.execute(%{"patch" => patch}, ctx)
+      assert length(ui.payload.files) == 3
+      assert File.read!(Path.join(dir, "file_a.txt")) == "aaa\nBBB\nccc\n"
+      assert File.read!(Path.join(dir, "file_b.txt")) == "ddd\nEEE\nfff\n"
+      assert File.read!(Path.join(dir, "file_c.txt")) == "ggg\nHHH\niii\n"
+    end
+  end
+
+  describe "multi-hunk in one file" do
+    test "applies all hunks and reports count", %{dir: dir, ctx: ctx} do
+      File.write!(Path.join(dir, "multi.txt"), "one\ntwo\nthree\nfour\nfive\n")
+
+      patch = """
+      --- a/multi.txt
+      +++ b/multi.txt
+      @@ -1,2 +1,2 @@
+       one
+      -two
+      +TWO
+      @@ -4,2 +4,2 @@
+       four
+      -five
+      +FIVE
+      """
+
+      assert {:ok, _msg, ui} = ApplyPatch.execute(%{"patch" => patch}, ctx)
+      assert [%{hunks_applied: 2}] = ui.payload.files
+      assert File.read!(Path.join(dir, "multi.txt")) == "one\nTWO\nthree\nfour\nFIVE\n"
+    end
+  end
+
+  describe "atomic rollback on bad context" do
+    test "no file is modified when any hunk fails context check", %{dir: dir, ctx: ctx} do
+      File.write!(Path.join(dir, "r1.txt"), "aaa\n")
+      File.write!(Path.join(dir, "r2.txt"), "bbb\n")
+      File.write!(Path.join(dir, "r3.txt"), "ccc\n")
+
+      patch = """
+      --- a/r1.txt
+      +++ b/r1.txt
+      @@ -1,1 +1,1 @@
+      -aaa
+      +AAA
+      --- a/r2.txt
+      +++ b/r2.txt
+      @@ -1,1 +1,1 @@
+      -WRONG_CONTENT
+      +BBB
+      --- a/r3.txt
+      +++ b/r3.txt
+      @@ -1,1 +1,1 @@
+      -ccc
+      +CCC
+      """
+
+      assert {:error, _} = ApplyPatch.execute(%{"patch" => patch}, ctx)
+      assert File.read!(Path.join(dir, "r1.txt")) == "aaa\n"
+      assert File.read!(Path.join(dir, "r2.txt")) == "bbb\n"
+      assert File.read!(Path.join(dir, "r3.txt")) == "ccc\n"
+    end
+  end
+
+  describe "dry_run" do
+    test "validates without writing to disk", %{dir: dir, ctx: ctx} do
+      File.write!(Path.join(dir, "dry.txt"), "original\n")
+
+      patch = """
+      --- a/dry.txt
+      +++ b/dry.txt
+      @@ -1,1 +1,1 @@
+      -original
+      +modified
+      """
+
+      assert {:ok, _msg, _ui} = ApplyPatch.execute(%{"patch" => patch, "dry_run" => true}, ctx)
+      assert File.read!(Path.join(dir, "dry.txt")) == "original\n"
+    end
+  end
+
+  describe "path traversal" do
+    test "diff targeting ../escape.txt is rejected", %{ctx: ctx} do
+      patch = """
+      --- a/../escape.txt
+      +++ b/../escape.txt
+      @@ -1,1 +1,1 @@
+      -old
+      +new
+      """
+
+      assert {:error, _} = ApplyPatch.execute(%{"patch" => patch}, ctx)
+    end
+  end
+
+  describe "malformed patch" do
+    test "empty patch string returns :empty_patch", %{ctx: ctx} do
+      assert {:error, :empty_patch} = ApplyPatch.execute(%{"patch" => ""}, ctx)
+    end
+
+    test "non-diff string returns error", %{ctx: ctx} do
+      assert {:error, _} = ApplyPatch.execute(%{"patch" => "this is not a diff at all"}, ctx)
+    end
+
+    test "missing patch key returns :missing_patch", %{ctx: ctx} do
+      assert {:error, :missing_patch} = ApplyPatch.execute(%{}, ctx)
+    end
+  end
+
+  describe "git backend" do
+    test "applies via git apply inside a git repo", %{dir: dir} do
+      {_, 0} = System.cmd("git", ["init"], cd: dir, stderr_to_stdout: true)
+      {_, 0} = System.cmd("git", ["config", "user.email", "test@t.com"], cd: dir)
+      {_, 0} = System.cmd("git", ["config", "user.name", "Test"], cd: dir)
+
+      ctx = ToolContext.new(cwd: dir)
+      File.write!(Path.join(dir, "git_file.txt"), "hello\nworld\n")
+
+      patch = """
+      --- a/git_file.txt
+      +++ b/git_file.txt
+      @@ -1,2 +1,2 @@
+      -hello
+      +HELLO
+       world
+      """
+
+      assert {:ok, _msg, _ui} = ApplyPatch.execute(%{"patch" => patch}, ctx)
+      assert File.read!(Path.join(dir, "git_file.txt")) == "HELLO\nworld\n"
+    end
+
+    test "bad context fails via git apply", %{dir: dir} do
+      {_, 0} = System.cmd("git", ["init"], cd: dir, stderr_to_stdout: true)
+      {_, 0} = System.cmd("git", ["config", "user.email", "test@t.com"], cd: dir)
+      {_, 0} = System.cmd("git", ["config", "user.name", "Test"], cd: dir)
+
+      ctx = ToolContext.new(cwd: dir)
+      File.write!(Path.join(dir, "git_bad.txt"), "actual_content\n")
+
+      patch = """
+      --- a/git_bad.txt
+      +++ b/git_bad.txt
+      @@ -1,1 +1,1 @@
+      -wrong_context
+      +new_content
+      """
+
+      assert {:error, {:git_apply_failed, _}} = ApplyPatch.execute(%{"patch" => patch}, ctx)
+      assert File.read!(Path.join(dir, "git_bad.txt")) == "actual_content\n"
+    end
+  end
+
+  describe "non-git cwd (Elixir backend)" do
+    test "plain tmp dir uses Elixir backend", %{dir: dir, ctx: ctx} do
+      File.write!(Path.join(dir, "plain.txt"), "content\n")
+
+      patch = """
+      --- a/plain.txt
+      +++ b/plain.txt
+      @@ -1,1 +1,1 @@
+      -content
+      +CONTENT
+      """
+
+      assert {:ok, _msg, _ui} = ApplyPatch.execute(%{"patch" => patch}, ctx)
+      assert File.read!(Path.join(dir, "plain.txt")) == "CONTENT\n"
+    end
+  end
+
+  describe "snapshot integration" do
+    test "records checkpoint for each touched path when session_id is set", %{dir: dir} do
+      session_id = "test-session-#{System.unique_integer([:positive])}"
+      ctx = ToolContext.new(cwd: dir, session_id: session_id)
+      File.write!(Path.join(dir, "snap.txt"), "before\n")
+
+      patch = """
+      --- a/snap.txt
+      +++ b/snap.txt
+      @@ -1,1 +1,1 @@
+      -before
+      +after
+      """
+
+      assert {:ok, _, _} = ApplyPatch.execute(%{"patch" => patch}, ctx)
+      history_dir = Path.join([dir, ".exathena", "file-history", session_id])
+      assert File.exists?(history_dir)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `ExAthena.Tools.ApplyPatch`, a new tool that accepts a unified diff and applies it atomically across one or more files in a single tool call. This addresses the latency cost of sequential `Edit` calls on multi-region and cross-file refactors, and aligns ex_athena's toolset with the `apply_patch` pattern used by OpenCode.

## Key Changes

- **`lib/ex_athena/tools/apply_patch.ex`** — New 410-line module implementing the `ExAthena.Tool` behaviour:
  - Accepts a `patch` string in standard unified-diff (`git apply`) format and an optional `dry_run` boolean.
  - **Two-pass atomicity**: all hunks across all files are validated in memory before any file is written to disk — partial mutations on error are impossible.
  - **Backend selection**: delegates to `git apply --whitespace=nowarn` inside a git work-tree (inherently atomic); falls back to a pure-Elixir unified-diff parser and applier in non-git directories.
  - Returns a structured result per file (`path`, `hunks_applied`, `hunks_skipped`) so the model can confirm outcomes without re-reading files.

- **`lib/ex_athena/tools.ex`** — Registers `ExAthena.Tools.ApplyPatch` in the tool list, positioned between `Edit` and `Bash`.

## Implementation Details

- **Permission model** mirrors `Edit` and `Write`: `:plan` mode denies, `:default` consults the host callback, `:accept_edits` auto-approves.
- **Hook compatibility**: `:PreToolUse` / `:PostToolUse` fire normally, allowing hosts to attach post-apply steps (e.g. `mix compile`, LSP diagnostics) via the existing hook mechanism.
- **v1 scope constraints**: no binary diffs, no `/dev/null` create/delete hunks (file creation/deletion), no fuzzy context matching. Context mismatches in any hunk cause the entire patch to be rejected before any write occurs.
- The pure-Elixir fallback parser handles standard hunk format only — bounded scope that covers the model-generated diff cases described in the ticket without pulling in an external diff library.

Closes https://github.com/udin-io/ex_athena/issues/28