### PR TITLE
feat(lsp): first-class Language Server Protocol integration (definitions, references, diagnostics)

### DIFF
--- a/.artifacts/adr-1-augment-return-type-for-posttooluse-hooks.md
+++ b/.artifacts/adr-1-augment-return-type-for-posttooluse-hooks.md
@@ -1,0 +1,33 @@
+# ADR 1: `{:augment, text}` return type for PostToolUse hooks
+
+**Status:** Accepted
+
+## Context
+
+The parent ticket calls for an implicit-diagnostic signal: after an `Edit`/`Write`, the model should automatically see compiler diagnostics for the modified file in the next turn, without having to call the LSP tool explicitly. Sub-tickets 1 and 2 shipped the LSP plumbing and an explicit tool. This sub-ticket needs a way for a built-in `PostToolUse` hook to push diagnostic text into the `tool` message that the LLM will read on the next turn.
+
+Three options were considered:
+
+1. **Append a separate synthetic message** (e.g. a system or assistant message immediately after the tool result). Adds a second message per edit, breaks the 1:1 mapping between tool call and tool result, and complicates conversation rendering.
+2. **Bypass the hook system entirely** with a dedicated post-edit step in React mode. Conflicts with the parent plan's framing as "a `:PostToolUse` matcher", and prevents users from implementing similar augmentations themselves.
+3. **Extend the hook system to allow result augmentation.** Generic; one mechanism serves both the built-in implicit-diagnostics feature and any future user hook that wants to add context to a tool result. Backward-compatible — adding a new return type doesn't change semantics for hooks that currently return `:ok` or `{:halt, _}`.
+
+## Decision
+
+1. Extend `ExAthena.Hooks.run_post_tool_use/4` to accept a new return value `{:augment, String.t()}` from hook callbacks. Multiple augmenting hooks accumulate by joining with `"\n"` in registration order. `{:halt, _}` still short-circuits. `:deny` is still ignored. `:ok` and unrecognised returns map to no-op.
+2. Update `ExAthena.Modes.ReAct.after_post_hook/3` to apply the augment by rewriting `result.content` (`result.content <> "\n\n" <> extra`). `is_error`, `tool_call_id`, and `ui_payload` pass through unchanged so telemetry, error tracking, and host UI rendering aren't disturbed.
+3. Extend the PostToolUse payload to `%{result: result, arguments: call.arguments, cwd: state.ctx.cwd, tool_name: call.name}`. Adding keys only — backward-compatible with existing hooks that pattern-match on `result`.
+4. Implement the implicit-diagnostics hook as `ExAthena.Lsp.ImplicitDiagnostics.post_tool_use_hook/2` and register it by default in `Loop.start` via `ImplicitDiagnostics.maybe_merge/1`, gated on `:lsp_implicit_diagnostics_enabled`. Prepend (not append) so user-supplied PostToolUse hooks observe the un-augmented `result`.
+
+## Consequences
+
+**Positive:**
+- Single message per tool call — no extra synthetic messages cluttering the conversation.
+- The augment mechanism is reusable: user hooks can attach context (e.g. lint output, build status) to any tool result.
+- LSP diagnostics flow through the same telemetry, error path, and UI hooks as any other tool result.
+- Backward-compatible: existing PostToolUse hooks returning `:ok | {:halt, _}` keep working unchanged.
+
+**Negative:**
+- The `Hooks` return-type contract grows by one variant; documentation in `guides/hooks_reference.md` will need a short addition.
+- A misbehaving augment hook can bloat tool result content; partially mitigated by the severity filter and by `safe_call/3` capturing exceptions.
+- The `cwd` and `arguments` fields in the PostToolUse payload are technically a contract change — hooks that pattern-match exhaustively on the payload map could regress (none in the tree do).

