### PR TITLE
bug(loop): error_consecutive_mistakes triggered on valid tool-call turns (counter not reset on successful tool result?)

### DIFF
--- a/.artifacts/adr-1-propagate-consecutive-mistakes-resets-through-parallel-fold-deltas.md
+++ b/.artifacts/adr-1-propagate-consecutive-mistakes-resets-through-parallel-fold-deltas.md
@@ -1,0 +1,56 @@
+# ADR-1: Propagate consecutive_mistakes Resets Through Parallel fold_deltas
+
+## Status
+
+Accepted
+
+## Context
+
+`ExAthena.Loop.Parallel` runs `parallel_safe?` tool calls concurrently via `Task.async_stream`. After all tasks complete, `fold_deltas/2` merges per-task state deltas back into the main state. The original implementation only merged `budget` to avoid race conditions on the mistake counter when multiple tasks run simultaneously — the comment reads: "Mistake counter and ctx phase belong to the sequential path."
+
+However, this design also discards `reset_mistakes/1` calls from *successful* parallel tasks, leaving the `consecutive_mistakes` counter elevated in the main state. Both `ExAthena.Tools.Glob` and `ExAthena.Tools.Read` declare `parallel_safe?: true`, so they both route through `run_concurrent` → `fold_deltas`. When either succeeds, the counter reset is thrown away.
+
+Over multiple loop iterations, this causes the counter to exceed `max_consecutive_mistakes` even though no consecutive model mistakes actually occurred — the counter never got reset by intervening successful parallel tool calls.
+
+The existing test "successful tool call resets the mistake counter" (v03_test.exs) uses `read` (parallel-safe) but passes accidentally: `max_consecutive_mistakes: 2` and the counter only reaches 1, so the threshold is never triggered. The test does not verify a reset actually occurred.
+
+## Decision
+
+Extend `fold_deltas/2` to propagate `consecutive_mistakes` from a task state **only when the task lowered the value** — specifically, when `n < state.consecutive_mistakes`. This covers the reset case (`n = 0`) while continuing to discard bumps (`n = initial + 1`), preserving the original race-condition safety guarantee.
+
+The implementation splits `fold_deltas/2` into a pipeline of two private helpers:
+
+```elixir
+defp fold_deltas(state, new_state) do
+  state
+  |> maybe_update_budget(new_state)
+  |> maybe_propagate_reset(new_state)
+end
+
+defp maybe_update_budget(state, %{budget: b}) when not is_nil(b), do: %{state | budget: b}
+defp maybe_update_budget(state, _), do: state
+
+defp maybe_propagate_reset(state, %{consecutive_mistakes: n})
+     when n < state.consecutive_mistakes,
+     do: %{state | consecutive_mistakes: n}
+
+defp maybe_propagate_reset(state, _), do: state
+```
+
+The guard `n < state.consecutive_mistakes` is the minimal predicate: it propagates any downward movement (resets) and ignores any upward movement (bumps from errors in concurrent tasks).
+
+A new regression test is added in v03_test.exs that will fail without the fix and pass with it: bad call → parallel glob (success) → bad call → final response, with `max_consecutive_mistakes: 2`. Without the fix the counter reaches 2 at turn 3 and triggers `error_consecutive_mistakes`; with the fix the glob reset brings it back to 0 so turn 3 only reaches 1.
+
+## Consequences
+
+**Positive:**
+- Successful parallel tool calls correctly reset the mistake counter, matching the behavior of the serial path.
+- `error_consecutive_mistakes` only fires when mistakes are genuinely consecutive — not when interrupted by successful parallel calls.
+- No change to the race-condition safety for concurrent bumps.
+
+**Neutral:**
+- If multiple parallel tasks all reset the counter, the final folded value is 0 regardless — correct and idempotent.
+- If some tasks succeed (reset) and some fail (bump), the reset propagates because `n = 0 < initial`. This is the right behavior: one successful tool call in a batch is enough to reset.
+
+**Negative:**
+- None identified. The change is additive and narrowly scoped to a single private function.

--- a/lib/ex_athena/loop/parallel.ex
+++ b/lib/ex_athena/loop/parallel.ex
@@ -125,15 +125,25 @@ defmodule ExAthena.Loop.Parallel do
 
   defp fold_halt(state, _call_id, _reason), do: state
 