--- a/.artifacts/adr-1-lsp-client-and-per-project-server-manager.md
+++ b/.artifacts/adr-1-lsp-client-and-per-project-server-manager.md
@@ -1,0 +1,123 @@
+# ADR 1: ExAthena.Lsp client and per-project server manager
+
+## Status
+
+Proposed (sub-ticket 1 of 3 for parent issue #27).
+
+## Context
+
+ex_athena agents read code as bytes via `Read`/`Grep`/`Edit`. They have no
+way to ask "where is this symbol defined?" or "what diagnostics does the
+compiler emit for this file?" The Language Server Protocol (LSP) is the
+standard mechanism — every modern IDE and every modern coding agent
+(Cursor, Codex, Copilot, OpenCode) plumbs it.
+
+The parent ticket decomposes into three sub-tickets:
+
+1. JSON-RPC client + per-project server manager (this ADR)
+2. `ExAthena.Tools.Lsp` exposing `definition`/`references`/`diagnostics`/`hover`
+3. `:PostToolUse` hook that surfaces diagnostics after `Edit`/`Write`
+
+This ADR covers the foundation only. The next two sub-tickets will
+consume — but not modify — the surface defined here.
+
+## Decision
+
+### Layered design
+
+Three pure-Elixir modules plus a small supervision subtree:
+
+- `ExAthena.Lsp.Framing` (pure) — `parse/1` over `Content-Length`-prefixed
+  LSP frames. Returns `{decoded_messages, leftover_buffer}` so the client
+  can accumulate partial frames across `{port, {:data, _}}` messages.
+- `ExAthena.Lsp.ServerRegistry` (pure) — extension → language atom;
+  language → `%{binary, args}` spawn spec resolved via
+  `System.find_executable/1`. App-env override: `{:ex_athena, :lsp_servers}`.
+- `ExAthena.Lsp.Client` (`GenServer`) — wraps an stdio `Port`, runs the
+  `initialize`/`initialized` handshake in `handle_continue/2`, multiplexes
+  concurrent `request/4` calls via an `id => GenServer.from()` map,
+  dispatches notifications, and runs the `shutdown`/`exit` handshake on
+  `terminate/2`.
+- `ExAthena.Lsp.Manager` (`GenServer`) — public façade. Lazily spawns one
+  client per `(project_root, language)`, looking up via a `Registry`.
+- `ExAthena.Lsp.Supervisor` (`Supervisor`, `:rest_for_one`) — owns the
+  `Registry`, the `DynamicSupervisor` for clients, and the Manager.
+  Mounted under `ExAthena.Supervisor` behind a `:enable_lsp` flag.
+
+### Choice of `Registry` vs Manager-held map
+
+The `Registry` is the source of truth for "is `(root, lang)` running?".
+Clients register under `{:via, Registry, {ExAthena.Lsp.Registry, {root,
+lang}}}`. This sidesteps a class of races where a client crashes and the
+Manager's local map disagrees with reality. Manager keeps only a small
+`%{monitor_ref => {root, lang}}` for telemetry on `:DOWN`.
+
+### Choice of `DynamicSupervisor` for clients
+
+Clients are restartable. `max_restarts: 3, max_seconds: 60` so a busted
+binary doesn't thrash. Each client is supervised independently — one
+project's broken `pyright` does not take down another project's working
+`elixir-ls`.
+
+### Concurrency model in Client
+
+A single GenServer owns the Port. Multiple callers can `request/4`
+concurrently because each `GenServer.call` blocks its own caller while the
+GenServer dispatches replies asynchronously as JSON-RPC frames arrive.
+This avoids the complexity of a separate reader process.
+
+### Telemetry
+
+- `[:ex_athena, :lsp, :spawn]` (discrete event) with metadata
+  `%{language, root, binary, pid, phase ∈ {:started, :stopped, :crashed}}`.
+- `[:ex_athena, :lsp, :request, :start | :stop | :exception]` via
+  `ExAthena.Telemetry.span/3` with metadata `%{method, language, root}`.
+
+This matches the existing `[:ex_athena, :tool, :start | :stop]` and
+`[:ex_athena, :chat, :start | :stop]` shape, so OTel consumers wire it up
+automatically.
+
+### Missing-binary handling
+
+If `System.find_executable/1` returns `nil`, `spawn_spec/1` returns
+`{:error, :unsupported}` and the Manager surfaces `{:error, {:no_server,
+lang}}` to callers. The Manager never crashes the supervision tree because
+the user lacks `pyright`. Sibling 2 will translate this into actionable
+tool-result text ("install pyright to use the lsp tool on Python files").
+
+### Out of scope for this ADR
+
+- The user-visible `lsp` tool — sibling 2.
+- The `:PostToolUse` diagnostics-injection hook — sibling 3.
+- Permission-mode integration (read-only signal under `:plan` mode) — lives
+  with the tool in sibling 2, since the tool is the boundary.
+- Workspace-wide symbol search, code actions, rename — parent v1 cuts.
+
+## Consequences
+
+**Positive:**
+
+- A clean, restartable, observable LSP layer that siblings 2 and 3 can
+  call without further infrastructure work.
+- Pure-module split (`Framing`, `ServerRegistry`) makes the bulk of the
+  test surface fast and deterministic.
+- `Registry` + via-tuples eliminate a class of "manager state disagrees
+  with reality" bugs.
+- Existing telemetry conventions are preserved end-to-end.
+
+**Negative / trade-offs:**
+
+- A user without any LSP server installed sees `{:error, {:no_server, _}}`
+  errors when sibling 2 lands. Mitigation: sibling 2's tool result will
+  carry installation hints.
+- Stderr from servers goes to the BEAM tty in v1 (we don't split it). If
+  a shipped server proves chatty in practice we'll wrap it in a small `sh
+  -c` redirect shim. Documented in the moduledoc.
+- One Port per `(root, language)` — fine for the few-projects case, but
+  long-running ex_athena processes could accumulate clients. Sibling 2 or
+  a future ticket may add idle eviction; out of scope here.
+
+**Neutral:**
+
+- No new dependencies. `Jason`, `:telemetry`, `Registry`, and
+  `DynamicSupervisor` are already in the project.

--- a/.artifacts/adr-1-lsp-tool-action-dispatch-and-readonly-classification.md
+++ b/.artifacts/adr-1-lsp-tool-action-dispatch-and-readonly-classification.md
@@ -1,0 +1,40 @@
+# ADR: `ExAthena.Tools.Lsp` action dispatch and read-only classification
+
+## Status
+
+Proposed
+
+## Context
+
+Sub-ticket 1 of the LSP feature shipped the JSON-RPC client and per-`{root, language}` manager. We now need to expose four LSP capabilities to the model — `definition`, `references`, `hover`, and `diagnostics`. Several design questions surface:
+
+1. **Tool granularity.** One tool with an `action` argument, or four separate tools (`lsp_definition`, `lsp_references`, …)?
+2. **Permission classification.** LSP queries are read-only on the LSP wire (no `workspace/applyEdit`), but the tool does perform side effects: it can spawn an LSP server process and send `textDocument/didOpen` notifications. Should it be allowed in `:plan` mode?
+3. **`textDocument/didOpen` strategy.** Track open files in the Client GenServer (state) and only `didOpen` once, or re-`didOpen` on every tool call?
+4. **Diagnostics protocol.** Push (`publishDiagnostics`, LSP 3.0+) or pull (`textDocument/diagnostic`, LSP 3.17)?
+
+## Decision
+
+1. **One tool, four actions.** `ExAthena.Tools.Lsp` dispatches on `args["action"] ∈ {definition, references, hover, diagnostics}`. Mirrors `ExAthena.Tools.PlanMode`'s `enter`/`exit` pattern and OpenCode's `lsp` tool. Avoids polluting the registry and the system prompt with four near-identical schema entries.
+
+2. **Read-only.** `parallel_safe?/0` returns `true`; `"lsp"` is appended to `ExAthena.Permissions.@readonly_tools`. Spawning an LSP server is a process-level side effect, but no source files are touched and no shell is invoked. The closest analog already in the readonly set is `web_fetch`, which opens an HTTP connection — also a side effect, also classified read-only. Allowing under `:plan` is required for the tool to be useful at exploration time, which is the primary value proposition.
+
+3. **`didOpen` per call.** The tool reads the file from disk and sends `textDocument/didOpen` before every position-based request. Servers in the default matrix (elixir-ls, pyright, gopls, rust-analyzer, typescript-language-server) all tolerate re-open by overwriting the buffer. This is exactly the desired semantics after an `Edit`/`Write`. The alternative — tracking open files in Client state with `didChange` + version increments — is more wire-efficient but adds significant Client complexity and stateful test surface; defer to v2 if telemetry shows the extra writes matter.
+
+4. **Push diagnostics, polled.** `diagnostics` action sends `didOpen`, then polls `Client.diagnostics/2` (which reads the cached push notifications from `textDocument/publishDiagnostics`) every 50 ms for up to 1500 ms. Returns whatever the server has published, including the empty list. Pull-mode (LSP 3.17 `textDocument/diagnostic`) is deferred — the entire default-server matrix supports push, and adding pull as a fallback is a future optimization, not a v1 requirement.
+
+## Consequences
+
+**Positive**
+
+- Single registry entry, single compact-schema line — minimal model-prompt footprint.
+- Allowed under `:plan` mode without callback consultation, so exploratory agent loops can use it freely.
+- No Client API extensions needed; ST1 stays untouched.
+- `didOpen` re-send naturally absorbs file edits between calls — the server always sees fresh contents.
+
+**Negative**
+
+- Re-sending full file contents on every call is wasteful for large files. Acceptable for v1; revisit if telemetry shows `didOpen` payload bytes dominate request latency.
+- 1500 ms diagnostics poll is a fixed budget; very slow servers (rust-analyzer warming up on a large workspace) may return empty when they shouldn't. Mitigation: ST3's `:PostToolUse` hook will own its own retry strategy and can extend the budget.
+- Push-only diagnostics means some future LSP servers that only support pull will return empty for the diagnostics action. Documented in the tool's moduledoc.
+- Action dispatch in a single tool means a typo in `action` returns `{:error, :invalid_action}` instead of "unknown tool" — slightly less ergonomic for the model. Mitigated by the `enum` in `schema/0` (native-tool-call providers will reject invalid values pre-execute).

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,3 @@
+import Config
+
+import_config "#{config_env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,1 @@
+import Config

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,1 @@
+import Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,9 @@
+import Config
+
+# Disable LSP supervisor during tests so individual test cases can start
+# their own isolated supervision trees via start_supervised!/1.
+config :ex_athena, enable_lsp: false
+
+# Disable sweepers that are not needed during tests.
+config :ex_athena, enable_worktree_sweeper: false
+config :ex_athena, enable_checkpoint_sweeper: false

--- a/config/test.exs
+++ b/config/test.exs
@@ -7,3 +7,7 @@ config :ex_athena, enable_lsp: false
 # Disable sweepers that are not needed during tests.
 config :ex_athena, enable_worktree_sweeper: false
 config :ex_athena, enable_checkpoint_sweeper: false
+
+# Disable implicit LSP diagnostics hook globally in tests so existing tests
+# are not affected. Individual ImplicitDiagnostics tests opt back in.
+config :ex_athena, lsp_implicit_diagnostics_enabled: false

--- a/guides/hooks_reference.md
+++ b/guides/hooks_reference.md
@@ -1,4 +1,4 @@
-# Hooks reference (v0.4)
+# Hooks reference (v0.5)
 
 Hooks are functions ex_athena calls at lifecycle events so hosts can
 observe, deny, halt, or augment the run without subclassing the loop
@@ -34,6 +34,7 @@ returns one of:
 | `{:deny, reason}` | Only valid from `PreToolUse` / `PermissionRequest`. Denies the tool call; routed back to the model as an error tool-result. |
 | `{:inject, msg_or_msgs}` | Append a `Message.t()` (or list) to the conversation. |
 | `{:transform, prompt}` | Only valid from `UserPromptSubmit`. Rewrites the user's prompt before it enters the loop. |
+| `{:augment, text}` | Only valid from `PostToolUse`. Appends `text` to the tool-result content the model sees on the next turn. Multiple augments are joined with `"\n"`. Halt takes priority. |
 
 ## Catalog
 
@@ -64,7 +65,7 @@ context just before a provider call.
 | Event | Fires at | Payload |
 |---|---|---|
 | `:PreToolUse` | Before tool execution. Honours `{:deny, reason}`. | `%{tool_name, tool_use_id, ...args}` |
-| `:PostToolUse` | After successful execution. Halt-only (deny is too late). | `%{tool_name, tool_use_id, result}` |
+| `:PostToolUse` | After successful execution. Supports `{:augment, text}` (deny is too late). | `%{tool_name, result, arguments, cwd}` |
 | `:PostToolUseFailure` | After tool returns `{:error, reason}` | `%{tool_name, tool_use_id, reason}` |
 | `:PermissionRequest` | Before `can_use_tool` callback (when `:default` mode prompts) | `%{tool_name, tool_use_id, arguments}` |
 | `:PermissionDenied` | Whenever the gate decides `{:deny, _}` | `%{tool_name, tool_use_id, arguments, reason}` |
@@ -183,6 +184,66 @@ outputs for callers that need them:
 `run_lifecycle/3` returns `:ok | {:halt, reason}` for backward-compat;
 use the `_with_outputs` variant when you need to read injects /
 transform.
+
+
+## Implicit LSP diagnostics (PostToolUse)
+
+When the model edits or writes a file, ex_athena automatically runs an LSP
+diagnostic check and appends any errors or warnings to the tool-result the
+model sees on the next turn. This is powered by
+`ExAthena.Lsp.ImplicitDiagnostics`, which registers a built-in PostToolUse
+hook matching `Edit|Write`.
+
+No configuration is needed when `elixir-ls` (or another LSP server) is on
+`$PATH` — the hook fires automatically on every Edit/Write call.
+
+### Seeing diagnostics in practice
+
+The augmented tool-result looks like:
+
+```
+edited foo.ex (1 replacement)
+
+[lsp diagnostics]
+error: undefined function bar/0 at foo.ex:3:1
+```
+
+The model reads both the edit confirmation and the compiler feedback in a
+single turn, without needing to call the `lsp` tool explicitly.
+
+### Configuration
+
+| Key | Default | Description |
+|---|---|---|
+| `:lsp_implicit_diagnostics_enabled` | `true` | Set to `false` to disable the hook globally (e.g. in test.exs). |
+| `:lsp_implicit_diagnostics_timeout_ms` | `1500` | How long to poll for push-diagnostics before giving up. |
+| `:lsp_implicit_diagnostics_severities` | `[:error, :warning]` | Severity levels to include. Options: `:error`, `:warning`, `:information`, `:hint`. |
+
+Example — disable in tests:
+
+```elixir
+# config/test.exs
+config :ex_athena, lsp_implicit_diagnostics_enabled: false
+```
+
+Example — extend to information-level messages:
+
+```elixir
+config :ex_athena, lsp_implicit_diagnostics_severities: [:error, :warning, :information]
+```
+
+### Telemetry
+
+The hook emits `[:ex_athena, :lsp, :implicit_diagnostics, :start | :stop]`
+events. The `:stop` measurements include:
+
+| Field | Type | Description |
+|---|---|---|
+| `duration_ms` | integer | Wall-clock time in ms |
+| `count` | integer | Number of diagnostics in the augmented text |
+| `had_errors` | boolean | `true` when at least one error-severity diagnostic was found |
+
+The `:stop` metadata includes `tool_name` (the triggering tool).
 
 ## See also
 

--- a/lib/ex_athena/application.ex
+++ b/lib/ex_athena/application.ex
@@ -37,6 +37,12 @@ defmodule ExAthena.Application do
 
     # Always supervise the in-memory store — it's used by tests and the
     # default Session config. Cheap to keep around (a single ETS table).
-    children ++ [ExAthena.Sessions.Stores.InMemory]
+    children = children ++ [ExAthena.Sessions.Stores.InMemory]
+
+    if Application.get_env(:ex_athena, :enable_lsp, true) do
+      children ++ [ExAthena.Lsp.Supervisor]
+    else
+      children
+    end
   end
 end

--- a/lib/ex_athena/hooks.ex
+++ b/lib/ex_athena/hooks.ex
@@ -21,6 +21,9 @@ defmodule ExAthena.Hooks do
       `experimental.chat.system.transform`-style context injection.
     * `{:transform, new_prompt}` — only valid from `UserPromptSubmit`;
       rewrites the incoming user prompt before it enters the loop.
+    * `{:augment, text}` — only valid from `PostToolUse`; appends `text`
+      to the tool result content visible to the model on the next turn.
+      Multiple augments from different hooks are joined with `"\\n"`.
 
   Hooks are matched by `:matcher` (regex run against `tool_name`); a `nil`
   matcher or a missing `:matcher` key fires for every tool. Lifecycle-only
@@ -87,13 +90,25 @@ defmodule ExAthena.Hooks do
     run_tool_phase(hooks[:PreToolUse] || [], tool_name, input, tool_use_id)
   end
 
-  @doc "Fire `PostToolUse` hooks matching `tool_name`."
-  @spec run_post_tool_use(t(), String.t(), map(), String.t() | nil) :: :ok | {:halt, term()}
+  @doc """
+  Fire `PostToolUse` hooks matching `tool_name`.
+
+  Returns:
+    * `:ok` — all hooks returned `:ok` (or ignored returns).
+    * `{:halt, term()}` — a hook requested a hard stop; no further hooks run.
+    * `{:augment, String.t()}` — one or more hooks returned `{:augment, text}`;
+      multiple augments are joined with `"\\n"`. `:halt` takes priority over any
+      accumulated augment text.
+  """
+  @spec run_post_tool_use(t(), String.t(), map(), String.t() | nil) ::
+          :ok | {:halt, term()} | {:augment, String.t()}
   def run_post_tool_use(hooks, tool_name, result, tool_use_id) do
     groups = hooks[:PostToolUse] || []
-    # PostToolUse denies are ignored (too late) — only :halt is honoured.
-    case run_tool_phase(groups, tool_name, result, tool_use_id) do
+
+    case run_tool_phase_post(groups, tool_name, result, tool_use_id) do
       {:halt, _} = halt -> halt
+      {:augment, ""} -> :ok
+      {:augment, text} when is_binary(text) -> {:augment, text}
       _ -> :ok
     end
   end
@@ -151,6 +166,7 @@ defmodule ExAthena.Hooks do
     end)
   end
 
+  # Pre-tool phase: supports :deny and :halt; ignores :augment.
   defp run_tool_phase(groups, tool_name, input, tool_use_id) do
     groups
     |> Enum.flat_map(fn
@@ -166,6 +182,33 @@ defmodule ExAthena.Hooks do
         {:deny, _} = deny -> {:halt, deny}
         {:halt, _} = halt -> {:halt, halt}
         _ -> {:cont, :ok}
+      end
+    end)
+  end
+
+  # Post-tool phase: ignores :deny; accumulates :augment texts; :halt wins.
+  defp run_tool_phase_post(groups, tool_name, input, tool_use_id) do
+    fns =
+      Enum.flat_map(groups, fn
+        %{hooks: fns} = group when is_list(fns) ->
+          matcher = Map.get(group, :matcher)
+          if matches?(matcher, tool_name), do: fns, else: []
+
+        fun when is_function(fun, 2) ->
+          [fun]
+      end)
+
+    Enum.reduce_while(fns, {:augment, ""}, fn fun, {:augment, acc_text} ->
+      case safe_call(fun, Map.put_new(input, :tool_name, tool_name), tool_use_id) do
+        {:halt, _} = halt ->
+          {:halt, halt}
+
+        {:augment, text} when is_binary(text) ->
+          joined = if acc_text == "", do: text, else: acc_text <> "\n" <> text
+          {:cont, {:augment, joined}}
+
+        _ ->
+          {:cont, {:augment, acc_text}}
       end
     end)
   end

--- a/lib/ex_athena/loop.ex
+++ b/lib/ex_athena/loop.ex
@@ -76,6 +76,7 @@ defmodule ExAthena.Loop do
 
   alias ExAthena.{Budget, Config, Error, Memory, Request, Result, Skills, Telemetry, Tools}
   alias ExAthena.Loop.{Events, Mode, State}
+  alias ExAthena.Lsp.ImplicitDiagnostics
 
   @default_max_iterations 25
   @default_max_mistakes 3
@@ -436,7 +437,7 @@ defmodule ExAthena.Loop do
         provider_opts: Config.provider_opts(provider_mod, opts),
         request_template: request_template,
         permissions_opts: permissions_opts,
-        hooks: Keyword.get(opts, :hooks, %{}),
+        hooks: Keyword.get(opts, :hooks, %{}) |> ImplicitDiagnostics.maybe_merge(),
         ctx: ctx,
         on_event: Keyword.get(opts, :on_event),
         budget: Budget.new(),

--- a/lib/ex_athena/lsp.ex
+++ b/lib/ex_athena/lsp.ex
@@ -1,0 +1,38 @@
+defmodule ExAthena.Lsp do
+  @moduledoc """
+  Public facade for the LSP subsystem.
+
+  Delegates to `ExAthena.Lsp.Manager` for client lifecycle operations and
+  `ExAthena.Lsp.Client` for per-session operations.
+
+  ## Architecture
+
+      ExAthena.Supervisor
+      └── ExAthena.Lsp.Supervisor (:rest_for_one)
+          ├── Registry (ExAthena.Lsp.Registry)
+          ├── DynamicSupervisor (ExAthena.Lsp.ClientSupervisor)
+          └── ExAthena.Lsp.Manager
+                  └─ spawns ExAthena.Lsp.Client (one per project_root × language)
+
+  ## Usage
+
+      # Get (or spawn) a client for a specific file:
+      {:ok, pid} = ExAthena.Lsp.client_for_file(File.cwd!(), "lib/my_app.ex")
+
+      # Make a JSON-RPC request:
+      {:ok, result} = ExAthena.Lsp.Client.request(pid, "textDocument/hover", params)
+
+  ## Telemetry
+
+  * `[:ex_athena, :lsp, :spawn]` — emitted on client start/stop/crash.
+  * `[:ex_athena, :lsp, :request, :start | :stop]` — emitted around each
+    JSON-RPC request/response cycle.
+  """
+
+  alias ExAthena.Lsp.Manager
+
+  defdelegate ensure_started(project_root, language), to: Manager
+  defdelegate client_for_file(project_root, file), to: Manager
+  defdelegate stop(project_root, language), to: Manager
+  defdelegate list(), to: Manager
+end

--- a/lib/ex_athena/lsp.ex
+++ b/lib/ex_athena/lsp.ex
@@ -24,7 +24,10 @@ defmodule ExAthena.Lsp do
 
   ## Telemetry
 
-  * `[:ex_athena, :lsp, :spawn]` — emitted on client start/stop/crash.
+  * `[:ex_athena, :lsp, :spawn]` — emitted on client start/stop/crash
+    (exactly once per phase, from the Client itself).
+  * `[:ex_athena, :lsp, :client_supervised, :down]` — emitted by the Manager
+    when a supervised client process exits, with `%{language, root, pid, reason}`.
   * `[:ex_athena, :lsp, :request, :start | :stop]` — emitted around each
     JSON-RPC request/response cycle.
   """

--- a/lib/ex_athena/lsp/client.ex
+++ b/lib/ex_athena/lsp/client.ex
@@ -21,6 +21,8 @@ defmodule ExAthena.Lsp.Client do
   * `[:ex_athena, :lsp, :spawn]` — discrete event with
     `%{system_time: ...}` measurements and
     `%{language: atom, root: binary, binary: binary, pid: pid, phase: :started | :stopped | :crashed}` metadata.
+    Emitted exactly once per phase transition. `:crashed` is emitted only from
+    `terminate/2`; the port `:exit_status` handler does not double-emit.
   * `[:ex_athena, :lsp, :request, :start | :stop]` — span around each
     JSON-RPC request/response cycle, metadata
     `%{method: binary, language: atom, root: binary}`.
@@ -119,7 +121,7 @@ defmodule ExAthena.Lsp.Client do
     state = %{
       port: port,
       buffer: "",
-      # %{id => {from, method}}
+      # %{id => {from, method, timer_ref}}
       pending: %{},
       next_id: 1,
       diagnostics: %{},
@@ -208,19 +210,10 @@ defmodule ExAthena.Lsp.Client do
   end
 
   def handle_info({port, {:exit_status, status}}, %{port: port} = state) do
-    Telemetry.event(
-      [:ex_athena, :lsp, :spawn],
-      %{system_time: System.system_time()},
-      %{
-        language: state.language,
-        root: state.root,
-        binary: state.binary,
-        pid: self(),
-        phase: :crashed
-      }
-    )
-
-    for {_id, {from, _method}} <- state.pending do
+    # `:crashed` telemetry is emitted from terminate/2 (which fires for every
+    # death, including this stop). Don't double-emit here.
+    for {_id, {from, _method, timer_ref}} <- state.pending do
+      cancel_deadline_timer(timer_ref)
       GenServer.reply(from, {:error, {:lsp_port_exit, status}})
     end
 
@@ -229,6 +222,21 @@ defmodule ExAthena.Lsp.Client do
     end
 
     {:stop, {:lsp_port_exit, status}, state}
+  end
+
+  def handle_info({:request_deadline, id}, state) do
+    case pop_in(state, [:pending, id]) do
+      {nil, state} ->
+        {:noreply, state}
+
+      {{from, _method, _timer_ref}, state} ->
+        GenServer.reply(from, {:error, :timeout})
+        {:noreply, state}
+    end
+  end
+
+  def handle_info({:lsp_init_failed, err}, state) do
+    {:stop, {:lsp_init_failed, err}, state}
   end
 
   def handle_info(_msg, state), do: {:noreply, state}
@@ -280,9 +288,25 @@ defmodule ExAthena.Lsp.Client do
     flush_queued_requests(state)
   end
 
+  # Initialize error response — fail every queued caller and stop the GenServer.
+  # Without this clause, an `initialize` error would fall through to the catch-all
+  # and queued requests would hang until their caller-side timeout.
+  defp handle_message(%{"id" => id, "error" => err}, %{init_request_id: id} = state)
+       when not is_nil(id) do
+    Logger.error("[ExAthena.Lsp.Client] LSP initialize failed: #{inspect(err)}")
+
+    for {from, _method, _params, _timeout} <- state.queued_requests do
+      GenServer.reply(from, {:error, {:lsp_init_failed, err}})
+    end
+
+    send(self(), {:lsp_init_failed, err})
+    %{state | queued_requests: [], init_request_id: nil}
+  end
+
   # Response to one of our requests.
   defp handle_message(%{"id" => id} = msg, state) when is_map_key(state.pending, id) do
-    {{from, method}, state} = pop_in(state, [:pending, id])
+    {{from, method, timer_ref}, state} = pop_in(state, [:pending, id])
+    cancel_deadline_timer(timer_ref)
 
     Telemetry.event(
       [:ex_athena, :lsp, :request, :stop],
@@ -336,7 +360,7 @@ defmodule ExAthena.Lsp.Client do
 
   # --- request helpers ---
 
-  defp dispatch_request(state, method, params, _timeout, from) do
+  defp dispatch_request(state, method, params, timeout, from) do
     {id, state} = next_id(state)
 
     Telemetry.event(
@@ -345,10 +369,18 @@ defmodule ExAthena.Lsp.Client do
       %{method: method, language: state.language, root: state.root}
     )
 
-    state = put_in(state, [:pending, id], {from, method})
+    timer_ref = Process.send_after(self(), {:request_deadline, id}, timeout)
+    state = put_in(state, [:pending, id], {from, method, timer_ref})
     send_request(state.port, id, method, params)
     state
   end
+
+  defp cancel_deadline_timer(timer_ref) when is_reference(timer_ref) do
+    Process.cancel_timer(timer_ref)
+    :ok
+  end
+
+  defp cancel_deadline_timer(_), do: :ok
 
   defp flush_queued_requests(state) do
     queued = Enum.reverse(state.queued_requests)

--- a/lib/ex_athena/lsp/client.ex
+++ b/lib/ex_athena/lsp/client.ex
@@ -1,0 +1,432 @@
+defmodule ExAthena.Lsp.Client do
+  @moduledoc """
+  GenServer wrapping a stdio `Port` that speaks JSON-RPC 2.0 (LSP framing).
+
+  ## Lifecycle
+
+  1. `start_link/1` opens the OS process port and sends the LSP `initialize`
+     request via `handle_continue/2`. The GenServer is immediately callable —
+     requests received before initialization completes are queued and replayed
+     once `initialized` is confirmed.
+  2. `request/4` sends a JSON-RPC request and awaits the reply (default 30 s).
+     Multiple concurrent callers are safe — replies are correlated by `id`.
+  3. `notify/3` sends a one-way notification (no reply expected).
+  4. `diagnostics/2` returns cached `textDocument/publishDiagnostics` payloads
+     for a given URI (populated by push notifications from the server).
+  5. `stop/2` sends the LSP `shutdown` + `exit` sequence, then waits for the
+     port to close.
+
+  ## Telemetry
+
+  * `[:ex_athena, :lsp, :spawn]` — discrete event with
+    `%{system_time: ...}` measurements and
+    `%{language: atom, root: binary, binary: binary, pid: pid, phase: :started | :stopped | :crashed}` metadata.
+  * `[:ex_athena, :lsp, :request, :start | :stop]` — span around each
+    JSON-RPC request/response cycle, metadata
+    `%{method: binary, language: atom, root: binary}`.
+
+  ## Assumptions
+
+  LSP servers must not interleave non-JSON-RPC bytes in stdout in normal
+  operation. Servers should use `--log-file` flags to avoid mixing stderr
+  with the JSON-RPC stream.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias ExAthena.Lsp.Framing
+  alias ExAthena.Telemetry
+
+  @default_request_timeout 30_000
+  @shutdown_wait_ms 1_000
+
+  # --- public API ---
+
+  @doc """
+  Start a client for the given LSP server.
+
+  Options:
+    * `:binary` (required) — absolute path to the server executable.
+    * `:args` (required) — list of additional CLI args.
+    * `:root_uri` (required) — `file:///abs/path` workspace root.
+    * `:root` (required) — plain filesystem root path (for telemetry/registry).
+    * `:language` (required) — language atom (for telemetry).
+    * `:name` (optional) — GenServer name (via-tuple for Registry).
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    {name_opts, init_opts} =
+      case Keyword.pop(opts, :name) do
+        {nil, rest} -> {[], rest}
+        {name, rest} -> {[name: name], rest}
+      end
+
+    GenServer.start_link(__MODULE__, init_opts, name_opts)
+  end
+
+  @doc """
+  Send a JSON-RPC request and await the response.
+
+  Returns `{:ok, result}` or `{:error, reason}`. On timeout returns
+  `{:error, :timeout}`.
+  """
+  @spec request(pid(), String.t(), map(), non_neg_integer()) ::
+          {:ok, term()} | {:error, term()}
+  def request(pid, method, params \\ %{}, timeout \\ @default_request_timeout) do
+    try do
+      GenServer.call(pid, {:request, method, params, timeout}, timeout + 5_000)
+    catch
+      :exit, {:timeout, _} -> {:error, :timeout}
+    end
+  end
+
+  @doc "Send a JSON-RPC notification (no reply)."
+  @spec notify(pid(), String.t(), map()) :: :ok
+  def notify(pid, method, params \\ %{}) do
+    GenServer.cast(pid, {:notify, method, params})
+  end
+
+  @doc "Return cached diagnostics for the given `uri`."
+  @spec diagnostics(pid(), String.t()) :: [map()]
+  def diagnostics(pid, uri) do
+    GenServer.call(pid, {:diagnostics, uri})
+  end
+
+  @doc "Initiate a graceful LSP shutdown and wait up to `timeout` ms."
+  @spec stop(pid(), non_neg_integer()) :: :ok
+  def stop(pid, timeout \\ @default_request_timeout) do
+    try do
+      GenServer.call(pid, :stop, timeout + 5_000)
+    catch
+      :exit, _ -> :ok
+    end
+  end
+
+  # --- GenServer callbacks ---
+
+  @impl true
+  def init(opts) do
+    binary = Keyword.fetch!(opts, :binary)
+    args = Keyword.fetch!(opts, :args)
+    root_uri = Keyword.fetch!(opts, :root_uri)
+    root = Keyword.fetch!(opts, :root)
+    language = Keyword.fetch!(opts, :language)
+
+    port = open_port(binary, args, root)
+
+    state = %{
+      port: port,
+      buffer: "",
+      # %{id => {from, method}}
+      pending: %{},
+      next_id: 1,
+      diagnostics: %{},
+      capabilities: %{},
+      root_uri: root_uri,
+      root: root,
+      language: language,
+      binary: binary,
+      # id of the in-flight initialize request; nil after handshake
+      init_request_id: nil,
+      initialized: false,
+      # [{from, method, params, timeout}] collected before handshake
+      queued_requests: [],
+      shutting_down: false
+    }
+
+    Telemetry.event(
+      [:ex_athena, :lsp, :spawn],
+      %{system_time: System.system_time()},
+      %{language: language, root: root, binary: binary, pid: self(), phase: :started}
+    )
+
+    {:ok, state, {:continue, :initialize}}
+  end
+
+  @impl true
+  def handle_continue(:initialize, state) do
+    {id, state} = next_id(state)
+
+    params = %{
+      "processId" => System.pid() |> String.to_integer(),
+      "rootUri" => state.root_uri,
+      "rootPath" => state.root,
+      "capabilities" => %{
+        "textDocument" => %{
+          "publishDiagnostics" => %{"relatedInformation" => true}
+        },
+        "workspace" => %{"workspaceFolders" => true}
+      },
+      "clientInfo" => %{"name" => "ex_athena", "version" => "0.5.0"},
+      "initializationOptions" => %{}
+    }
+
+    send_request(state.port, id, "initialize", params)
+    {:noreply, %{state | init_request_id: id}}
+  end
+
+  @impl true
+  def handle_call({:request, method, params, timeout}, from, state) do
+    if state.initialized do
+      state = dispatch_request(state, method, params, timeout, from)
+      {:noreply, state}
+    else
+      queued = [{from, method, params, timeout} | state.queued_requests]
+      {:noreply, %{state | queued_requests: queued}}
+    end
+  end
+
+  def handle_call({:diagnostics, uri}, _from, state) do
+    {:reply, Map.get(state.diagnostics, uri, []), state}
+  end
+
+  def handle_call(:stop, _from, state) do
+    if state.shutting_down do
+      {:reply, :ok, state}
+    else
+      state = %{state | shutting_down: true}
+      run_shutdown(state)
+      {:stop, :normal, :ok, state}
+    end
+  end
+
+  @impl true
+  def handle_cast({:notify, method, params}, state) do
+    send_notification(state.port, method, params)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({port, {:data, data}}, %{port: port} = state) do
+    new_buffer = state.buffer <> data
+    {frames, leftover} = Framing.parse(new_buffer)
+    state = %{state | buffer: leftover}
+    state = Enum.reduce(frames, state, &dispatch_frame/2)
+    {:noreply, state}
+  end
+
+  def handle_info({port, {:exit_status, status}}, %{port: port} = state) do
+    Telemetry.event(
+      [:ex_athena, :lsp, :spawn],
+      %{system_time: System.system_time()},
+      %{
+        language: state.language,
+        root: state.root,
+        binary: state.binary,
+        pid: self(),
+        phase: :crashed
+      }
+    )
+
+    for {_id, {from, _method}} <- state.pending do
+      GenServer.reply(from, {:error, {:lsp_port_exit, status}})
+    end
+
+    for {from, _method, _params, _timeout} <- state.queued_requests do
+      GenServer.reply(from, {:error, {:lsp_port_exit, status}})
+    end
+
+    {:stop, {:lsp_port_exit, status}, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  @impl true
+  def terminate(reason, state) do
+    # run_shutdown is a no-op if shutting_down is already true
+    # (stop/2 already ran it) or if the port is already dead.
+    unless state.shutting_down do
+      run_shutdown(state)
+    end
+
+    phase = if reason in [:normal, :shutdown], do: :stopped, else: :crashed
+
+    Telemetry.event(
+      [:ex_athena, :lsp, :spawn],
+      %{system_time: System.system_time()},
+      %{
+        language: state.language,
+        root: state.root,
+        binary: state.binary,
+        pid: self(),
+        phase: phase
+      }
+    )
+
+    :ok
+  end
+
+  # --- frame dispatch ---
+
+  defp dispatch_frame(body, state) do
+    case Jason.decode(body) do
+      {:ok, msg} ->
+        handle_message(msg, state)
+
+      {:error, _} ->
+        Logger.warning("[ExAthena.Lsp.Client] invalid JSON frame dropped: #{inspect(body)}")
+        state
+    end
+  end
+
+  # Initialize response — completes the handshake.
+  defp handle_message(%{"id" => id, "result" => result}, %{init_request_id: id} = state)
+       when not is_nil(id) do
+    caps = (result || %{}) |> Map.get("capabilities", %{})
+    state = %{state | capabilities: caps, init_request_id: nil, initialized: true}
+    send_notification(state.port, "initialized", %{})
+    flush_queued_requests(state)
+  end
+
+  # Response to one of our requests.
+  defp handle_message(%{"id" => id} = msg, state) when is_map_key(state.pending, id) do
+    {{from, method}, state} = pop_in(state, [:pending, id])
+
+    Telemetry.event(
+      [:ex_athena, :lsp, :request, :stop],
+      %{system_time: System.system_time()},
+      %{method: method, language: state.language, root: state.root}
+    )
+
+    reply =
+      cond do
+        Map.has_key?(msg, "result") -> {:ok, msg["result"]}
+        Map.has_key?(msg, "error") -> {:error, msg["error"]}
+        true -> {:error, :malformed_response}
+      end
+
+    GenServer.reply(from, reply)
+    state
+  end
+
+  # Server-initiated request — reply with MethodNotFound.
+  defp handle_message(%{"method" => _method, "id" => id}, state) do
+    error =
+      Jason.encode!(%{
+        "jsonrpc" => "2.0",
+        "id" => id,
+        "error" => %{"code" => -32601, "message" => "MethodNotFound"}
+      })
+
+    send_raw(state.port, error)
+    state
+  end
+
+  # Notification.
+  defp handle_message(%{"method" => method} = msg, state) do
+    handle_notification(method, Map.get(msg, "params", %{}), state)
+  end
+
+  defp handle_message(_msg, state), do: state
+
+  defp handle_notification("textDocument/publishDiagnostics", params, state) do
+    uri = Map.get(params, "uri", "")
+    diags = Map.get(params, "diagnostics", [])
+    %{state | diagnostics: Map.put(state.diagnostics, uri, diags)}
+  end
+
+  defp handle_notification("window/logMessage", params, state) do
+    Logger.debug("[LSP:#{state.language}] #{Map.get(params, "message", "")}")
+    state
+  end
+
+  defp handle_notification(_method, _params, state), do: state
+
+  # --- request helpers ---
+
+  defp dispatch_request(state, method, params, _timeout, from) do
+    {id, state} = next_id(state)
+
+    Telemetry.event(
+      [:ex_athena, :lsp, :request, :start],
+      %{system_time: System.system_time()},
+      %{method: method, language: state.language, root: state.root}
+    )
+
+    state = put_in(state, [:pending, id], {from, method})
+    send_request(state.port, id, method, params)
+    state
+  end
+
+  defp flush_queued_requests(state) do
+    queued = Enum.reverse(state.queued_requests)
+    state = %{state | queued_requests: []}
+
+    Enum.reduce(queued, state, fn {from, method, params, timeout}, acc ->
+      dispatch_request(acc, method, params, timeout, from)
+    end)
+  end
+
+  # --- port helpers ---
+
+  defp open_port(binary, args, root) do
+    Port.open({:spawn_executable, binary}, [
+      :binary,
+      :exit_status,
+      args: args,
+      cd: root
+    ])
+  end
+
+  defp send_request(port, id, method, params) do
+    msg =
+      Jason.encode!(%{
+        "jsonrpc" => "2.0",
+        "id" => id,
+        "method" => method,
+        "params" => params
+      })
+
+    send_raw(port, msg)
+  end
+
+  defp send_notification(port, method, params) do
+    msg =
+      Jason.encode!(%{
+        "jsonrpc" => "2.0",
+        "method" => method,
+        "params" => params
+      })
+
+    send_raw(port, msg)
+  end
+
+  defp send_raw(port, json) do
+    frame = "Content-Length: #{byte_size(json)}\r\n\r\n#{json}"
+
+    try do
+      Port.command(port, frame)
+    rescue
+      ArgumentError -> :error
+    end
+  end
+
+  defp next_id(%{next_id: id} = state), do: {id, %{state | next_id: id + 1}}
+
+  defp run_shutdown(state) do
+    {id, _state} = next_id(state)
+    send_request(state.port, id, "shutdown", %{})
+
+    receive do
+      {port, {:data, _}} when port == state.port -> :ok
+      {port, {:exit_status, _}} when port == state.port -> :ok
+    after
+      @shutdown_wait_ms -> :ok
+    end
+
+    send_notification(state.port, "exit", %{})
+
+    receive do
+      {port, {:exit_status, _}} when port == state.port -> :ok
+    after
+      @shutdown_wait_ms ->
+        try do
+          Port.close(state.port)
+        rescue
+          ArgumentError -> :ok
+        end
+    end
+  end
+end

--- a/lib/ex_athena/lsp/framing.ex
+++ b/lib/ex_athena/lsp/framing.ex
@@ -1,0 +1,126 @@
+defmodule ExAthena.Lsp.Framing do
+  @moduledoc """
+  Pure decoder for LSP's `Content-Length`-prefixed JSON-RPC framing.
+
+  The wire format is:
+
+      Content-Length: <N>\\r\\n
+      [Content-Type: ...]\\r\\n
+      \\r\\n
+      <N bytes of JSON>
+
+  `parse/1` returns all complete frame bodies found in the buffer (as raw
+  binaries — callers are responsible for `Jason.decode!/1`) and the
+  unconsumed tail. Garbage bytes before the first `Content-Length:` token
+  are dropped with a warning; this keeps the stream live if the server
+  emits a startup banner before its first LSP frame.
+  """
+
+  require Logger
+
+  @doc """
+  Parse one or more LSP frames from `buffer`.
+
+  Returns `{bodies, remainder}` where `bodies` is a list of raw JSON
+  binaries (in order) and `remainder` is whatever bytes follow the last
+  complete frame.
+  """
+  @spec parse(binary()) :: {[binary()], binary()}
+  def parse(buffer) when is_binary(buffer) do
+    parse_frames(buffer, [])
+  end
+
+  # --- private ---
+
+  defp parse_frames(buf, acc) do
+    case find_content_length(buf) do
+      :not_found ->
+        {Enum.reverse(acc), buf}
+
+      {:ok, length, rest_after_headers} ->
+        case rest_after_headers do
+          <<body::binary-size(length), remainder::binary>> ->
+            parse_frames(remainder, [body | acc])
+
+          _incomplete ->
+            {Enum.reverse(acc), buf}
+        end
+
+      {:garbage, stripped} ->
+        parse_frames(stripped, acc)
+    end
+  end
+
+  # Scan `buf` for "Content-Length: <n>\r\n" (or LF-only).
+  # Returns:
+  #   {:ok, length, rest_after_blank_line}
+  #   :not_found
+  #   {:garbage, buf_starting_at_content_length}
+  defp find_content_length(buf) do
+    case :binary.match(buf, "Content-Length:") do
+      :nomatch ->
+        :not_found
+
+      {0, _} ->
+        extract_length_and_body(buf)
+
+      {offset, _} ->
+        # Bytes before Content-Length are garbage — drop them and warn.
+        garbage = binary_part(buf, 0, offset)
+
+        Logger.warning(
+          "[ExAthena.Lsp] dropped #{offset} garbage bytes before LSP frame: #{inspect(garbage)}"
+        )
+
+        {:garbage, binary_part(buf, offset, byte_size(buf) - offset)}
+    end
+  end
+
+  defp extract_length_and_body(buf) do
+    # Find end of headers — blank line separates headers from body.
+    # Support both \r\n\r\n and \n\n separators.
+    with {:ok, length, after_first_header} <- parse_content_length_line(buf),
+         {:ok, body_start} <- find_header_end(after_first_header) do
+      rest =
+        binary_part(after_first_header, body_start, byte_size(after_first_header) - body_start)
+
+      {:ok, length, rest}
+    else
+      _ -> :not_found
+    end
+  end
+
+  defp parse_content_length_line(buf) do
+    # Match "Content-Length: <digits>\r\n" or "Content-Length: <digits>\n"
+    case Regex.run(~r/\AContent-Length:\s*(\d+)\r?\n/, buf, return: :index) do
+      nil ->
+        :error
+
+      [{_start, match_len}, {digits_start, digits_len}] ->
+        length = buf |> binary_part(digits_start, digits_len) |> String.to_integer()
+        rest = binary_part(buf, match_len, byte_size(buf) - match_len)
+        {:ok, length, rest}
+    end
+  end
+
+  # After the Content-Length header, there may be more headers before the
+  # blank line. Skip them and return the offset where the body begins.
+  defp find_header_end(buf) do
+    cond do
+      # Already at blank line
+      String.starts_with?(buf, "\r\n") -> {:ok, 2}
+      String.starts_with?(buf, "\n") -> {:ok, 1}
+      true -> skip_extra_headers(buf)
+    end
+  end
+
+  defp skip_extra_headers(buf) do
+    case Regex.run(~r/\r?\n\r?\n/, buf, return: :index) do
+      nil ->
+        :error
+
+      [{start, len}] ->
+        {:ok, start + len}
+    end
+  end
+end

--- a/lib/ex_athena/lsp/implicit_diagnostics.ex
+++ b/lib/ex_athena/lsp/implicit_diagnostics.ex
@@ -1,0 +1,219 @@
+defmodule ExAthena.Lsp.ImplicitDiagnostics do
+  @moduledoc """
+  PostToolUse hook that automatically fetches LSP diagnostics after Edit/Write
+  tool calls and injects any errors or warnings into the next turn's tool-result.
+
+  When the model edits a file, the hook:
+
+    1. Resolves the file path from the tool call's `arguments["path"]`.
+    2. Looks up (or spawns) the language server for the file's extension.
+    3. Sends `textDocument/didOpen` with the current file contents.
+    4. Polls `publishDiagnostics` push-notifications for up to
+       `:lsp_implicit_diagnostics_timeout_ms` (default 1500 ms).
+    5. Filters to `:lsp_implicit_diagnostics_severities` (default `[:error, :warning]`).
+    6. Returns `{:augment, text}` with a `[lsp diagnostics]` block, or
+       `:ok` if there is nothing to report.
+
+  All failure paths (LSP disabled, unsupported file type, server crash, timeout)
+  collapse to `:ok` — the hook must never stall the agent loop.
+
+  ## Configuration keys
+
+    * `:lsp_implicit_diagnostics_enabled` — boolean, default `true`
+    * `:lsp_implicit_diagnostics_timeout_ms` — poll deadline in ms, default `1500`
+    * `:lsp_implicit_diagnostics_severities` — list of `:error | :warning |
+      :information | :hint`, default `[:error, :warning]`
+  """
+
+  alias ExAthena.Lsp.{Client, Manager, ServerRegistry}
+  alias ExAthena.Tools.Lsp, as: LspTool
+
+  @default_timeout_ms 1_500
+  @default_severities [:error, :warning]
+  @poll_interval_ms 50
+
+  @severity_atoms %{1 => :error, 2 => :warning, 3 => :information, 4 => :hint}
+
+  @doc """
+  PostToolUse hook function. Receives the payload map and tool_use_id.
+
+  Returns `{:augment, text}` when LSP diagnostics are available, otherwise `:ok`.
+  Emits `[:ex_athena, :lsp, :implicit_diagnostics, :start | :stop]` telemetry events.
+  """
+  @spec post_tool_use_hook(map(), String.t() | nil) :: :ok | {:augment, String.t()}
+  def post_tool_use_hook(payload, _tool_use_id) do
+    tool_name = Map.get(payload, :tool_name, "unknown")
+    meta = %{tool_name: tool_name}
+    start_time = System.monotonic_time()
+
+    :telemetry.execute(
+      [:ex_athena, :lsp, :implicit_diagnostics, :start],
+      %{system_time: System.system_time()},
+      meta
+    )
+
+    result = run(payload)
+
+    duration_native = System.monotonic_time() - start_time
+    duration_ms = System.convert_time_unit(duration_native, :native, :millisecond)
+
+    :telemetry.execute(
+      [:ex_athena, :lsp, :implicit_diagnostics, :stop],
+      %{
+        duration_ms: duration_ms,
+        duration_native: duration_native,
+        count: count_from(result),
+        had_errors: had_errors?(result)
+      },
+      meta
+    )
+
+    result
+  end
+
+  @doc "Default hook entry to merge into Loop.start's hooks map."
+  @spec default_hooks_entry() :: map()
+  def default_hooks_entry do
+    %{matcher: "^(Edit|Write)$", hooks: [&__MODULE__.post_tool_use_hook/2]}
+  end
+
+  @doc """
+  Merge the default implicit-diagnostics hook into a user-supplied hooks map.
+
+  When `:lsp_implicit_diagnostics_enabled` is false (the default in tests),
+  returns `hooks` unchanged. Otherwise prepends the built-in entry to the
+  `:PostToolUse` list so user-supplied hooks still run after it.
+  """
+  @spec maybe_merge(ExAthena.Hooks.t()) :: ExAthena.Hooks.t()
+  def maybe_merge(hooks) do
+    if enabled?() do
+      existing = Map.get(hooks, :PostToolUse, [])
+      Map.put(hooks, :PostToolUse, [default_hooks_entry() | existing])
+    else
+      hooks
+    end
+  end
+
+  # --- private ---
+
+  defp run(payload) do
+    with true <- enabled?(),
+         {:ok, abs_path} <- file_from_payload(payload),
+         :ok <- has_language?(abs_path),
+         {:ok, pid} <- client_for_file(payload, abs_path),
+         :ok <- LspTool.ensure_did_open(pid, abs_path),
+         diags when diags != [] <- await_diagnostics(pid, abs_path),
+         filtered when filtered != [] <- filter_severities(diags) do
+      {:augment, format(filtered, abs_path, Map.get(payload, :cwd, ""))}
+    else
+      _ -> :ok
+    end
+  end
+
+  defp enabled? do
+    Application.get_env(:ex_athena, :lsp_implicit_diagnostics_enabled, true) == true
+  end
+
+  defp file_from_payload(%{arguments: args, cwd: cwd}) when is_map(args) do
+    case Map.get(args, "path") do
+      nil ->
+        :skip
+
+      rel_or_abs ->
+        abs =
+          if Path.type(rel_or_abs) == :absolute,
+            do: rel_or_abs,
+            else: Path.expand(rel_or_abs, cwd || ".")
+
+        {:ok, abs}
+    end
+  end
+
+  defp file_from_payload(_), do: :skip
+
+  defp has_language?(abs_path) do
+    case ServerRegistry.language_for_path(abs_path) do
+      nil -> :skip
+      _lang -> :ok
+    end
+  end
+
+  defp client_for_file(%{cwd: cwd}, abs_path) when is_binary(cwd) do
+    try do
+      Manager.client_for_file(cwd, abs_path)
+    catch
+      :exit, _ -> {:error, :manager_unavailable}
+    end
+  end
+
+  defp client_for_file(_, _), do: {:error, :no_cwd}
+
+  defp await_diagnostics(pid, abs_path) do
+    timeout_ms =
+      Application.get_env(
+        :ex_athena,
+        :lsp_implicit_diagnostics_timeout_ms,
+        @default_timeout_ms
+      )
+
+    uri = "file://" <> abs_path
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_poll(pid, uri, deadline)
+  end
+
+  defp do_poll(pid, uri, deadline) do
+    case Client.diagnostics(pid, uri) do
+      [] ->
+        remaining = deadline - System.monotonic_time(:millisecond)
+
+        if remaining > 0 do
+          Process.sleep(min(@poll_interval_ms, remaining))
+          do_poll(pid, uri, deadline)
+        else
+          []
+        end
+
+      diags ->
+        diags
+    end
+  end
+
+  defp filter_severities(diags) do
+    allowed =
+      Application.get_env(
+        :ex_athena,
+        :lsp_implicit_diagnostics_severities,
+        @default_severities
+      )
+
+    Enum.filter(diags, fn d ->
+      atom = Map.get(@severity_atoms, d["severity"])
+      atom in allowed
+    end)
+  end
+
+  defp format(diags, abs_path, cwd) do
+    rel = if cwd != "", do: Path.relative_to(abs_path, cwd), else: abs_path
+
+    lines =
+      Enum.map(diags, fn d ->
+        sev = Map.get(@severity_atoms, d["severity"], :unknown)
+        msg = d["message"] || ""
+        start = get_in(d, ["range", "start"]) || %{}
+        line = (start["line"] || 0) + 1
+        col = (start["character"] || 0) + 1
+        "#{sev}: #{msg} at #{rel}:#{line}:#{col}"
+      end)
+
+    "[lsp diagnostics]\n" <> Enum.join(lines, "\n")
+  end
+
+  defp count_from({:augment, text}) do
+    text |> String.split("\n") |> Enum.count(&(&1 =~ ~r/^(error|warning|information|hint):/))
+  end
+
+  defp count_from(:ok), do: 0
+
+  defp had_errors?({:augment, text}), do: text =~ "error:"
+  defp had_errors?(:ok), do: false
+end

--- a/lib/ex_athena/lsp/implicit_diagnostics.ex
+++ b/lib/ex_athena/lsp/implicit_diagnostics.ex
@@ -25,6 +25,8 @@ defmodule ExAthena.Lsp.ImplicitDiagnostics do
       :information | :hint`, default `[:error, :warning]`
   """
 
+  require Logger
+
   alias ExAthena.Lsp.{Client, Manager, ServerRegistry}
   alias ExAthena.Tools.Lsp, as: LspTool
 
@@ -97,18 +99,68 @@ defmodule ExAthena.Lsp.ImplicitDiagnostics do
   # --- private ---
 
   defp run(payload) do
-    with true <- enabled?(),
-         {:ok, abs_path} <- file_from_payload(payload),
-         :ok <- has_language?(abs_path),
-         {:ok, pid} <- client_for_file(payload, abs_path),
-         :ok <- LspTool.ensure_did_open(pid, abs_path),
-         diags when diags != [] <- await_diagnostics(pid, abs_path),
-         filtered when filtered != [] <- filter_severities(diags) do
+    with true <- enabled?() || log_skip(:disabled),
+         {:ok, abs_path} <- file_from_payload(payload) |> log_step(:no_path),
+         :ok <- has_language?(abs_path) |> log_step(:unsupported_language, abs_path),
+         {:ok, pid} <- client_for_file(payload, abs_path) |> log_step(:no_client, abs_path),
+         :ok <- LspTool.ensure_did_open(pid, abs_path) |> log_step(:did_open_failed, abs_path),
+         diags when diags != [] <-
+           await_diagnostics(pid, abs_path) |> log_no_diags(abs_path),
+         filtered when filtered != [] <-
+           filter_severities(diags) |> log_filtered_out(abs_path) do
       {:augment, format(filtered, abs_path, Map.get(payload, :cwd, ""))}
     else
       _ -> :ok
     end
   end
+
+  # --- failure-mode logging helpers ---
+  # Each helper passes through its argument unchanged so the `with` chain is
+  # unaffected; a Logger.debug fires on the failure paths so operators can
+  # diagnose why diagnostics never appeared.
+
+  defp log_skip(:disabled) do
+    Logger.debug("[ExAthena.Lsp.ImplicitDiagnostics] skipped: lsp disabled")
+    false
+  end
+
+  defp log_step({:ok, _} = ok, _reason), do: ok
+
+  defp log_step(other, reason) do
+    Logger.debug("[ExAthena.Lsp.ImplicitDiagnostics] skipped: #{reason} (#{inspect(other)})")
+    other
+  end
+
+  defp log_step({:ok, _} = ok, _reason, _ctx), do: ok
+  defp log_step(:ok, _reason, _ctx), do: :ok
+
+  defp log_step(other, reason, ctx) do
+    Logger.debug(
+      "[ExAthena.Lsp.ImplicitDiagnostics] skipped: #{reason} for #{ctx} (#{inspect(other)})"
+    )
+
+    other
+  end
+
+  defp log_no_diags([], abs_path) do
+    Logger.debug(
+      "[ExAthena.Lsp.ImplicitDiagnostics] no diagnostics within timeout for #{abs_path}"
+    )
+
+    []
+  end
+
+  defp log_no_diags(diags, _abs_path), do: diags
+
+  defp log_filtered_out([], abs_path) do
+    Logger.debug(
+      "[ExAthena.Lsp.ImplicitDiagnostics] all diagnostics filtered by severity for #{abs_path}"
+    )
+
+    []
+  end
+
+  defp log_filtered_out(diags, _abs_path), do: diags
 
   defp enabled? do
     Application.get_env(:ex_athena, :lsp_implicit_diagnostics_enabled, true) == true
@@ -214,6 +266,6 @@ defmodule ExAthena.Lsp.ImplicitDiagnostics do
 
   defp count_from(:ok), do: 0
 
-  defp had_errors?({:augment, text}), do: text =~ "error:"
+  defp had_errors?({:augment, text}), do: text =~ ~r/^error:/m
   defp had_errors?(:ok), do: false
 end

--- a/lib/ex_athena/lsp/manager.ex
+++ b/lib/ex_athena/lsp/manager.ex
@@ -1,0 +1,176 @@
+defmodule ExAthena.Lsp.Manager do
+  @moduledoc """
+  Manages one `ExAthena.Lsp.Client` per `{project_root, language}` pair.
+
+  Clients are lazily spawned under `ExAthena.Lsp.ClientSupervisor` and
+  registered in `ExAthena.Lsp.Registry` — the registry is the source of
+  truth for "is this client running?", not Manager state.
+
+  Manager state holds only a `%{monitor_ref => {root, language}}` map for
+  crash telemetry; pids are always looked up from the Registry.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias ExAthena.Lsp.{Client, ServerRegistry}
+  alias ExAthena.Telemetry
+
+  # --- public API ---
+
+  @doc """
+  Return `{:ok, pid}` for the LSP client serving `(project_root, language)`,
+  spawning one if none is running yet.
+  """
+  @spec ensure_started(String.t(), atom()) :: {:ok, pid()} | {:error, term()}
+  def ensure_started(project_root, language) do
+    GenServer.call(__MODULE__, {:ensure_started, project_root, language})
+  end
+
+  @doc """
+  Return `{:ok, pid}` for the LSP client that handles files with the
+  extension of `file`, or `{:error, :unsupported_language}` if the
+  extension is not mapped.
+  """
+  @spec client_for_file(String.t(), String.t()) ::
+          {:ok, pid()} | {:error, :unsupported_language | term()}
+  def client_for_file(project_root, file) do
+    case ServerRegistry.language_for_path(file) do
+      nil -> {:error, :unsupported_language}
+      language -> ensure_started(project_root, language)
+    end
+  end
+
+  @doc "Terminate the client for `(project_root, language)` if one is running."
+  @spec stop(String.t(), atom()) :: :ok
+  def stop(project_root, language) do
+    GenServer.call(__MODULE__, {:stop, project_root, language})
+  end
+
+  @doc "Return a list of all running clients."
+  @spec list() :: [%{root: String.t(), language: atom(), pid: pid()}]
+  def list do
+    GenServer.call(__MODULE__, :list)
+  end
+
+  # --- GenServer ---
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @impl true
+  def init(:ok) do
+    {:ok, %{monitors: %{}}}
+  end
+
+  @impl true
+  def handle_call({:ensure_started, root, language}, _from, state) do
+    case lookup(root, language) do
+      {:ok, pid} ->
+        {:reply, {:ok, pid}, state}
+
+      :not_found ->
+        case do_start(root, language) do
+          {:ok, pid} ->
+            ref = Process.monitor(pid)
+            state = put_in(state, [:monitors, ref], {root, language})
+            {:reply, {:ok, pid}, state}
+
+          {:error, _} = err ->
+            {:reply, err, state}
+        end
+    end
+  end
+
+  def handle_call({:stop, root, language}, _from, state) do
+    case lookup(root, language) do
+      {:ok, pid} ->
+        DynamicSupervisor.terminate_child(ExAthena.Lsp.ClientSupervisor, pid)
+        {:reply, :ok, state}
+
+      :not_found ->
+        {:reply, :ok, state}
+    end
+  end
+
+  def handle_call(:list, _from, state) do
+    entries =
+      Registry.select(ExAthena.Lsp.Registry, [{{:"$1", :"$2", :_}, [], [{{:"$1", :"$2"}}]}])
+      |> Enum.map(fn {{root, language}, pid} ->
+        %{root: root, language: language, pid: pid}
+      end)
+
+    {:reply, entries, state}
+  end
+
+  @impl true
+  def handle_info({:DOWN, ref, :process, _pid, reason}, state) do
+    case Map.pop(state.monitors, ref) do
+      {nil, _} ->
+        {:noreply, state}
+
+      {{root, language}, monitors} ->
+        phase = if reason == :normal, do: :stopped, else: :crashed
+
+        Telemetry.event(
+          [:ex_athena, :lsp, :spawn],
+          %{system_time: System.system_time()},
+          %{language: language, root: root, binary: "", pid: self(), phase: phase}
+        )
+
+        Logger.info(
+          "[ExAthena.Lsp.Manager] client for {#{root}, #{language}} exited: #{inspect(reason)}"
+        )
+
+        {:noreply, %{state | monitors: monitors}}
+    end
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  # --- private ---
+
+  defp lookup(root, language) do
+    case Registry.lookup(ExAthena.Lsp.Registry, {root, language}) do
+      [{pid, _}] -> {:ok, pid}
+      [] -> :not_found
+    end
+  end
+
+  defp via(root, language) do
+    {:via, Registry, {ExAthena.Lsp.Registry, {root, language}}}
+  end
+
+  defp do_start(root, language) do
+    case ServerRegistry.spawn_spec(language) do
+      {:error, :unsupported} ->
+        {:error, {:no_server, language}}
+
+      {:ok, %{binary: binary, args: args}} ->
+        child_spec = %{
+          id: {Client, root, language},
+          start:
+            {Client, :start_link,
+             [
+               [
+                 binary: binary,
+                 args: args,
+                 root_uri: "file://#{root}",
+                 root: root,
+                 language: language,
+                 name: via(root, language)
+               ]
+             ]},
+          restart: :transient
+        }
+
+        case DynamicSupervisor.start_child(ExAthena.Lsp.ClientSupervisor, child_spec) do
+          {:ok, pid} -> {:ok, pid}
+          {:error, {:already_started, pid}} -> {:ok, pid}
+          {:error, reason} -> {:error, reason}
+        end
+    end
+  end
+end

--- a/lib/ex_athena/lsp/manager.ex
+++ b/lib/ex_athena/lsp/manager.ex
@@ -106,18 +106,19 @@ defmodule ExAthena.Lsp.Manager do
   end
 
   @impl true
-  def handle_info({:DOWN, ref, :process, _pid, reason}, state) do
+  def handle_info({:DOWN, ref, :process, pid, reason}, state) do
     case Map.pop(state.monitors, ref) do
       {nil, _} ->
         {:noreply, state}
 
       {{root, language}, monitors} ->
-        phase = if reason == :normal, do: :stopped, else: :crashed
-
+        # Use a distinct event name from the Client's own `:spawn` telemetry —
+        # the Client already emits `[:ex_athena, :lsp, :spawn]` from terminate/2,
+        # so consumers would otherwise count crashes twice.
         Telemetry.event(
-          [:ex_athena, :lsp, :spawn],
+          [:ex_athena, :lsp, :client_supervised, :down],
           %{system_time: System.system_time()},
-          %{language: language, root: root, binary: "", pid: self(), phase: phase}
+          %{language: language, root: root, pid: pid, reason: reason}
         )
 
         Logger.info(

--- a/lib/ex_athena/lsp/server_registry.ex
+++ b/lib/ex_athena/lsp/server_registry.ex
@@ -1,0 +1,87 @@
+defmodule ExAthena.Lsp.ServerRegistry do
+  @moduledoc """
+  Maps file extensions to language atoms and language atoms to LSP server
+  spawn specifications.
+
+  ## Language detection
+
+  `language_for_path/1` inspects the file extension and returns a language
+  atom, or `nil` for unknown types.
+
+  ## Spawn specs
+
+  `spawn_spec/1` resolves the server binary via `System.find_executable/1`
+  (injectable for tests via the optional second argument) and returns
+  `{:ok, %{binary: path, args: [...]}}` or `{:error, :unsupported}`.
+
+  ## Application-env override
+
+  Set `Application.put_env(:ex_athena, :lsp_servers, overrides)` where
+  `overrides` is a map of `language_atom => %{binary: path, args: [...]}`
+  to replace or disable default servers without editing source. Overridden
+  specs skip `find_executable` lookup — the binary path is used as-is.
+  """
+
+  @extension_map %{
+    ".ex" => :elixir,
+    ".exs" => :elixir,
+    ".py" => :python,
+    ".pyi" => :python,
+    ".rs" => :rust,
+    ".go" => :go,
+    ".ts" => :typescript,
+    ".tsx" => :typescript,
+    ".js" => :typescript,
+    ".jsx" => :typescript,
+    ".mjs" => :typescript,
+    ".cjs" => :typescript
+  }
+
+  # Default server definitions: {executable_name, default_args}
+  @default_servers %{
+    elixir: {"elixir-ls", []},
+    python: {"pyright-langserver", ["--stdio"]},
+    rust: {"rust-analyzer", []},
+    go: {"gopls", ["serve"]},
+    typescript: {"typescript-language-server", ["--stdio"]}
+  }
+
+  @doc """
+  Return the language atom for the given file path based on its extension,
+  or `nil` if the extension is not recognized.
+  """
+  @spec language_for_path(Path.t()) :: atom() | nil
+  def language_for_path(path) do
+    ext = path |> Path.extname() |> String.downcase()
+    Map.get(@extension_map, ext)
+  end
+
+  @doc """
+  Return the spawn spec for `language`, resolving the binary via
+  `find_executable` (defaults to `System.find_executable/1`).
+
+  Returns `{:ok, %{binary: path, args: [...]}}` or `{:error, :unsupported}`.
+  """
+  @spec spawn_spec(atom(), (String.t() -> String.t() | nil)) ::
+          {:ok, %{binary: String.t(), args: [String.t()]}} | {:error, :unsupported}
+  def spawn_spec(language, find_executable \\ &System.find_executable/1) do
+    overrides = Application.get_env(:ex_athena, :lsp_servers, %{})
+
+    cond do
+      Map.has_key?(overrides, language) ->
+        spec = Map.fetch!(overrides, language)
+        {:ok, spec}
+
+      Map.has_key?(@default_servers, language) ->
+        {executable, args} = Map.fetch!(@default_servers, language)
+
+        case find_executable.(executable) do
+          nil -> {:error, :unsupported}
+          path -> {:ok, %{binary: path, args: args}}
+        end
+
+      true ->
+        {:error, :unsupported}
+    end
+  end
+end

--- a/lib/ex_athena/lsp/supervisor.ex
+++ b/lib/ex_athena/lsp/supervisor.ex
@@ -1,0 +1,39 @@
+defmodule ExAthena.Lsp.Supervisor do
+  @moduledoc """
+  Top-level supervisor for the LSP subsystem.
+
+  Starts three children in `:rest_for_one` order:
+
+  1. `Registry` (unique, named `ExAthena.Lsp.Registry`) — clients register
+     under `{root, language}` via-tuples so the Manager can look them up
+     without holding a mutable pid map.
+  2. `DynamicSupervisor` (named `ExAthena.Lsp.ClientSupervisor`) — owns
+     client lifecycle; restarts failed clients up to 3 times per 60 s.
+  3. `ExAthena.Lsp.Manager` — the public façade for spawning and locating
+     clients.
+
+  Enabled by default; set `config :ex_athena, enable_lsp: false` to skip
+  (used in test config so individual tests opt in via `start_supervised!/1`).
+  """
+
+  use Supervisor
+
+  def start_link(_opts) do
+    Supervisor.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @impl true
+  def init(:ok) do
+    children = [
+      {Registry, keys: :unique, name: ExAthena.Lsp.Registry},
+      {DynamicSupervisor,
+       name: ExAthena.Lsp.ClientSupervisor,
+       strategy: :one_for_one,
+       max_restarts: 3,
+       max_seconds: 60},
+      ExAthena.Lsp.Manager
+    ]
+
+    Supervisor.init(children, strategy: :rest_for_one)
+  end
+end

--- a/lib/ex_athena/modes/react.ex
+++ b/lib/ex_athena/modes/react.ex
@@ -250,10 +250,28 @@ defmodule ExAthena.Modes.ReAct do
   end
 
   # Run PostToolUse hooks then emit events.
+  # The payload includes `arguments` and `cwd` so hooks like
+  # ImplicitDiagnostics can resolve the affected file.
   defp after_post_hook(state, call, result) do
-    case ExAthena.Hooks.run_post_tool_use(state.hooks, call.name, %{result: result}, call.id) do
-      {:halt, reason} -> {{:halt, reason}, state}
-      _ -> emit_and_return(state, call, result)
+    payload = %{
+      result: result,
+      arguments: call.arguments,
+      cwd: state.ctx.cwd,
+      tool_name: call.name
+    }
+
+    case ExAthena.Hooks.run_post_tool_use(state.hooks, call.name, payload, call.id) do
+      {:halt, reason} ->
+        {{:halt, reason}, state}
+
+      {:augment, extra} ->
+        [tr | rest] = result.tool_results
+        augmented_tr = %{tr | content: tr.content <> "\n\n" <> extra}
+        augmented = %{result | tool_results: [augmented_tr | rest]}
+        emit_and_return(state, call, augmented)
+
+      _ ->
+        emit_and_return(state, call, result)
     end
   end
 

--- a/lib/ex_athena/permissions.ex
+++ b/lib/ex_athena/permissions.ex
@@ -58,7 +58,7 @@ defmodule ExAthena.Permissions do
   alias ExAthena.Messages.ToolCall
   alias ExAthena.ToolContext
 
-  @readonly_tools ~w(read glob grep web_fetch plan_mode spawn_agent)
+  @readonly_tools ~w(read glob grep web_fetch plan_mode spawn_agent lsp)
   @mutating_tools ~w(write edit bash todo_write)
   # `:accept_edits` auto-allows file edits + every read-only tool,
   # but still falls through to the callback for everything else

--- a/lib/ex_athena/tools.ex
+++ b/lib/ex_athena/tools.ex
@@ -28,7 +28,8 @@ defmodule ExAthena.Tools do
     ExAthena.Tools.WebFetch,
     ExAthena.Tools.TodoWrite,
     ExAthena.Tools.PlanMode,
-    ExAthena.Tools.SpawnAgent
+    ExAthena.Tools.SpawnAgent,
+    ExAthena.Tools.Lsp
   ]
 
   @doc "List the builtin tool modules."

--- a/lib/ex_athena/tools/lsp.ex
+++ b/lib/ex_athena/tools/lsp.ex
@@ -1,0 +1,322 @@
+defmodule ExAthena.Tools.Lsp do
+  @moduledoc """
+  Built-in tool that exposes Language Server Protocol queries to the model.
+
+  Dispatches four LSP actions — `definition`, `references`, `hover`,
+  `diagnostics` — by delegating to the running `ExAthena.Lsp.Client` for the
+  file's language, managed by `ExAthena.Lsp.Manager`.
+
+  Before every position-based request the tool sends `textDocument/didOpen`
+  so the server has an up-to-date buffer. Repeated `didOpen` calls are
+  tolerated by LSP servers — they re-sync the buffer.
+
+  The `diagnostics` action reads push-cached diagnostics
+  (`textDocument/publishDiagnostics` notifications stored by the client).
+  It polls every 50 ms up to `@diagnostics_poll_ms` (default 1 500 ms,
+  overridable via `config :ex_athena, :lsp_diagnostics_poll_ms, ms`).
+  Servers that only support the LSP 3.17 pull protocol return an empty list —
+  this is a valid result, not an error.
+
+  ## Compact schema line
+
+      lsp(action: string, file: string, line?: integer, character?: integer, include_declaration?: boolean) — Query LSP for definition / references / hover / diagnostics.
+
+  ## Position params
+
+  `line` and `character` are **0-indexed** (LSP wire format). The `read`
+  tool returns 1-indexed line prefixes — subtract 1 before passing here.
+
+  ## Return shape
+
+  `{:ok, formatted_string, ui_payload}` on success.
+
+  `formatted_string` per action:
+    * `definition` — `path:line:col` entries joined by newline.
+    * `references` — count header + one `path:line:col` per line.
+    * `hover` — stripped markdown value string.
+    * `diagnostics` — `<severity>: <message> at :<line>:<col>` per line,
+      or `"count: 0"` when none.
+
+  `ui_payload` — `%{kind: :lsp, payload: %{action: atom, file: path, results: list}}`.
+
+  ## Errors
+
+    * `{:error, :missing_action}` — `"action"` key absent.
+    * `{:error, :invalid_action}` — unrecognised action string.
+    * `{:error, :missing_file}` — `"file"` key absent.
+    * `{:error, :missing_position}` — `line`/`character` absent for position actions.
+    * `{:error, :unsupported_language}` — no LSP server for the file's extension.
+    * `{:error, {:lsp_error, map}}` — server replied with a JSON-RPC error object.
+    * `{:error, :timeout}` — LSP request exceeded the default 30 s timeout.
+    * `{:error, {:lsp_port_exit, status}}` — server process died mid-flight.
+  """
+
+  @behaviour ExAthena.Tool
+
+  alias ExAthena.Lsp.{Client, Manager}
+  alias ExAthena.ToolContext
+
+  @diagnostics_poll_ms 1_500
+  @diagnostics_poll_interval_ms 50
+
+  @impl true
+  def name, do: "lsp"
+
+  @impl true
+  def description,
+    do: "Query the language server for definition, references, hover, or diagnostics."
+
+  @impl true
+  def parallel_safe?, do: true
+
+  @impl true
+  def schema do
+    %{
+      type: "object",
+      properties: %{
+        action: %{
+          type: "string",
+          enum: ["definition", "references", "hover", "diagnostics"],
+          description: "LSP action to perform"
+        },
+        file: %{
+          type: "string",
+          description: "absolute path or path relative to cwd"
+        },
+        line: %{
+          type: "integer",
+          description: "0-indexed line (required for definition/references/hover)"
+        },
+        character: %{
+          type: "integer",
+          description: "0-indexed UTF-16 column (required for definition/references/hover)"
+        },
+        include_declaration: %{
+          type: "boolean",
+          description: "for `references`: include the declaration site (default: true)"
+        }
+      },
+      required: ["action", "file"]
+    }
+  end
+
+  @impl true
+  def execute(args, %ToolContext{} = ctx) do
+    with {:ok, action} <- fetch_action(args),
+         {:ok, abs_path} <- fetch_file(args, ctx),
+         {:ok, pid} <- Manager.client_for_file(ctx.cwd, abs_path),
+         :ok <- ensure_did_open(pid, abs_path),
+         {:ok, raw} <- dispatch(action, pid, abs_path, args) do
+      {:ok, format(action, raw, abs_path), ui(action, abs_path, raw)}
+    end
+  end
+
+  # --- action fetch ---
+
+  defp fetch_action(%{"action" => "definition"}), do: {:ok, :definition}
+  defp fetch_action(%{"action" => "references"}), do: {:ok, :references}
+  defp fetch_action(%{"action" => "hover"}), do: {:ok, :hover}
+  defp fetch_action(%{"action" => "diagnostics"}), do: {:ok, :diagnostics}
+  defp fetch_action(%{"action" => _}), do: {:error, :invalid_action}
+  defp fetch_action(_), do: {:error, :missing_action}
+
+  defp fetch_file(%{"file" => file}, ctx), do: ToolContext.resolve_path(ctx, file)
+  defp fetch_file(_, _), do: {:error, :missing_file}
+
+  # --- didOpen ---
+
+  @doc false
+  def ensure_did_open(pid, abs_path) do
+    case File.read(abs_path) do
+      {:ok, contents} ->
+        Client.notify(pid, "textDocument/didOpen", %{
+          "textDocument" => %{
+            "uri" => "file://" <> abs_path,
+            "languageId" => language_id(abs_path),
+            "version" => 1,
+            "text" => contents
+          }
+        })
+
+        :ok
+
+      {:error, reason} ->
+        {:error, {:file_read_error, reason}}
+    end
+  end
+
+  # --- dispatch ---
+
+  defp dispatch(:definition, pid, abs_path, args) do
+    with {:ok, pos} <- require_position(args) do
+      pid
+      |> Client.request("textDocument/definition", text_document_position(abs_path, pos))
+      |> wrap_lsp_result()
+    end
+  end
+
+  defp dispatch(:references, pid, abs_path, args) do
+    with {:ok, pos} <- require_position(args) do
+      include_declaration = Map.get(args, "include_declaration", true)
+
+      params =
+        Map.merge(text_document_position(abs_path, pos), %{
+          "context" => %{"includeDeclaration" => include_declaration}
+        })
+
+      pid
+      |> Client.request("textDocument/references", params)
+      |> wrap_lsp_result()
+    end
+  end
+
+  defp dispatch(:hover, pid, abs_path, args) do
+    with {:ok, pos} <- require_position(args) do
+      pid
+      |> Client.request("textDocument/hover", text_document_position(abs_path, pos))
+      |> wrap_lsp_result()
+    end
+  end
+
+  defp dispatch(:diagnostics, pid, abs_path, _args) do
+    uri = "file://" <> abs_path
+    {:ok, poll_diagnostics(pid, uri)}
+  end
+
+  # Wraps a JSON-RPC error map into {:error, {:lsp_error, map}}.
+  defp wrap_lsp_result({:ok, result}), do: {:ok, result}
+
+  defp wrap_lsp_result({:error, %{"code" => _, "message" => _} = err}),
+    do: {:error, {:lsp_error, err}}
+
+  defp wrap_lsp_result({:error, reason}), do: {:error, reason}
+
+  # --- diagnostics polling ---
+
+  defp poll_diagnostics(pid, uri) do
+    poll_ms = Application.get_env(:ex_athena, :lsp_diagnostics_poll_ms, @diagnostics_poll_ms)
+    deadline = System.monotonic_time(:millisecond) + poll_ms
+    do_poll(pid, uri, deadline)
+  end
+
+  defp do_poll(pid, uri, deadline) do
+    case Client.diagnostics(pid, uri) do
+      [] ->
+        remaining = deadline - System.monotonic_time(:millisecond)
+
+        if remaining > 0 do
+          Process.sleep(min(@diagnostics_poll_interval_ms, remaining))
+          do_poll(pid, uri, deadline)
+        else
+          []
+        end
+
+      diags ->
+        diags
+    end
+  end
+
+  # --- position helpers ---
+
+  defp require_position(%{"line" => line, "character" => character})
+       when is_integer(line) and is_integer(character) do
+    {:ok, %{line: line, character: character}}
+  end
+
+  defp require_position(_), do: {:error, :missing_position}
+
+  defp text_document_position(abs_path, %{line: line, character: character}) do
+    %{
+      "textDocument" => %{"uri" => "file://" <> abs_path},
+      "position" => %{"line" => line, "character" => character}
+    }
+  end
+
+  # --- language id ---
+
+  defp language_id(path) do
+    case Path.extname(path) do
+      ".ex" -> "elixir"
+      ".exs" -> "elixir"
+      ".py" -> "python"
+      ".pyi" -> "python"
+      ".rs" -> "rust"
+      ".go" -> "go"
+      ".ts" -> "typescript"
+      ".tsx" -> "typescriptreact"
+      ".js" -> "javascript"
+      ".jsx" -> "javascriptreact"
+      ".mjs" -> "javascript"
+      ".cjs" -> "javascript"
+      _ -> "plaintext"
+    end
+  end
+
+  # --- formatters ---
+
+  defp format(:definition, locations, _abs_path) when is_list(locations) do
+    locations
+    |> Enum.map(fn loc ->
+      path = uri_to_path(loc["uri"] || "")
+      start = get_in(loc, ["range", "start"]) || %{}
+      "#{path}:#{start["line"] || 0}:#{start["character"] || 0}"
+    end)
+    |> Enum.join("\n")
+  end
+
+  defp format(:definition, _nil_or_other, _abs_path), do: ""
+
+  defp format(:references, locations, _abs_path) when is_list(locations) do
+    count = length(locations)
+
+    lines =
+      Enum.map(locations, fn loc ->
+        path = uri_to_path(loc["uri"] || "")
+        start = get_in(loc, ["range", "start"]) || %{}
+        "  #{path}:#{start["line"] || 0}:#{start["character"] || 0}"
+      end)
+
+    "#{count} reference(s):\n" <> Enum.join(lines, "\n")
+  end
+
+  defp format(:references, _nil_or_other, _abs_path), do: "0 reference(s):"
+
+  defp format(:hover, %{"contents" => %{"value" => value}}, _abs_path), do: value
+  defp format(:hover, %{"contents" => content}, _abs_path) when is_binary(content), do: content
+  defp format(:hover, _other, _abs_path), do: ""
+
+  defp format(:diagnostics, [], _abs_path), do: "count: 0"
+
+  defp format(:diagnostics, diags, _abs_path) when is_list(diags) do
+    Enum.map_join(diags, "\n", fn d ->
+      sev = severity_label(d["severity"])
+      msg = d["message"] || ""
+      start = get_in(d, ["range", "start"]) || %{}
+      "#{sev}: #{msg} at :#{start["line"] || 0}:#{start["character"] || 0}"
+    end)
+  end
+
+  defp severity_label(1), do: "error"
+  defp severity_label(2), do: "warning"
+  defp severity_label(3), do: "information"
+  defp severity_label(4), do: "hint"
+  defp severity_label(_), do: "unknown"
+
+  # --- ui payload ---
+
+  defp ui(action, abs_path, raw) do
+    %{
+      kind: :lsp,
+      payload: %{
+        action: action,
+        file: abs_path,
+        results: raw || []
+      }
+    }
+  end
+
+  # --- helpers ---
+
+  defp uri_to_path("file://" <> path), do: path
+  defp uri_to_path(uri), do: uri
+end

--- a/test/ex_athena/hooks_test.exs
+++ b/test/ex_athena/hooks_test.exs
@@ -50,4 +50,63 @@ defmodule ExAthena.HooksTest do
     assert {:halt, {:hook_crashed, _msg}} =
              Hooks.run_pre_tool_use(%{PreToolUse: [%{hooks: [crasher]}]}, "read", %{}, "c1")
   end
+
+  test "PostToolUse single augment is returned" do
+    fn_aug = fn _input, _id -> {:augment, "diag: error on line 1"} end
+
+    assert {:augment, "diag: error on line 1"} =
+             Hooks.run_post_tool_use(
+               %{PostToolUse: [%{hooks: [fn_aug]}]},
+               "Edit",
+               %{},
+               "c1"
+             )
+  end
+
+  test "PostToolUse multiple augments are concatenated with newline" do
+    fn_a = fn _input, _id -> {:augment, "first"} end
+    fn_b = fn _input, _id -> {:augment, "second"} end
+
+    assert {:augment, "first\nsecond"} =
+             Hooks.run_post_tool_use(
+               %{PostToolUse: [%{hooks: [fn_a, fn_b]}]},
+               "Edit",
+               %{},
+               "c1"
+             )
+  end
+
+  test "PostToolUse empty augment string collapses to :ok" do
+    fn_empty = fn _input, _id -> {:augment, ""} end
+
+    assert :ok =
+             Hooks.run_post_tool_use(
+               %{PostToolUse: [%{hooks: [fn_empty]}]},
+               "Edit",
+               %{},
+               "c1"
+             )
+  end
+
+  test "PostToolUse halt wins over augment" do
+    fn_aug = fn _input, _id -> {:augment, "should not appear"} end
+    fn_halt = fn _input, _id -> {:halt, :aborted} end
+
+    assert {:halt, :aborted} =
+             Hooks.run_post_tool_use(
+               %{PostToolUse: [%{hooks: [fn_aug, fn_halt]}]},
+               "Edit",
+               %{},
+               "c1"
+             )
+  end
+
+  test "PostToolUse augment respects matcher — non-matching tool name returns :ok" do
+    fn_aug = fn _input, _id -> {:augment, "lsp diagnostics"} end
+
+    hooks = %{PostToolUse: [%{matcher: "^(Edit|Write)$", hooks: [fn_aug]}]}
+
+    assert :ok = Hooks.run_post_tool_use(hooks, "Read", %{}, "c1")
+    assert {:augment, "lsp diagnostics"} = Hooks.run_post_tool_use(hooks, "Edit", %{}, "c2")
+  end
 end

--- a/test/ex_athena/loop/implicit_diagnostics_integration_test.exs
+++ b/test/ex_athena/loop/implicit_diagnostics_integration_test.exs
@@ -1,0 +1,194 @@
+defmodule ExAthena.Loop.ImplicitDiagnosticsIntegrationTest do
+  @moduledoc """
+  Round-trip integration test: Loop.run with a fake Edit tool + fake LSP server.
+  Verifies the implicit-diagnostics PostToolUse hook augments the tool result
+  message and fires telemetry.
+  """
+  use ExUnit.Case, async: false
+
+  alias ExAthena.{Loop, Response, Result}
+  alias ExAthena.Messages.ToolCall
+
+  @fake_server_script Path.expand("../../support/fake_lsp_server.exs", __DIR__)
+  @elixir_bin System.find_executable("elixir")
+
+  # Fake edit tool — writes a file and returns success text.
+  defmodule FakeEditTool do
+    @behaviour ExAthena.Tool
+    def name, do: "Edit"
+    def description, do: "Edit a file"
+    def parallel_safe?, do: false
+
+    def schema do
+      %{
+        type: "object",
+        properties: %{path: %{type: "string"}},
+        required: ["path"]
+      }
+    end
+
+    def execute(%{"path" => path} = _args, _ctx) do
+      if File.exists?(path) do
+        {:ok, "edited #{Path.basename(path)} (1 replacement)"}
+      else
+        {:error, "file not found: #{path}"}
+      end
+    end
+  end
+
+  defp setup_lsp_override do
+    Application.put_env(:ex_athena, :lsp_servers, %{
+      elixir: %{binary: @elixir_bin, args: ["--erl", "-noinput", @fake_server_script]}
+    })
+
+    on_exit(fn -> Application.delete_env(:ex_athena, :lsp_servers) end)
+  end
+
+  defp start_lsp_supervisor do
+    start_supervised!({Registry, keys: :unique, name: ExAthena.Lsp.Registry})
+
+    start_supervised!(
+      {DynamicSupervisor, name: ExAthena.Lsp.ClientSupervisor, strategy: :one_for_one}
+    )
+
+    start_supervised!(ExAthena.Lsp.Manager)
+  end
+
+  defp unique_dir do
+    dir = Path.join(System.tmp_dir!(), "impl_int_test_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+    dir
+  end
+
+  defp enable_implicit_diagnostics do
+    Application.put_env(:ex_athena, :lsp_implicit_diagnostics_enabled, true)
+    on_exit(fn -> Application.put_env(:ex_athena, :lsp_implicit_diagnostics_enabled, false) end)
+  end
+
+  # Responder that calls Edit on turn 1 then stops on turn 2.
+  defp edit_then_stop(file_path) do
+    counter = :counters.new(1, [:atomics])
+
+    fn _request ->
+      :counters.add(counter, 1, 1)
+
+      case :counters.get(counter, 1) do
+        1 ->
+          %Response{
+            text: "",
+            tool_calls: [%ToolCall{id: "t1", name: "Edit", arguments: %{"path" => file_path}}],
+            finish_reason: :tool_calls,
+            provider: :mock
+          }
+
+        _ ->
+          %Response{text: "done", finish_reason: :stop, provider: :mock}
+      end
+    end
+  end
+
+  describe "Edit on .ex file" do
+    setup do
+      setup_lsp_override()
+      start_lsp_supervisor()
+      enable_implicit_diagnostics()
+      dir = unique_dir()
+      {:ok, dir: dir}
+    end
+
+    test "tool result message contains both edit output and lsp diagnostics block", %{dir: dir} do
+      path = Path.join(dir, "foo.ex")
+      File.write!(path, "defmodule Foo do\nend\n")
+
+      assert {:ok, %Result{} = result} =
+               Loop.run("fix the file",
+                 provider: :mock,
+                 mock: [responder: edit_then_stop(path)],
+                 cwd: dir,
+                 tools: [FakeEditTool]
+               )
+
+      tool_msgs = Enum.filter(result.messages, &(&1.role == :tool))
+      assert length(tool_msgs) == 1
+      [tool_msg] = tool_msgs
+      [tr] = tool_msg.tool_results
+      assert tr.content =~ "edited foo.ex"
+      assert tr.content =~ "[lsp diagnostics]"
+      assert tr.content =~ "error"
+    end
+
+    test "telemetry stop event fires with had_errors: true", %{dir: dir} do
+      test_pid = self()
+
+      :telemetry.attach(
+        "integration-diag-#{System.unique_integer()}",
+        [:ex_athena, :lsp, :implicit_diagnostics, :stop],
+        fn _name, measurements, _meta, _cfg ->
+          send(test_pid, {:telemetry_stop, measurements})
+        end,
+        nil
+      )
+
+      path = Path.join(dir, "bar.ex")
+      File.write!(path, "defmodule Bar do\nend\n")
+
+      Loop.run("fix the file",
+        provider: :mock,
+        mock: [responder: edit_then_stop(path)],
+        cwd: dir,
+        tools: [FakeEditTool]
+      )
+
+      assert_receive {:telemetry_stop, measurements}, 5_000
+      assert measurements.had_errors == true
+    end
+  end
+
+  describe "Edit on .md file (no LSP server for extension)" do
+    setup do
+      setup_lsp_override()
+      start_lsp_supervisor()
+      enable_implicit_diagnostics()
+      dir = unique_dir()
+      {:ok, dir: dir}
+    end
+
+    test "tool result content is unchanged when no LSP server matches", %{dir: dir} do
+      path = Path.join(dir, "README.md")
+      File.write!(path, "# heading\n")
+
+      counter = :counters.new(1, [:atomics])
+
+      responder = fn _request ->
+        :counters.add(counter, 1, 1)
+
+        case :counters.get(counter, 1) do
+          1 ->
+            %Response{
+              text: "",
+              tool_calls: [%ToolCall{id: "t1", name: "Edit", arguments: %{"path" => path}}],
+              finish_reason: :tool_calls,
+              provider: :mock
+            }
+
+          _ ->
+            %Response{text: "done", finish_reason: :stop, provider: :mock}
+        end
+      end
+
+      assert {:ok, %Result{} = result} =
+               Loop.run("fix the file",
+                 provider: :mock,
+                 mock: [responder: responder],
+                 cwd: dir,
+                 tools: [FakeEditTool]
+               )
+
+      [tool_msg] = Enum.filter(result.messages, &(&1.role == :tool))
+      [tr] = tool_msg.tool_results
+      assert tr.content =~ "edited README.md"
+      refute tr.content =~ "[lsp diagnostics]"
+    end
+  end
+end

--- a/test/ex_athena/lsp/client_test.exs
+++ b/test/ex_athena/lsp/client_test.exs
@@ -165,6 +165,40 @@ defmodule ExAthena.Lsp.ClientTest do
     end
   end
 
+  describe "initialize error response" do
+    test "queued requests get {:lsp_init_failed, err} and GenServer stops" do
+      System.put_env("FAKE_LSP_FAIL_INITIALIZE", "1")
+      on_exit(fn -> System.delete_env("FAKE_LSP_FAIL_INITIALIZE") end)
+
+      pid =
+        start_supervised!(
+          {Client,
+           [
+             binary: @elixir_bin,
+             args: ["--erl", "-noinput", @fake_server_script],
+             root_uri: "file://#{@root}",
+             root: @root,
+             language: :test
+           ]},
+          restart: :temporary
+        )
+
+      ref = Process.monitor(pid)
+      caller = self()
+
+      spawn(fn ->
+        result = Client.request(pid, "textDocument/echo", %{}, 5_000)
+        send(caller, {:result, result})
+      end)
+
+      assert_receive {:result, {:error, {:lsp_init_failed, err}}}, 5_000
+      assert is_map(err)
+      assert err["message"] == "InvalidParams"
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, {:lsp_init_failed, _}}, 5_000
+    end
+  end
+
   describe "stop/2" do
     test "stop/2 shuts down cleanly" do
       pid = start_client()

--- a/test/ex_athena/lsp/client_test.exs
+++ b/test/ex_athena/lsp/client_test.exs
@@ -1,0 +1,195 @@
+defmodule ExAthena.Lsp.ClientTest do
+  use ExUnit.Case, async: false
+
+  alias ExAthena.Lsp.Client
+
+  @fake_server_script Path.expand("../../support/fake_lsp_server.exs", __DIR__)
+  @elixir_bin System.find_executable("elixir")
+  @root System.tmp_dir!()
+
+  defp start_client(opts \\ []) do
+    default = [
+      binary: @elixir_bin,
+      # --erl "-noinput" prevents the Erlang :user group leader from competing
+      # with our Port.open({:fd, 0, 1}) reads in the fake server's VM.
+      args: ["--erl", "-noinput", @fake_server_script],
+      root_uri: "file://#{@root}",
+      root: @root,
+      language: :test
+    ]
+
+    start_supervised!({Client, Keyword.merge(default, opts)})
+  end
+
+  # Waits until the client completes initialization by making a simple
+  # request that requires the server to be ready.
+  defp await_initialized(pid) do
+    assert {:ok, _} = Client.request(pid, "textDocument/echo", %{"ping" => true}, 10_000)
+  end
+
+  describe "initialize handshake" do
+    test "client starts successfully and completes initialize" do
+      pid = start_client()
+      # Initialization is async; wait for it by issuing a test request.
+      assert {:ok, %{"ping" => true}} =
+               Client.request(pid, "textDocument/echo", %{"ping" => true}, 10_000)
+
+      assert Process.alive?(pid)
+    end
+  end
+
+  describe "request/4" do
+    test "textDocument/echo returns params verbatim" do
+      pid = start_client()
+      params = %{"x" => 1, "y" => "hello"}
+      assert {:ok, result} = Client.request(pid, "textDocument/echo", params, 10_000)
+      assert result["x"] == 1
+      assert result["y"] == "hello"
+    end
+
+    test "unknown method returns error response" do
+      pid = start_client()
+      # Wait for initialization first.
+      await_initialized(pid)
+      assert {:error, _reason} = Client.request(pid, "unknown/method", %{}, 5_000)
+    end
+
+    test "ten concurrent requests each get the right reply" do
+      pid = start_client()
+      # Ensure initialized before issuing concurrent requests.
+      await_initialized(pid)
+
+      tasks =
+        Enum.map(1..10, fn i ->
+          Task.async(fn ->
+            Client.request(pid, "textDocument/echo", %{"i" => i}, 10_000)
+          end)
+        end)
+
+      results = Task.await_many(tasks, 15_000)
+
+      Enum.each(Enum.zip(1..10, results), fn {i, result} ->
+        assert {:ok, body} = result
+        assert body["i"] == i
+      end)
+    end
+
+    test "requests made before initialization are queued and completed after" do
+      # Start client - initialization is async but requests queued before
+      # initialization completes are replayed once initialized.
+      pid =
+        start_supervised!(
+          {Client,
+           [
+             binary: @elixir_bin,
+             args: ["--erl", "-noinput", @fake_server_script],
+             root_uri: "file://#{@root}",
+             root: @root,
+             language: :test
+           ]}
+        )
+
+      # This request is issued immediately and may arrive before initialization.
+      # It should still succeed (either immediately or after initialization).
+      assert {:ok, %{"queued" => true}} =
+               Client.request(pid, "textDocument/echo", %{"queued" => true}, 15_000)
+    end
+  end
+
+  describe "notify/3" do
+    test "notif/trigger causes publishDiagnostics to be cached" do
+      pid = start_client()
+      await_initialized(pid)
+
+      :ok = Client.notify(pid, "notif/trigger", %{})
+
+      # Give the server time to push the notification back.
+      # The diagnostics state is updated when handle_info processes the notification.
+      assert_diagnostics(pid, "file:///test/foo.ex", 500)
+    end
+  end
+
+  describe "diagnostics/2" do
+    test "returns empty list for unknown uri" do
+      pid = start_client()
+      await_initialized(pid)
+      assert Client.diagnostics(pid, "file:///nonexistent.ex") == []
+    end
+  end
+
+  describe "telemetry" do
+    setup do
+      handler_id = "test-lsp-request-#{System.unique_integer()}"
+
+      :telemetry.attach(
+        handler_id,
+        [:ex_athena, :lsp, :request, :stop],
+        fn _event, _measurements, metadata, test_pid ->
+          send(test_pid, {:telemetry_stop, metadata})
+        end,
+        self()
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+      :ok
+    end
+
+    test "[:ex_athena, :lsp, :request, :stop] fires with method metadata" do
+      pid = start_client()
+      {:ok, _} = Client.request(pid, "textDocument/echo", %{"k" => 1}, 10_000)
+
+      assert_receive {:telemetry_stop, meta}, 3_000
+      assert meta.method == "textDocument/echo"
+      assert meta.language == :test
+    end
+  end
+
+  describe "spawn telemetry" do
+    test "[:ex_athena, :lsp, :spawn] fires with phase: :started on init" do
+      handler_id = "test-lsp-spawn-#{System.unique_integer()}"
+
+      :telemetry.attach(
+        handler_id,
+        [:ex_athena, :lsp, :spawn],
+        fn _event, _measurements, metadata, test_pid ->
+          send(test_pid, {:telemetry_spawn, metadata})
+        end,
+        self()
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      _pid = start_client()
+
+      assert_receive {:telemetry_spawn, %{phase: :started}}, 3_000
+    end
+  end
+
+  describe "stop/2" do
+    test "stop/2 shuts down cleanly" do
+      pid = start_client()
+      await_initialized(pid)
+
+      ref = Process.monitor(pid)
+      assert :ok = Client.stop(pid)
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, 3_000
+    end
+  end
+
+  # --- helpers ---
+
+  defp assert_diagnostics(pid, uri, max_wait_ms, attempts \\ 20) do
+    case Client.diagnostics(pid, uri) do
+      [] when attempts > 0 ->
+        Process.sleep(div(max_wait_ms, 20))
+        assert_diagnostics(pid, uri, max_wait_ms, attempts - 1)
+
+      [] ->
+        flunk("No diagnostics for #{uri} after #{max_wait_ms}ms")
+
+      diags ->
+        diags
+    end
+  end
+end

--- a/test/ex_athena/lsp/framing_test.exs
+++ b/test/ex_athena/lsp/framing_test.exs
@@ -1,0 +1,62 @@
+defmodule ExAthena.Lsp.FramingTest do
+  use ExUnit.Case, async: true
+
+  alias ExAthena.Lsp.Framing
+
+  defp frame(body) when is_binary(body) do
+    "Content-Length: #{byte_size(body)}\r\n\r\n#{body}"
+  end
+
+  test "decodes a single complete frame" do
+    body = ~s({"jsonrpc":"2.0","id":1,"result":null})
+    buf = frame(body)
+    assert {[^body], ""} = Framing.parse(buf)
+  end
+
+  test "decodes two frames in one buffer" do
+    b1 = ~s({"jsonrpc":"2.0","id":1,"result":null})
+    b2 = ~s({"jsonrpc":"2.0","method":"initialized","params":{}})
+    buf = frame(b1) <> frame(b2)
+    assert {[^b1, ^b2], ""} = Framing.parse(buf)
+  end
+
+  test "returns leftover bytes when frame body is truncated" do
+    body = ~s({"jsonrpc":"2.0","id":1,"result":null})
+    truncated = frame(body) |> binary_part(0, byte_size(frame(body)) - 3)
+    assert {[], leftover} = Framing.parse(truncated)
+    assert leftover == truncated
+  end
+
+  test "handles extra Content-Type header line" do
+    body = ~s({"jsonrpc":"2.0","id":1,"result":"ok"})
+
+    buf =
+      "Content-Length: #{byte_size(body)}\r\nContent-Type: application/vscode-jsonrpc; charset=utf-8\r\n\r\n#{body}"
+
+    assert {[^body], ""} = Framing.parse(buf)
+  end
+
+  test "handles LF-only line endings" do
+    body = ~s({"jsonrpc":"2.0","id":1,"result":"ok"})
+    buf = "Content-Length: #{byte_size(body)}\n\n#{body}"
+    assert {[^body], ""} = Framing.parse(buf)
+  end
+
+  test "returns leftover unchanged when Content-Length header is missing" do
+    garbage = "this is not an LSP frame at all"
+    assert {[], ^garbage} = Framing.parse(garbage)
+  end
+
+  test "drops garbage bytes before a valid frame" do
+    body = ~s({"jsonrpc":"2.0","id":1,"result":null})
+    garbage_prefix = "some garbage bytes\r\n"
+    buf = garbage_prefix <> frame(body)
+    {frames, leftover} = Framing.parse(buf)
+    assert leftover == ""
+    assert frames == [body]
+  end
+
+  test "handles empty buffer" do
+    assert {[], ""} = Framing.parse("")
+  end
+end

--- a/test/ex_athena/lsp/implicit_diagnostics_test.exs
+++ b/test/ex_athena/lsp/implicit_diagnostics_test.exs
@@ -1,0 +1,245 @@
+defmodule ExAthena.Lsp.ImplicitDiagnosticsTest do
+  use ExUnit.Case, async: false
+
+  alias ExAthena.Lsp.{Client, ImplicitDiagnostics, Manager}
+
+  @fake_server_script Path.expand("../../support/fake_lsp_server.exs", __DIR__)
+  @elixir_bin System.find_executable("elixir")
+
+  defp setup_lsp_override do
+    Application.put_env(:ex_athena, :lsp_servers, %{
+      elixir: %{binary: @elixir_bin, args: ["--erl", "-noinput", @fake_server_script]}
+    })
+
+    on_exit(fn -> Application.delete_env(:ex_athena, :lsp_servers) end)
+  end
+
+  defp start_lsp_supervisor do
+    start_supervised!({Registry, keys: :unique, name: ExAthena.Lsp.Registry})
+
+    start_supervised!(
+      {DynamicSupervisor, name: ExAthena.Lsp.ClientSupervisor, strategy: :one_for_one}
+    )
+
+    start_supervised!(Manager)
+  end
+
+  defp enable_implicit_diagnostics do
+    Application.put_env(:ex_athena, :lsp_implicit_diagnostics_enabled, true)
+    on_exit(fn -> Application.put_env(:ex_athena, :lsp_implicit_diagnostics_enabled, false) end)
+  end
+
+  defp unique_dir do
+    dir = Path.join(System.tmp_dir!(), "impl_diag_test_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+    dir
+  end
+
+  defp write_elixir_file(dir, name \\ "test.ex") do
+    path = Path.join(dir, name)
+    File.write!(path, "defmodule Test do\nend\n")
+    path
+  end
+
+  # ── Disabled config ───────────────────────────────────────────────
+
+  test "returns :ok when lsp_implicit_diagnostics_enabled is false" do
+    # test.exs sets this to false globally; no LSP setup needed
+    dir = unique_dir()
+    path = write_elixir_file(dir)
+
+    payload = %{arguments: %{"path" => path}, cwd: dir, tool_name: "Edit"}
+    assert :ok = ImplicitDiagnostics.post_tool_use_hook(payload, "c1")
+  end
+
+  # ── No path in arguments ──────────────────────────────────────────
+
+  test "returns :ok when arguments map has no 'path' key" do
+    enable_implicit_diagnostics()
+    dir = unique_dir()
+
+    payload = %{arguments: %{}, cwd: dir, tool_name: "Edit"}
+    assert :ok = ImplicitDiagnostics.post_tool_use_hook(payload, "c1")
+  end
+
+  test "returns :ok when arguments is nil" do
+    enable_implicit_diagnostics()
+    dir = unique_dir()
+
+    payload = %{arguments: nil, cwd: dir, tool_name: "Edit"}
+    assert :ok = ImplicitDiagnostics.post_tool_use_hook(payload, "c1")
+  end
+
+  # ── Unknown extension ────────────────────────────────────────────
+
+  test "returns :ok for files with unsupported extensions" do
+    enable_implicit_diagnostics()
+    dir = unique_dir()
+    path = Path.join(dir, "notes.txt")
+    File.write!(path, "hello")
+
+    payload = %{arguments: %{"path" => path}, cwd: dir, tool_name: "Edit"}
+    assert :ok = ImplicitDiagnostics.post_tool_use_hook(payload, "c1")
+  end
+
+  test "returns :ok for markdown files" do
+    enable_implicit_diagnostics()
+    dir = unique_dir()
+    path = Path.join(dir, "README.md")
+    File.write!(path, "# heading")
+
+    payload = %{arguments: %{"path" => path}, cwd: dir, tool_name: "Edit"}
+    assert :ok = ImplicitDiagnostics.post_tool_use_hook(payload, "c1")
+  end
+
+  # ── Manager unavailable ──────────────────────────────────────────
+
+  test "returns :ok when no LSP manager is running" do
+    enable_implicit_diagnostics()
+    dir = unique_dir()
+    path = write_elixir_file(dir)
+
+    payload = %{arguments: %{"path" => path}, cwd: dir, tool_name: "Edit"}
+    assert :ok = ImplicitDiagnostics.post_tool_use_hook(payload, "c1")
+  end
+
+  # ── Diagnostics returned ─────────────────────────────────────────
+
+  describe "with LSP running" do
+    setup do
+      setup_lsp_override()
+      start_lsp_supervisor()
+      enable_implicit_diagnostics()
+      dir = unique_dir()
+      {:ok, dir: dir}
+    end
+
+    test "returns {:augment, text} containing error when fake server emits diagnostic", %{
+      dir: dir
+    } do
+      path = write_elixir_file(dir)
+      payload = %{arguments: %{"path" => path}, cwd: dir, tool_name: "Edit"}
+
+      assert {:augment, text} = ImplicitDiagnostics.post_tool_use_hook(payload, "c1")
+      assert text =~ "[lsp diagnostics]"
+      assert text =~ "error"
+      assert text =~ Path.basename(path)
+    end
+
+    test "returned text includes the file's relative path from cwd", %{dir: dir} do
+      path = write_elixir_file(dir, "mymodule.ex")
+      payload = %{arguments: %{"path" => path}, cwd: dir, tool_name: "Edit"}
+
+      assert {:augment, text} = ImplicitDiagnostics.post_tool_use_hook(payload, "c1")
+      assert text =~ "mymodule.ex"
+    end
+
+    test "returns :ok when diagnostics are filtered out by severity config", %{dir: dir} do
+      Application.put_env(:ex_athena, :lsp_implicit_diagnostics_severities, [:warning])
+      on_exit(fn -> Application.delete_env(:ex_athena, :lsp_implicit_diagnostics_severities) end)
+
+      path = write_elixir_file(dir)
+      payload = %{arguments: %{"path" => path}, cwd: dir, tool_name: "Edit"}
+
+      assert :ok = ImplicitDiagnostics.post_tool_use_hook(payload, "c1")
+    end
+
+    test "returns :ok within timeout_ms when server emits no diagnostics", %{dir: dir} do
+      path = write_elixir_file(dir)
+
+      {:ok, pid} = Manager.client_for_file(dir, path)
+      Client.notify(pid, "notif/suppress_next_diag", %{})
+
+      Application.put_env(:ex_athena, :lsp_implicit_diagnostics_timeout_ms, 200)
+      on_exit(fn -> Application.delete_env(:ex_athena, :lsp_implicit_diagnostics_timeout_ms) end)
+
+      payload = %{arguments: %{"path" => path}, cwd: dir, tool_name: "Edit"}
+
+      before_ms = System.monotonic_time(:millisecond)
+      assert :ok = ImplicitDiagnostics.post_tool_use_hook(payload, "c1")
+      elapsed = System.monotonic_time(:millisecond) - before_ms
+
+      assert elapsed < 500, "Expected hook to complete within 500ms, took #{elapsed}ms"
+    end
+
+    test "telemetry :stop event fires with count and had_errors measurements", %{dir: dir} do
+      test_pid = self()
+
+      :telemetry.attach(
+        "test-implicit-diag-#{System.unique_integer()}",
+        [:ex_athena, :lsp, :implicit_diagnostics, :stop],
+        fn _name, measurements, meta, _cfg ->
+          send(test_pid, {:telemetry_stop, measurements, meta})
+        end,
+        nil
+      )
+
+      path = write_elixir_file(dir)
+      payload = %{arguments: %{"path" => path}, cwd: dir, tool_name: "Edit"}
+
+      ImplicitDiagnostics.post_tool_use_hook(payload, "c1")
+
+      assert_receive {:telemetry_stop, measurements, meta}, 5_000
+      assert is_integer(measurements.count)
+      assert is_boolean(measurements.had_errors)
+      assert meta.tool_name == "Edit"
+    end
+
+    test "path relative to cwd is resolved correctly for subdirectory files", %{dir: dir} do
+      sub = Path.join(dir, "sub")
+      File.mkdir_p!(sub)
+      path = Path.join(sub, "mod.ex")
+      File.write!(path, "defmodule Mod do\nend\n")
+
+      payload = %{arguments: %{"path" => "sub/mod.ex"}, cwd: dir, tool_name: "Edit"}
+
+      assert {:augment, _text} = ImplicitDiagnostics.post_tool_use_hook(payload, "c1")
+    end
+  end
+
+  # ── default_hooks_entry/0 ─────────────────────────────────────────
+
+  test "default_hooks_entry/0 returns a matcher group matching Edit and Write" do
+    entry = ImplicitDiagnostics.default_hooks_entry()
+
+    assert %{matcher: matcher, hooks: hooks} = entry
+    assert is_binary(matcher)
+    assert Regex.match?(Regex.compile!(matcher), "Edit")
+    assert Regex.match?(Regex.compile!(matcher), "Write")
+    refute Regex.match?(Regex.compile!(matcher), "Read")
+    assert is_list(hooks)
+    assert length(hooks) == 1
+    assert is_function(hd(hooks), 2)
+  end
+
+  # ── maybe_merge/1 ─────────────────────────────────────────────────
+
+  test "maybe_merge/1 returns hooks unchanged when diagnostics disabled" do
+    # test.exs disables it globally
+    hooks = %{PostToolUse: [%{hooks: [fn _, _ -> :ok end]}]}
+    assert ImplicitDiagnostics.maybe_merge(hooks) == hooks
+  end
+
+  test "maybe_merge/1 prepends implicit hook when diagnostics enabled" do
+    Application.put_env(:ex_athena, :lsp_implicit_diagnostics_enabled, true)
+    on_exit(fn -> Application.delete_env(:ex_athena, :lsp_implicit_diagnostics_enabled) end)
+
+    user_hook = fn _, _ -> :ok end
+    hooks = %{PostToolUse: [%{hooks: [user_hook]}]}
+
+    merged = ImplicitDiagnostics.maybe_merge(hooks)
+    assert [first | rest] = merged[:PostToolUse]
+    assert first.hooks == [&ImplicitDiagnostics.post_tool_use_hook/2]
+    assert [%{hooks: [^user_hook]}] = rest
+  end
+
+  test "maybe_merge/1 initialises PostToolUse key when absent" do
+    Application.put_env(:ex_athena, :lsp_implicit_diagnostics_enabled, true)
+    on_exit(fn -> Application.delete_env(:ex_athena, :lsp_implicit_diagnostics_enabled) end)
+
+    merged = ImplicitDiagnostics.maybe_merge(%{})
+    assert [entry] = merged[:PostToolUse]
+    assert %{matcher: _, hooks: _} = entry
+  end
+end

--- a/test/ex_athena/lsp/manager_test.exs
+++ b/test/ex_athena/lsp/manager_test.exs
@@ -160,6 +160,13 @@ defmodule ExAthena.Lsp.ManagerTest do
   # --- helpers ---
 
   defp unique_root do
-    "/tmp/lsp_manager_test_#{System.unique_integer([:positive])}"
+    # Each test calls this AFTER `start_supervised!` runs in setup, so an
+    # `on_exit` cleanup here would fire BEFORE the supervisor stops the spawned
+    # LSP VM (LIFO order) — the VM would then see a missing cwd and emit
+    # "Runtime terminating during boot" noise. Leave the empty dir in /tmp;
+    # the OS reaps it. The point of this fix is just to make `cd:` succeed.
+    root = Path.join(System.tmp_dir!(), "lsp_manager_test_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(root)
+    root
   end
 end

--- a/test/ex_athena/lsp/manager_test.exs
+++ b/test/ex_athena/lsp/manager_test.exs
@@ -1,0 +1,165 @@
+defmodule ExAthena.Lsp.ManagerTest do
+  use ExUnit.Case, async: false
+
+  alias ExAthena.Lsp.Manager
+
+  @fake_server_script Path.expand("../../support/fake_lsp_server.exs", __DIR__)
+  @elixir_bin System.find_executable("elixir")
+
+  # Override :lsp_servers so Manager resolves to our fake server binary
+  # instead of the real elixir-ls binary (which may not be installed).
+  defp setup_lsp_override do
+    Application.put_env(:ex_athena, :lsp_servers, %{
+      # --erl "-noinput" prevents the Erlang :user group leader from competing
+      # with our Port.open({:fd, 0, 1}) reads in the fake server's VM.
+      elixir: %{binary: @elixir_bin, args: ["--erl", "-noinput", @fake_server_script]}
+    })
+
+    on_exit(fn -> Application.delete_env(:ex_athena, :lsp_servers) end)
+  end
+
+  defp start_lsp_supervisor do
+    start_supervised!({Registry, keys: :unique, name: ExAthena.Lsp.Registry})
+
+    start_supervised!(
+      {DynamicSupervisor, name: ExAthena.Lsp.ClientSupervisor, strategy: :one_for_one}
+    )
+
+    start_supervised!(Manager)
+  end
+
+  describe "ensure_started/2" do
+    setup do
+      setup_lsp_override()
+      start_lsp_supervisor()
+      :ok
+    end
+
+    test "returns {:ok, pid} and spawns a client" do
+      root = unique_root()
+      assert {:ok, pid} = Manager.ensure_started(root, :elixir)
+      assert is_pid(pid)
+      assert Process.alive?(pid)
+    end
+
+    test "second call for same (root, language) returns the same pid" do
+      handler_id = "test-lsp-spawn-#{System.unique_integer()}"
+
+      spawn_events = :ets.new(:spawn_events, [:bag, :public])
+
+      :telemetry.attach(
+        handler_id,
+        [:ex_athena, :lsp, :spawn],
+        fn _event, _measurements, metadata, table ->
+          :ets.insert(table, {:event, metadata})
+        end,
+        spawn_events
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      root = unique_root()
+      {:ok, pid1} = Manager.ensure_started(root, :elixir)
+      {:ok, pid2} = Manager.ensure_started(root, :elixir)
+
+      assert pid1 == pid2
+
+      # Only one :started spawn event for this root (the second call was a registry hit)
+      # Give a moment for any stray events
+      Process.sleep(100)
+      events = :ets.lookup(spawn_events, :event)
+
+      started_count =
+        Enum.count(events, fn {:event, meta} -> meta.phase == :started and meta.root == root end)
+
+      assert started_count == 1
+    end
+
+    test "different roots spawn different pids" do
+      root1 = unique_root()
+      root2 = unique_root()
+
+      {:ok, pid1} = Manager.ensure_started(root1, :elixir)
+      {:ok, pid2} = Manager.ensure_started(root2, :elixir)
+
+      assert pid1 != pid2
+    end
+
+    test "returns {:error, {:no_server, language}} for unknown language" do
+      # :unknown_lang has no override and no real binary
+      root = unique_root()
+      assert {:error, {:no_server, :unknown_lang}} = Manager.ensure_started(root, :unknown_lang)
+    end
+  end
+
+  describe "client_for_file/2" do
+    setup do
+      setup_lsp_override()
+      start_lsp_supervisor()
+      :ok
+    end
+
+    test "returns {:ok, pid} for a known extension" do
+      root = unique_root()
+      assert {:ok, pid} = Manager.client_for_file(root, "foo.ex")
+      assert is_pid(pid)
+    end
+
+    test "returns {:error, :unsupported_language} for unknown extension" do
+      root = unique_root()
+      assert {:error, :unsupported_language} = Manager.client_for_file(root, "foo.unknown")
+    end
+  end
+
+  describe "stop/2" do
+    setup do
+      setup_lsp_override()
+      start_lsp_supervisor()
+      :ok
+    end
+
+    test "terminates the client and allows a fresh spawn" do
+      root = unique_root()
+      {:ok, pid1} = Manager.ensure_started(root, :elixir)
+      ref = Process.monitor(pid1)
+
+      :ok = Manager.stop(root, :elixir)
+      assert_receive {:DOWN, ^ref, :process, ^pid1, _}, 3_000
+
+      # A new ensure_started should spawn a fresh pid.
+      {:ok, pid2} = Manager.ensure_started(root, :elixir)
+      assert pid2 != pid1
+      assert Process.alive?(pid2)
+    end
+
+    test "stop/2 on non-existent client returns :ok" do
+      root = unique_root()
+      assert :ok = Manager.stop(root, :elixir)
+    end
+  end
+
+  describe "list/0" do
+    setup do
+      setup_lsp_override()
+      start_lsp_supervisor()
+      :ok
+    end
+
+    test "includes running clients" do
+      root = unique_root()
+      {:ok, pid} = Manager.ensure_started(root, :elixir)
+
+      entries = Manager.list()
+
+      assert Enum.any?(entries, fn e ->
+               e.root == root and e.language == :elixir and e.pid == pid
+             end)
+    end
+  end
+
+  # --- helpers ---
+
+  defp unique_root do
+    "/tmp/lsp_manager_test_#{System.unique_integer([:positive])}"
+  end
+end

--- a/test/ex_athena/lsp/server_registry_test.exs
+++ b/test/ex_athena/lsp/server_registry_test.exs
@@ -1,0 +1,118 @@
+defmodule ExAthena.Lsp.ServerRegistryTest do
+  use ExUnit.Case, async: true
+
+  alias ExAthena.Lsp.ServerRegistry
+
+  describe "language_for_path/1" do
+    test "detects elixir from .ex" do
+      assert ServerRegistry.language_for_path("lib/foo.ex") == :elixir
+    end
+
+    test "detects elixir from .exs" do
+      assert ServerRegistry.language_for_path("mix.exs") == :elixir
+    end
+
+    test "detects python from .py" do
+      assert ServerRegistry.language_for_path("app/main.py") == :python
+    end
+
+    test "detects python from .pyi" do
+      assert ServerRegistry.language_for_path("stubs/foo.pyi") == :python
+    end
+
+    test "detects rust from .rs" do
+      assert ServerRegistry.language_for_path("src/main.rs") == :rust
+    end
+
+    test "detects go from .go" do
+      assert ServerRegistry.language_for_path("cmd/main.go") == :go
+    end
+
+    test "detects typescript from .ts" do
+      assert ServerRegistry.language_for_path("src/index.ts") == :typescript
+    end
+
+    test "detects typescript from .tsx" do
+      assert ServerRegistry.language_for_path("src/App.tsx") == :typescript
+    end
+
+    test "detects typescript from .js" do
+      assert ServerRegistry.language_for_path("app.js") == :typescript
+    end
+
+    test "detects typescript from .jsx" do
+      assert ServerRegistry.language_for_path("App.jsx") == :typescript
+    end
+
+    test "detects typescript from .mjs" do
+      assert ServerRegistry.language_for_path("index.mjs") == :typescript
+    end
+
+    test "detects typescript from .cjs" do
+      assert ServerRegistry.language_for_path("index.cjs") == :typescript
+    end
+
+    test "returns nil for unknown extension" do
+      assert ServerRegistry.language_for_path("README.md") == nil
+    end
+
+    test "returns nil for file with no extension" do
+      assert ServerRegistry.language_for_path("Makefile") == nil
+    end
+  end
+
+  describe "spawn_spec/1" do
+    test "returns error for unsupported language" do
+      assert {:error, :unsupported} = ServerRegistry.spawn_spec(:cobol)
+    end
+
+    test "returns error when binary is missing from PATH" do
+      finder = fn _name -> nil end
+      assert {:error, :unsupported} = ServerRegistry.spawn_spec(:elixir, finder)
+    end
+
+    test "returns spec when binary is present" do
+      finder = fn "elixir-ls" -> "/usr/local/bin/elixir-ls" end
+
+      assert {:ok, %{binary: "/usr/local/bin/elixir-ls", args: []}} =
+               ServerRegistry.spawn_spec(:elixir, finder)
+    end
+
+    test "returns spec for pyright with --stdio arg" do
+      finder = fn "pyright-langserver" -> "/usr/bin/pyright-langserver" end
+
+      assert {:ok, %{binary: "/usr/bin/pyright-langserver", args: ["--stdio"]}} =
+               ServerRegistry.spawn_spec(:python, finder)
+    end
+
+    test "returns spec for gopls with serve arg" do
+      finder = fn "gopls" -> "/usr/local/bin/gopls" end
+
+      assert {:ok, %{binary: "/usr/local/bin/gopls", args: ["serve"]}} =
+               ServerRegistry.spawn_spec(:go, finder)
+    end
+
+    test "app-env override replaces default for a known language" do
+      override = %{elixir: %{binary: "/custom/elixir-ls", args: ["--custom"]}}
+      Application.put_env(:ex_athena, :lsp_servers, override)
+
+      on_exit(fn -> Application.delete_env(:ex_athena, :lsp_servers) end)
+
+      finder = fn _name -> nil end
+
+      assert {:ok, %{binary: "/custom/elixir-ls", args: ["--custom"]}} =
+               ServerRegistry.spawn_spec(:elixir, finder)
+    end
+
+    test "app-env override with string key binary does not run through find_executable" do
+      override = %{rust: %{binary: "/custom/rust-analyzer", args: []}}
+      Application.put_env(:ex_athena, :lsp_servers, override)
+      on_exit(fn -> Application.delete_env(:ex_athena, :lsp_servers) end)
+
+      finder = fn _name -> nil end
+
+      assert {:ok, %{binary: "/custom/rust-analyzer", args: []}} =
+               ServerRegistry.spawn_spec(:rust, finder)
+    end
+  end
+end

--- a/test/ex_athena/modes/react_post_hook_test.exs
+++ b/test/ex_athena/modes/react_post_hook_test.exs
@@ -1,0 +1,151 @@
+defmodule ExAthena.Modes.ReactPostHookTest do
+  @moduledoc """
+  Verifies that `after_post_hook/3` in ReAct mode correctly applies the
+  `{:augment, text}` return from PostToolUse hooks by appending the extra
+  text to the tool result content.
+  """
+  use ExUnit.Case, async: true
+
+  alias ExAthena.{Loop, Response, Result}
+  alias ExAthena.Messages.ToolCall
+
+  # Minimal tool that returns a fixed string.
+  defmodule FakeEchoTool do
+    @behaviour ExAthena.Tool
+    def name, do: "echo"
+    def description, do: "echo"
+    def parallel_safe?, do: true
+    def schema, do: %{type: "object", properties: %{}, required: []}
+    def execute(_args, _ctx), do: {:ok, "tool-output"}
+  end
+
+  setup do
+    dir = Path.join(System.tmp_dir!(), "react_hook_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+    {:ok, dir: dir}
+  end
+
+  test "PostToolUse {:augment, text} appends to tool result content", %{dir: dir} do
+    augment_hook = fn _payload, _id -> {:augment, "[lsp] error: bad syntax"} end
+
+    # Provider: turn 1 calls the echo tool; turn 2 returns plain text (stop).
+    counter = :counters.new(1, [:atomics])
+
+    responder = fn _request ->
+      :counters.add(counter, 1, 1)
+
+      case :counters.get(counter, 1) do
+        1 ->
+          %Response{
+            text: "",
+            tool_calls: [%ToolCall{id: "t1", name: "echo", arguments: %{}}],
+            finish_reason: :tool_calls,
+            provider: :mock
+          }
+
+        _ ->
+          %Response{text: "done", finish_reason: :stop, provider: :mock}
+      end
+    end
+
+    assert {:ok, %Result{} = result} =
+             Loop.run("go",
+               provider: :mock,
+               mock: [responder: responder],
+               cwd: dir,
+               tools: [FakeEchoTool],
+               hooks: %{
+                 PostToolUse: [
+                   %{matcher: "^echo$", hooks: [augment_hook]}
+                 ]
+               }
+             )
+
+    tool_msgs = Enum.filter(result.messages, &(&1.role == :tool))
+    assert length(tool_msgs) == 1
+    [tool_msg] = tool_msgs
+    [tr] = tool_msg.tool_results
+    assert tr.content =~ "tool-output"
+    assert tr.content =~ "[lsp] error: bad syntax"
+  end
+
+  test "PostToolUse :ok hook leaves tool result content unchanged", %{dir: dir} do
+    ok_hook = fn _payload, _id -> :ok end
+
+    counter = :counters.new(1, [:atomics])
+
+    responder = fn _request ->
+      :counters.add(counter, 1, 1)
+
+      case :counters.get(counter, 1) do
+        1 ->
+          %Response{
+            text: "",
+            tool_calls: [%ToolCall{id: "t1", name: "echo", arguments: %{}}],
+            finish_reason: :tool_calls,
+            provider: :mock
+          }
+
+        _ ->
+          %Response{text: "done", finish_reason: :stop, provider: :mock}
+      end
+    end
+
+    assert {:ok, %Result{} = result} =
+             Loop.run("go",
+               provider: :mock,
+               mock: [responder: responder],
+               cwd: dir,
+               tools: [FakeEchoTool],
+               hooks: %{PostToolUse: [%{hooks: [ok_hook]}]}
+             )
+
+    [tool_msg] = Enum.filter(result.messages, &(&1.role == :tool))
+    [tr] = tool_msg.tool_results
+    assert tr.content == "tool-output"
+  end
+
+  test "PostToolUse augment payload includes arguments and cwd", %{dir: dir} do
+    test_pid = self()
+
+    capture_hook = fn payload, _id ->
+      send(test_pid, {:payload, payload})
+      :ok
+    end
+
+    counter = :counters.new(1, [:atomics])
+
+    responder = fn _request ->
+      :counters.add(counter, 1, 1)
+
+      case :counters.get(counter, 1) do
+        1 ->
+          %Response{
+            text: "",
+            tool_calls: [
+              %ToolCall{id: "t1", name: "echo", arguments: %{"key" => "val"}}
+            ],
+            finish_reason: :tool_calls,
+            provider: :mock
+          }
+
+        _ ->
+          %Response{text: "done", finish_reason: :stop, provider: :mock}
+      end
+    end
+
+    Loop.run("go",
+      provider: :mock,
+      mock: [responder: responder],
+      cwd: dir,
+      tools: [FakeEchoTool],
+      hooks: %{PostToolUse: [%{hooks: [capture_hook]}]}
+    )
+
+    assert_receive {:payload, payload}
+    assert payload.arguments == %{"key" => "val"}
+    assert payload.cwd == dir
+    assert payload.tool_name == "echo"
+  end
+end

--- a/test/ex_athena/tools/lsp_test.exs
+++ b/test/ex_athena/tools/lsp_test.exs
@@ -219,14 +219,11 @@ defmodule ExAthena.Tools.LspTest do
     test "surfaces {:error, {:lsp_error, map}} when server returns error object", %{dir: dir} do
       path = write_elixir_file(dir)
 
-      # Arm the fake server to fail the next request with a MethodNotFound error
+      # Arm the fake server to fail the next request with a MethodNotFound error.
+      # Use the synchronous request form so we don't race a notification against
+      # the definition request that follows.
       {:ok, pid} = Manager.client_for_file(dir, path)
-      Client.notify(pid, "notif/fail_next", %{})
-
-      # Give the notification time to reach the fake server before the tool sends
-      # the definition request — both go through the GenServer mailbox in order,
-      # but we add a brief sleep to let the port pipe drain.
-      Process.sleep(50)
+      assert {:ok, %{"armed" => true}} = Client.request(pid, "notif/fail_next", %{}, 5_000)
 
       assert {:error, {:lsp_error, err}} =
                Lsp.execute(

--- a/test/ex_athena/tools/lsp_test.exs
+++ b/test/ex_athena/tools/lsp_test.exs
@@ -1,0 +1,284 @@
+defmodule ExAthena.Tools.LspTest do
+  use ExUnit.Case, async: false
+
+  alias ExAthena.Lsp.{Client, Manager}
+  alias ExAthena.Messages.ToolCall
+  alias ExAthena.Tools.Lsp
+  alias ExAthena.{Permissions, ToolContext}
+
+  @fake_server_script Path.expand("../../support/fake_lsp_server.exs", __DIR__)
+  @elixir_bin System.find_executable("elixir")
+
+  defp setup_lsp_override do
+    Application.put_env(:ex_athena, :lsp_servers, %{
+      elixir: %{binary: @elixir_bin, args: ["--erl", "-noinput", @fake_server_script]}
+    })
+
+    on_exit(fn -> Application.delete_env(:ex_athena, :lsp_servers) end)
+  end
+
+  defp start_lsp_supervisor do
+    start_supervised!({Registry, keys: :unique, name: ExAthena.Lsp.Registry})
+
+    start_supervised!(
+      {DynamicSupervisor, name: ExAthena.Lsp.ClientSupervisor, strategy: :one_for_one}
+    )
+
+    start_supervised!(Manager)
+  end
+
+  defp unique_dir do
+    dir = Path.join(System.tmp_dir!(), "lsp_tool_test_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+    dir
+  end
+
+  defp write_elixir_file(dir, name \\ "test.ex", content \\ "defmodule Test do\nend\n") do
+    path = Path.join(dir, name)
+    File.write!(path, content)
+    path
+  end
+
+  defp ctx(cwd), do: ToolContext.new(cwd: cwd)
+
+  setup do
+    setup_lsp_override()
+    start_lsp_supervisor()
+    dir = unique_dir()
+    {:ok, dir: dir}
+  end
+
+  describe "action: definition" do
+    test "returns formatted location string and ui payload", %{dir: dir} do
+      path = write_elixir_file(dir)
+
+      assert {:ok, result, ui} =
+               Lsp.execute(
+                 %{"action" => "definition", "file" => path, "line" => 0, "character" => 0},
+                 ctx(dir)
+               )
+
+      # Fake server returns line 3, character 0 for any definition request
+      assert result =~ ":3:0"
+      assert ui.kind == :lsp
+      assert ui.payload.action == :definition
+      assert ui.payload.file == path
+      assert is_list(ui.payload.results)
+      assert length(ui.payload.results) == 1
+      [loc] = ui.payload.results
+      assert get_in(loc, ["range", "start", "line"]) == 3
+    end
+  end
+
+  describe "action: references" do
+    test "returns count and location list", %{dir: dir} do
+      path = write_elixir_file(dir)
+
+      assert {:ok, result, ui} =
+               Lsp.execute(
+                 %{"action" => "references", "file" => path, "line" => 0, "character" => 0},
+                 ctx(dir)
+               )
+
+      assert result =~ "3 reference(s)"
+      assert ui.payload.action == :references
+      assert length(ui.payload.results) == 3
+    end
+
+    test "forwards include_declaration: false to LSP params", %{dir: dir} do
+      path = write_elixir_file(dir)
+
+      # Fake server accepts any references request — just verify it succeeds
+      assert {:ok, result, _ui} =
+               Lsp.execute(
+                 %{
+                   "action" => "references",
+                   "file" => path,
+                   "line" => 0,
+                   "character" => 0,
+                   "include_declaration" => false
+                 },
+                 ctx(dir)
+               )
+
+      assert result =~ "reference(s)"
+    end
+  end
+
+  describe "action: hover" do
+    test "returns markdown content string", %{dir: dir} do
+      path = write_elixir_file(dir)
+
+      assert {:ok, result, ui} =
+               Lsp.execute(
+                 %{"action" => "hover", "file" => path, "line" => 0, "character" => 0},
+                 ctx(dir)
+               )
+
+      # Fake server returns "**doc** — doc text"
+      assert result =~ "doc text"
+      assert ui.payload.action == :hover
+    end
+  end
+
+  describe "action: diagnostics" do
+    test "returns diagnostics published on didOpen", %{dir: dir} do
+      path = write_elixir_file(dir)
+
+      Application.put_env(:ex_athena, :lsp_diagnostics_poll_ms, 5_000)
+      on_exit(fn -> Application.delete_env(:ex_athena, :lsp_diagnostics_poll_ms) end)
+
+      assert {:ok, result, ui} =
+               Lsp.execute(%{"action" => "diagnostics", "file" => path}, ctx(dir))
+
+      assert result =~ "error"
+      assert result =~ "undefined function"
+      assert ui.payload.action == :diagnostics
+      assert is_list(ui.payload.results)
+      assert length(ui.payload.results) >= 1
+    end
+
+    test "returns empty result (not error) when no diagnostics within timeout", %{dir: dir} do
+      path = write_elixir_file(dir)
+
+      # Suppress the publishDiagnostics side-effect before the tool runs
+      {:ok, pid} = Manager.client_for_file(dir, path)
+      Client.notify(pid, "notif/suppress_next_diag", %{})
+
+      # Short poll window so the test doesn't take long
+      Application.put_env(:ex_athena, :lsp_diagnostics_poll_ms, 200)
+      on_exit(fn -> Application.delete_env(:ex_athena, :lsp_diagnostics_poll_ms) end)
+
+      # Must be {:ok, ...}, never {:error, :timeout}
+      assert {:ok, result, ui} =
+               Lsp.execute(%{"action" => "diagnostics", "file" => path}, ctx(dir))
+
+      assert result == "count: 0"
+      assert ui.payload.results == []
+    end
+  end
+
+  describe "error: invalid / missing arguments" do
+    test "invalid action string returns {:error, :invalid_action}", %{dir: dir} do
+      path = write_elixir_file(dir)
+
+      assert {:error, :invalid_action} =
+               Lsp.execute(%{"action" => "unknown_action", "file" => path}, ctx(dir))
+    end
+
+    test "missing action key returns {:error, :missing_action}", %{dir: dir} do
+      assert {:error, :missing_action} =
+               Lsp.execute(%{"file" => "/some/file.ex"}, ctx(dir))
+    end
+
+    test "missing file key returns {:error, :missing_file}", %{dir: dir} do
+      assert {:error, :missing_file} =
+               Lsp.execute(%{"action" => "definition"}, ctx(dir))
+    end
+
+    test "missing position for definition returns {:error, :missing_position}", %{dir: dir} do
+      path = write_elixir_file(dir)
+
+      assert {:error, :missing_position} =
+               Lsp.execute(%{"action" => "definition", "file" => path}, ctx(dir))
+    end
+
+    test "missing position for references returns {:error, :missing_position}", %{dir: dir} do
+      path = write_elixir_file(dir)
+
+      assert {:error, :missing_position} =
+               Lsp.execute(%{"action" => "references", "file" => path}, ctx(dir))
+    end
+
+    test "missing position for hover returns {:error, :missing_position}", %{dir: dir} do
+      path = write_elixir_file(dir)
+
+      assert {:error, :missing_position} =
+               Lsp.execute(%{"action" => "hover", "file" => path}, ctx(dir))
+    end
+
+    test "unsupported file extension returns {:error, :unsupported_language}", %{dir: dir} do
+      unknown_path = Path.join(dir, "file.unknownext_xyz")
+      File.write!(unknown_path, "content")
+
+      assert {:error, :unsupported_language} =
+               Lsp.execute(
+                 %{
+                   "action" => "definition",
+                   "file" => unknown_path,
+                   "line" => 0,
+                   "character" => 0
+                 },
+                 ctx(dir)
+               )
+    end
+  end
+
+  describe "error: LSP server error response" do
+    test "surfaces {:error, {:lsp_error, map}} when server returns error object", %{dir: dir} do
+      path = write_elixir_file(dir)
+
+      # Arm the fake server to fail the next request with a MethodNotFound error
+      {:ok, pid} = Manager.client_for_file(dir, path)
+      Client.notify(pid, "notif/fail_next", %{})
+
+      # Give the notification time to reach the fake server before the tool sends
+      # the definition request — both go through the GenServer mailbox in order,
+      # but we add a brief sleep to let the port pipe drain.
+      Process.sleep(50)
+
+      assert {:error, {:lsp_error, err}} =
+               Lsp.execute(
+                 %{"action" => "definition", "file" => path, "line" => 0, "character" => 0},
+                 ctx(dir)
+               )
+
+      assert is_map(err)
+      assert Map.has_key?(err, "code")
+      assert Map.has_key?(err, "message")
+    end
+  end
+
+  describe "metadata" do
+    test "Lsp is in builtins registry" do
+      builtins = ExAthena.Tools.builtins()
+      assert Lsp in builtins
+    end
+
+    test "find/2 resolves \"lsp\" to the Lsp module" do
+      builtins = ExAthena.Tools.builtins()
+      assert ExAthena.Tools.find(builtins, "lsp") == Lsp
+    end
+
+    test "parallel_safe?/0 is true" do
+      assert Lsp.parallel_safe?() == true
+    end
+
+    test "\"lsp\" is allowed under :plan mode" do
+      tc = %ToolCall{id: "c1", name: "lsp", arguments: %{}}
+      ctx = ToolContext.new(cwd: "/tmp", phase: :plan)
+      assert :allow = Permissions.check(tc, ctx, %{})
+    end
+
+    test "\"lsp\" appears in Permissions.readonly_tools/0" do
+      assert "lsp" in Permissions.readonly_tools()
+    end
+  end
+
+  describe "didOpen precedes request" do
+    test "definition succeeds (proves didOpen was sent before the request)", %{dir: dir} do
+      path = write_elixir_file(dir)
+
+      # The fake server only responds to textDocument/definition after seeing
+      # textDocument/didOpen for the URI. A successful result proves ordering.
+      assert {:ok, result, _ui} =
+               Lsp.execute(
+                 %{"action" => "definition", "file" => path, "line" => 0, "character" => 0},
+                 ctx(dir)
+               )
+
+      assert is_binary(result)
+    end
+  end
+end

--- a/test/support/fake_lsp_server.exs
+++ b/test/support/fake_lsp_server.exs
@@ -58,7 +58,13 @@ defmodule FakeLspServer do
 
   def run do
     port = Port.open({:fd, 0, 1}, [:binary, :eof])
-    loop(port, "", %{suppress_next_diag: false, fail_next_request: false})
+    fail_init = System.get_env("FAKE_LSP_FAIL_INITIALIZE") == "1"
+
+    loop(port, "", %{
+      suppress_next_diag: false,
+      fail_next_request: false,
+      fail_initialize: fail_init
+    })
   end
 
   defp loop(port, buffer, state) do
@@ -151,7 +157,12 @@ defmodule FakeLspServer do
   # --- message handlers (each returns new state) ---
 
   defp handle(%{"method" => "initialize", "id" => id}, port, state) do
-    reply(port, id, %{"capabilities" => %{}})
+    if state.fail_initialize do
+      error_reply(port, id, -32602, "InvalidParams")
+    else
+      reply(port, id, %{"capabilities" => %{}})
+    end
+
     state
   end
 
@@ -191,6 +202,13 @@ defmodule FakeLspServer do
   # Suppress the next textDocument/didOpen publishDiagnostics side effect.
   defp handle(%{"method" => "notif/suppress_next_diag"}, _port, state) do
     %{state | suppress_next_diag: true}
+  end
+
+  # Synchronous request form: arms the fail_next flag and replies. Tests use
+  # this to avoid racing a notification against the next request.
+  defp handle(%{"method" => "notif/fail_next", "id" => id}, port, state) do
+    reply(port, id, %{"armed" => true})
+    %{state | fail_next_request: true}
   end
 
   # Make the next request (with an id) fail with a MethodNotFound error.

--- a/test/support/fake_lsp_server.exs
+++ b/test/support/fake_lsp_server.exs
@@ -1,0 +1,210 @@
+defmodule FakeLspServer do
+  @moduledoc """
+  Minimal LSP server script for testing ExAthena.Lsp.Client.
+
+  Run as: elixir test/support/fake_lsp_server.exs
+
+  No external dependencies required — uses only OTP stdlib.
+  """
+
+  # --- JSON encode (subset sufficient for LSP responses) ---
+
+  def encode(nil), do: "null"
+  def encode(true), do: "true"
+  def encode(false), do: "false"
+  def encode(:null), do: "null"
+  def encode(n) when is_integer(n), do: Integer.to_string(n)
+  def encode(f) when is_float(f), do: Float.to_string(f)
+
+  def encode(s) when is_binary(s) do
+    escaped =
+      s
+      |> String.replace("\\", "\\\\")
+      |> String.replace("\"", "\\\"")
+      |> String.replace("\n", "\\n")
+      |> String.replace("\r", "\\r")
+      |> String.replace("\t", "\\t")
+
+    ~s("#{escaped}")
+  end
+
+  def encode(list) when is_list(list) do
+    "[" <> Enum.map_join(list, ",", &encode/1) <> "]"
+  end
+
+  def encode(map) when is_map(map) do
+    pairs =
+      Enum.map_join(map, ",", fn {k, v} ->
+        "#{encode(to_string(k))}:#{encode(v)}"
+      end)
+
+    "{#{pairs}}"
+  end
+
+  # --- JSON decode using OTP 27 :json ---
+  # :json.decode maps JSON null → :null (not nil)
+
+  def decode(bin), do: :json.decode(bin)
+
+  # --- server loop ---
+  # Uses Port.open({:fd, 0, 1}, ...) to communicate via raw file descriptors,
+  # bypassing Erlang's IO system which is unreliable in port-subprocess context.
+
+  def run do
+    port = Port.open({:fd, 0, 1}, [:binary, :eof])
+    loop(port, "")
+  end
+
+  defp loop(port, buffer) do
+    receive do
+      {^port, {:data, data}} ->
+        process_buffer(port, buffer <> data)
+
+      {^port, :eof} ->
+        :ok
+
+      _other ->
+        loop(port, buffer)
+    end
+  end
+
+  defp process_buffer(port, buffer) do
+    case read_frame(buffer) do
+      {:ok, body, rest} ->
+        msg = decode(body)
+        handle(msg, port)
+        process_buffer(port, rest)
+
+      {:need_more, buf} ->
+        loop(port, buf)
+    end
+  end
+
+  defp read_frame(buf) do
+    case parse_header(buf) do
+      {:ok, len, body_buf} when byte_size(body_buf) >= len ->
+        <<body::binary-size(len), remaining::binary>> = body_buf
+        {:ok, body, remaining}
+
+      _ ->
+        {:need_more, buf}
+    end
+  end
+
+  defp parse_header(buf) do
+    with {cl_start, _} <- :binary.match(buf, "Content-Length:"),
+         rest <- binary_part(buf, cl_start, byte_size(buf) - cl_start),
+         {eol_pos, eol_len} <- find_eol(rest),
+         # "Content-Length:" is 15 chars; skip it and trim for the digits
+         digits_part <- rest |> binary_part(15, eol_pos - 15) |> String.trim(),
+         {len, ""} <- Integer.parse(digits_part),
+         after_first <- binary_part(rest, eol_pos + eol_len, byte_size(rest) - eol_pos - eol_len),
+         {:ok, body_offset} <- skip_to_body(after_first) do
+      body_buf = binary_part(after_first, body_offset, byte_size(after_first) - body_offset)
+      {:ok, len, body_buf}
+    else
+      _ -> :error
+    end
+  end
+
+  defp find_eol(buf) do
+    case :binary.match(buf, "\r\n") do
+      {pos, 2} ->
+        {pos, 2}
+
+      :nomatch ->
+        case :binary.match(buf, "\n") do
+          {pos, 1} -> {pos, 1}
+          :nomatch -> nil
+        end
+    end
+  end
+
+  defp skip_to_body(buf) do
+    cond do
+      String.starts_with?(buf, "\r\n") ->
+        {:ok, 2}
+
+      String.starts_with?(buf, "\n") ->
+        {:ok, 1}
+
+      true ->
+        case :binary.match(buf, "\r\n\r\n") do
+          {pos, 4} ->
+            {:ok, pos + 4}
+
+          :nomatch ->
+            case :binary.match(buf, "\n\n") do
+              {pos, 2} -> {:ok, pos + 2}
+              :nomatch -> :error
+            end
+        end
+    end
+  end
+
+  # --- message handlers ---
+
+  defp handle(%{"method" => "initialize", "id" => id}, port) do
+    reply(port, id, %{"capabilities" => %{}})
+  end
+
+  defp handle(%{"method" => "shutdown", "id" => id}, port) do
+    reply(port, id, nil)
+  end
+
+  defp handle(%{"method" => "exit"}, _port) do
+    System.halt(0)
+  end
+
+  defp handle(%{"method" => "textDocument/echo", "id" => id, "params" => params}, port) do
+    reply(port, id, params)
+  end
+
+  defp handle(%{"method" => "notif/trigger"}, port) do
+    notify(port, "textDocument/publishDiagnostics", %{
+      "uri" => "file:///test/foo.ex",
+      "diagnostics" => [
+        %{
+          "range" => %{
+            "start" => %{"line" => 0, "character" => 0},
+            "end" => %{"line" => 0, "character" => 3}
+          },
+          "severity" => 1,
+          "message" => "undefined function foo/0"
+        }
+      ]
+    })
+  end
+
+  defp handle(%{"method" => _method, "id" => id}, port) do
+    error_reply(port, id, -32601, "MethodNotFound")
+  end
+
+  defp handle(_notification, _port), do: :ok
+
+  # --- wire helpers ---
+
+  defp reply(port, id, result) do
+    send_msg(port, %{"jsonrpc" => "2.0", "id" => id, "result" => result})
+  end
+
+  defp error_reply(port, id, code, message) do
+    send_msg(port, %{
+      "jsonrpc" => "2.0",
+      "id" => id,
+      "error" => %{"code" => code, "message" => message}
+    })
+  end
+
+  defp notify(port, method, params) do
+    send_msg(port, %{"jsonrpc" => "2.0", "method" => method, "params" => params})
+  end
+
+  defp send_msg(port, msg) do
+    json = encode(msg)
+    frame = "Content-Length: #{byte_size(json)}\r\n\r\n#{json}"
+    Port.command(port, frame)
+  end
+end
+
+FakeLspServer.run()

--- a/test/support/fake_lsp_server.exs
+++ b/test/support/fake_lsp_server.exs
@@ -5,6 +5,12 @@ defmodule FakeLspServer do
   Run as: elixir test/support/fake_lsp_server.exs
 
   No external dependencies required — uses only OTP stdlib.
+
+  State flags:
+    * `:suppress_next_diag` — if true, the next textDocument/didOpen will NOT
+      emit publishDiagnostics (flag resets after use).
+    * `:fail_next_request` — if true, the next request with an `id` will reply
+      with a MethodNotFound error (flag resets after use).
   """
 
   # --- JSON encode (subset sufficient for LSP responses) ---
@@ -52,31 +58,31 @@ defmodule FakeLspServer do
 
   def run do
     port = Port.open({:fd, 0, 1}, [:binary, :eof])
-    loop(port, "")
+    loop(port, "", %{suppress_next_diag: false, fail_next_request: false})
   end
 
-  defp loop(port, buffer) do
+  defp loop(port, buffer, state) do
     receive do
       {^port, {:data, data}} ->
-        process_buffer(port, buffer <> data)
+        process_buffer(port, buffer <> data, state)
 
       {^port, :eof} ->
         :ok
 
       _other ->
-        loop(port, buffer)
+        loop(port, buffer, state)
     end
   end
 
-  defp process_buffer(port, buffer) do
+  defp process_buffer(port, buffer, state) do
     case read_frame(buffer) do
       {:ok, body, rest} ->
         msg = decode(body)
-        handle(msg, port)
-        process_buffer(port, rest)
+        new_state = handle(msg, port, state)
+        process_buffer(port, rest, new_state)
 
       {:need_more, buf} ->
-        loop(port, buf)
+        loop(port, buf, state)
     end
   end
 
@@ -142,25 +148,29 @@ defmodule FakeLspServer do
     end
   end
 
-  # --- message handlers ---
+  # --- message handlers (each returns new state) ---
 
-  defp handle(%{"method" => "initialize", "id" => id}, port) do
+  defp handle(%{"method" => "initialize", "id" => id}, port, state) do
     reply(port, id, %{"capabilities" => %{}})
+    state
   end
 
-  defp handle(%{"method" => "shutdown", "id" => id}, port) do
+  defp handle(%{"method" => "shutdown", "id" => id}, port, state) do
     reply(port, id, nil)
+    state
   end
 
-  defp handle(%{"method" => "exit"}, _port) do
+  defp handle(%{"method" => "exit"}, _port, _state) do
     System.halt(0)
   end
 
-  defp handle(%{"method" => "textDocument/echo", "id" => id, "params" => params}, port) do
+  defp handle(%{"method" => "textDocument/echo", "id" => id, "params" => params}, port, state) do
     reply(port, id, params)
+    state
   end
 
-  defp handle(%{"method" => "notif/trigger"}, port) do
+  # Original trigger notification — fires diagnostics for the fixed test URI.
+  defp handle(%{"method" => "notif/trigger"}, port, state) do
     notify(port, "textDocument/publishDiagnostics", %{
       "uri" => "file:///test/foo.ex",
       "diagnostics" => [
@@ -174,13 +184,119 @@ defmodule FakeLspServer do
         }
       ]
     })
+
+    state
   end
 
-  defp handle(%{"method" => _method, "id" => id}, port) do
+  # Suppress the next textDocument/didOpen publishDiagnostics side effect.
+  defp handle(%{"method" => "notif/suppress_next_diag"}, _port, state) do
+    %{state | suppress_next_diag: true}
+  end
+
+  # Make the next request (with an id) fail with a MethodNotFound error.
+  defp handle(%{"method" => "notif/fail_next"}, _port, state) do
+    %{state | fail_next_request: true}
+  end
+
+  # textDocument/didOpen — optionally publish diagnostics for the opened URI.
+  defp handle(%{"method" => "textDocument/didOpen", "params" => params}, port, state) do
+    uri = get_in(params, ["textDocument", "uri"]) || ""
+
+    unless state.suppress_next_diag do
+      notify(port, "textDocument/publishDiagnostics", %{
+        "uri" => uri,
+        "diagnostics" => [
+          %{
+            "range" => %{
+              "start" => %{"line" => 0, "character" => 0},
+              "end" => %{"line" => 0, "character" => 5}
+            },
+            "severity" => 1,
+            "message" => "undefined function foo/0"
+          }
+        ]
+      })
+    end
+
+    %{state | suppress_next_diag: false}
+  end
+
+  # textDocument/definition — returns a deterministic single-location list.
+  defp handle(
+         %{"method" => "textDocument/definition", "id" => id, "params" => params},
+         port,
+         state
+       ) do
+    if state.fail_next_request do
+      error_reply(port, id, -32601, "MethodNotFound")
+      %{state | fail_next_request: false}
+    else
+      uri = get_in(params, ["textDocument", "uri"]) || ""
+
+      reply(port, id, [
+        %{
+          "uri" => uri,
+          "range" => %{
+            "start" => %{"line" => 3, "character" => 0},
+            "end" => %{"line" => 3, "character" => 10}
+          }
+        }
+      ])
+
+      state
+    end
+  end
+
+  # textDocument/references — returns three deterministic locations.
+  defp handle(
+         %{"method" => "textDocument/references", "id" => id, "params" => params},
+         port,
+         state
+       ) do
+    if state.fail_next_request do
+      error_reply(port, id, -32601, "MethodNotFound")
+      %{state | fail_next_request: false}
+    else
+      uri = get_in(params, ["textDocument", "uri"]) || ""
+
+      locations =
+        Enum.map(0..2, fn i ->
+          %{
+            "uri" => uri,
+            "range" => %{
+              "start" => %{"line" => i, "character" => 0},
+              "end" => %{"line" => i, "character" => 5}
+            }
+          }
+        end)
+
+      reply(port, id, locations)
+      state
+    end
+  end
+
+  # textDocument/hover — returns markdown contents.
+  defp handle(%{"method" => "textDocument/hover", "id" => id, "params" => _params}, port, state) do
+    if state.fail_next_request do
+      error_reply(port, id, -32601, "MethodNotFound")
+      %{state | fail_next_request: false}
+    else
+      reply(port, id, %{
+        "contents" => %{"kind" => "markdown", "value" => "**doc** — doc text"}
+      })
+
+      state
+    end
+  end
+
+  # Catch-all for unknown requests with id — optionally fail, otherwise MethodNotFound.
+  defp handle(%{"method" => _method, "id" => id}, port, state) do
     error_reply(port, id, -32601, "MethodNotFound")
+    %{state | fail_next_request: false}
   end
 
-  defp handle(_notification, _port), do: :ok
+  # Catch-all for notifications (no id) — ignore.
+  defp handle(_notification, _port, state), do: state
 
   # --- wire helpers ---
 


### PR DESCRIPTION
## Summary

Introduces first-class Language Server Protocol (LSP) integration into ex_athena, giving agents semantic-grade code intelligence (go-to-definition, find-references, diagnostics, hover) without baking language-specific parsing into the runtime. Closes #27.

Previously, agents relied on `grep`/`bash` heuristics for symbol lookup and had no way to know whether an `Edit` introduced a compile error until a separate shell command was run. This PR closes that loop.

## Key Changes

- **`ExAthena.Lsp.Manager`** — supervised GenServer that spawns and tracks LSP server processes per `(project_root, language)` pair using OS Ports for stdio communication. Language is auto-detected from file extension via a built-in server registry (`elixir-ls`, `pyright`, `rust-analyzer`, `gopls`, etc.).

- **`ExAthena.Lsp.Client`** — JSON-RPC 2.0 client implementing the LSP wire protocol: `initialize`, `textDocument/definition`, `textDocument/references`, `textDocument/diagnostic`, `textDocument/hover`.

- **`ExAthena.Tools.Lsp`** — built-in tool exposing `definition`, `references`, `diagnostics`, and `hover` actions. LSP queries are treated as read-only and are permitted under `:plan` mode by default.

- **`ExAthena.Lsp.ImplicitDiagnostics`** — a built-in `:PostToolUse` hook that fires automatically after every `Edit`/`Write` call, runs `textDocument/diagnostic` on the affected file, and appends any errors or warnings to the tool-result the model sees on the next turn — no explicit `lsp` tool call required.

- **`{:augment, text}` hook return value** — extends the `:PostToolUse` hook contract with a new return type that appends text to the outgoing tool-result. Multiple augments are joined with `"
"`; `halt` takes priority. The hooks reference is updated to v0.5 to reflect this addition and the expanded `:PostToolUse` payload (`arguments`, `cwd`).

- **Config scaffolding** — adds `config/config.exs` with per-environment splits. `config/test.exs` disables the LSP supervisor, worktree/checkpoint sweepers, and implicit diagnostics globally so existing tests are unaffected; individual `ImplicitDiagnostics` tests opt back in explicitly.

## Implementation Notes

- The implicit diagnostics hook is the primary UX win for Elixir consumers: after any `Edit` to a `.ex` file, `elixir-ls` diagnostics surface in the same turn, replacing the need to shell out to `mix compile` to verify a refactor compiled cleanly.
- Telemetry events emitted: `[:ex_athena, :lsp, :spawn]`, `[:ex_athena, :lsp, :request, :start]`, `[:ex_athena, :lsp, :request, :stop]`.
- v1 scope is intentionally read-only. Write-side LSP operations (`rename`, `codeAction`, workspace-wide symbol search) and custom server registries are deferred.

Closes https://github.com/udin-io/ex_athena/issues/27