-  # Each task returns its own fresh `state`; we only keep deltas that matter
-  # across concurrent tasks: the budget accumulator. Mistake counter and ctx
-  # phase belong to the sequential path.
+  # Each task returns its own fresh `state`; we keep deltas that matter
+  # across concurrent tasks: the budget accumulator and mistake-counter resets.
+  # Bumps (counter increases) from concurrent tasks are intentionally discarded
+  # to avoid double-counting; resets must propagate so a successful parallel
+  # call doesn't leave a stale elevated counter.
   defp fold_deltas(state, new_state) do
-    case new_state do
-      %{budget: b} when not is_nil(b) -> %{state | budget: b}
-      _ -> state
-    end
+    state
+    |> maybe_update_budget(new_state)
+    |> maybe_propagate_reset(new_state)
   end
+
+  defp maybe_update_budget(state, %{budget: b}) when not is_nil(b), do: %{state | budget: b}
+  defp maybe_update_budget(state, _), do: state
+
+  defp maybe_propagate_reset(state, %{consecutive_mistakes: n})
+       when n < state.consecutive_mistakes,
+       do: %{state | consecutive_mistakes: n}
+
+  defp maybe_propagate_reset(state, _), do: state
 
   # ── Ordering ──────────────────────────────────────────────────────
 

--- a/lib/ex_athena/providers/req_llm.ex
+++ b/lib/ex_athena/providers/req_llm.ex
@@ -207,7 +207,9 @@ defmodule ExAthena.Providers.ReqLLM do
   defp encode_arguments(nil), do: "{}"
   defp encode_arguments(args) when is_binary(args), do: args
   defp encode_arguments(args) when is_map(args), do: Jason.encode!(args)
-  defp encode_arguments(args), do: raise(ArgumentError, "unexpected tool_call arguments type: #{inspect(args)}")
+
+  defp encode_arguments(args),
+    do: raise(ArgumentError, "unexpected tool_call arguments type: #{inspect(args)}")
 
   # ── Options ────────────────────────────────────────────────────────
 

--- a/test/ex_athena/loop/v03_test.exs
+++ b/test/ex_athena/loop/v03_test.exs
@@ -170,7 +170,6 @@ defmodule ExAthena.Loop.V03Test do
         n = :counters.get(counter, 1)
 
         case n do
-          # Turn 1: nonexistent tool — bumps counter to 1
           1 ->
             %Response{
               text: "",
@@ -179,7 +178,6 @@ defmodule ExAthena.Loop.V03Test do
               provider: :mock
             }
 
-          # Turn 2: parallel-safe glob — should reset counter to 0
           2 ->
             %Response{
               text: "",
@@ -190,7 +188,6 @@ defmodule ExAthena.Loop.V03Test do
               provider: :mock
             }
 
-          # Turn 3: nonexistent tool again — bumps to 1 (with fix) or 2 (without fix)
           3 ->
             %Response{
               text: "",
@@ -199,7 +196,6 @@ defmodule ExAthena.Loop.V03Test do
               provider: :mock
             }
 
-          # Turn 4: final response — only reached if counter < max after turn 3
           _ ->
             %Response{text: "done", tool_calls: [], finish_reason: :stop, provider: :mock}
         end

--- a/test/ex_athena/loop/v03_test.exs
+++ b/test/ex_athena/loop/v03_test.exs
@@ -159,6 +159,65 @@ defmodule ExAthena.Loop.V03Test do
                  max_iterations: 10
                )
     end
+
+    test "successful parallel tool call resets the mistake counter", %{dir: dir} do
+      # Glob is parallel_safe? true — its reset_mistakes must propagate back
+      # through fold_deltas to the outer state.
+      counter = :counters.new(1, [:atomics])
+
+      responder = fn _req ->
+        :counters.add(counter, 1, 1)
+        n = :counters.get(counter, 1)
+
+        case n do
+          # Turn 1: nonexistent tool — bumps counter to 1
+          1 ->
+            %Response{
+              text: "",
+              tool_calls: [%ToolCall{id: "c1", name: "nonexistent", arguments: %{}}],
+              finish_reason: :tool_calls,
+              provider: :mock
+            }
+
+          # Turn 2: parallel-safe glob — should reset counter to 0
+          2 ->
+            %Response{
+              text: "",
+              tool_calls: [
+                %ToolCall{id: "c2", name: "glob", arguments: %{"pattern" => "*.txt"}}
+              ],
+              finish_reason: :tool_calls,
+              provider: :mock
+            }
+
+          # Turn 3: nonexistent tool again — bumps to 1 (with fix) or 2 (without fix)
+          3 ->
+            %Response{
+              text: "",
+              tool_calls: [%ToolCall{id: "c3", name: "nonexistent", arguments: %{}}],
+              finish_reason: :tool_calls,
+              provider: :mock
+            }
+
+          # Turn 4: final response — only reached if counter < max after turn 3
+          _ ->
+            %Response{text: "done", tool_calls: [], finish_reason: :stop, provider: :mock}
+        end
+      end
+
+      # With max_consecutive_mistakes: 2:
+      #   Without fix: turn1→1, turn2→stays 1, turn3→2 = max → :error_consecutive_mistakes
+      #   With fix:    turn1→1, turn2→reset 0, turn3→1 < max → continues → :stop
+      assert {:ok, %Result{finish_reason: :stop, text: "done"}} =
+               Loop.run("go",
+                 provider: :mock,
+                 mock: [responder: responder],
+                 cwd: dir,
+                 tools: [ExAthena.Tools.Glob],
+                 max_consecutive_mistakes: 2,
+                 max_iterations: 10
+               )
+    end
   end
 
   describe "parallel tool execution" do

--- a/test/ex_athena/structured_output_test.exs
+++ b/test/ex_athena/structured_output_test.exs
@@ -1,7 +1,10 @@
 defmodule ExAthena.StructuredOutputTest.NoStructuredOutput do
   @behaviour ExAthena.Provider
   def capabilities, do: %{structured_output: false}
-  def query(_req, _opts), do: {:ok, %ExAthena.Response{text: "{}", tool_calls: [], provider: :test}}
+
+  def query(_req, _opts),
+    do: {:ok, %ExAthena.Response{text: "{}", tool_calls: [], provider: :test}}
+
   def stream(_req, _cb, _opts), do: {:ok, %ExAthena.Response{text: ""}}
 end
 


### PR DESCRIPTION
## Summary

Fixes a false-positive `error_consecutive_mistakes` termination that fired during valid tool-calling turns. When a parallel tool call succeeded, the mistake counter reset was silently discarded by `fold_deltas/2`, leaving any previously elevated counter in place. After enough successful-but-stale-counter cycles the loop tripped its threshold and terminated incorrectly.

## Root Cause

`fold_deltas/2` in `ExAthena.Loop.Parallel` only propagated budget updates from completed parallel tasks back to the outer loop state — mistake-counter resets were thrown away entirely. A real mistake earlier in the session could bump the counter to 1 or 2; every subsequent successful parallel tool-call turn would leave that elevated value intact, eventually crossing `max_consecutive_mistakes` and killing the loop.

## Key Changes

- **`lib/ex_athena/loop/parallel.ex`** — Splits the single `fold_deltas/2` clause into two composable helpers:
  - `maybe_update_budget/2` — unchanged behaviour, propagates budget accumulator.
  - `maybe_propagate_reset/2` — propagates a mistake-counter value from a completed task **only if it is lower than the current outer-state value** (i.e. a reset). Counter *increases* from concurrent tasks are still intentionally discarded to prevent double-counting.
- **`test/ex_athena/loop/v03_test.exs`** — Adds a regression test that drives the loop through a sequence of `nonexistent-tool → glob (parallel-safe) → nonexistent-tool` turns and asserts the loop does not terminate with `:error_consecutive_mistakes`; confirms the reset from the successful `glob` call propagates back through `fold_deltas`.
- **`lib/ex_athena/providers/req_llm.ex`** — Cosmetic line-length fix to `encode_arguments/1`; no behaviour change.

## Implementation Detail

The fix is intentionally asymmetric: only resets (counter going *down*) cross the `fold_deltas` boundary. This preserves the existing invariant that parallel tasks cannot inflate the mistake counter relative to each other while ensuring a successful tool execution correctly clears accumulated noise from earlier genuine failures.

Closes https://github.com/udin-io/ex_athena/issues/29