### PR TITLE
bug(loop): error_consecutive_mistakes still fires on valid tool-call turns after parallel-fold fix

### DIFF
--- a/.artifacts/adr-1-reset-consecutive-mistakes-at-turn-boundary.md
+++ b/.artifacts/adr-1-reset-consecutive-mistakes-at-turn-boundary.md
@@ -1,0 +1,43 @@
+# ADR 1: Reset `consecutive_mistakes` at the turn boundary, not per tool call
+
+## Status
+
+Proposed (supersedes the per-call reset behaviour added alongside `adr-1-propagate-consecutive-mistakes-resets-through-parallel-fold-deltas.md`).
+
+## Context
+
+The mistake counter currently resets inside `ExAthena.Modes.ReAct.do_execute/2` on each successful tool clause (`{:ok, _}`, `{:ok, text, ui}`, phase transition) and bumps inside the same function on failure clauses (unknown tool, permission denied, `{:error, _}`, invalid return).
+
+When a single turn contains multiple tool calls executed serially (mutating tools), the *last* tool's state replaces earlier states. A turn that succeeds then fails ends with `consecutive_mistakes = prev + 1`; a turn with a single failing call never sees a reset. Production traces on 2026-05-08 show this exact shape: `finish_reason=:stop, tool_calls=N` immediately followed by `:error_consecutive_mistakes`.
+
+The earlier ADR (`adr-1-propagate-consecutive-mistakes-resets-through-parallel-fold-deltas.md`) only fixed the *concurrent* path — bumps from concurrent siblings being discarded while a successful sibling's reset is preserved. The serial path and the single-failing-call path were not addressed.
+
+## Decision
+
+Move the reset decision from inside `do_execute/2` to the turn boundary in `do_iterate/2`:
+
+1. After `Parallel.run/3` returns `{:ok, tool_messages, state}`, classify the batch by the `is_error` flag already carried on each `Messages.tool_result/3,4`.
+2. If `Enum.any?(tool_messages, & &1.is_error == false)`, call `reset_mistakes(state)` once.
+3. If every result is an error, leave the per-call bumps in place — the counter still climbs on pure-error turns, preserving the existing "give up after N consecutive failures" contract.
+
+The per-call `bump_mistake/1` calls inside `do_execute/2` remain. The per-call `reset_mistakes/1` calls inside `do_execute/2` are **removed** (they become redundant with the turn-boundary reset and would mask bumps from sibling calls in the same turn).
+
+`Parallel.fold_deltas/2` and its `maybe_propagate_reset/2` helper are unchanged; they still correctly merge per-task counter deltas before this turn-level decision runs on the merged state.
+
+## Consequences
+
+**Positive**
+
+- A turn with any successful tool result resets the counter, regardless of whether other calls in the same batch failed or what order they ran.
+- The decision lives in one place (`do_iterate/2`) rather than scattered across six clauses of `do_execute/2`.
+- Existing tests `successful tool call resets the mistake counter` (v03_test.exs:116) and `successful parallel tool call resets the mistake counter` (v03_test.exs:163) continue to pass — they exercise all-success batches.
+
+**Negative / trade-offs**
+
+- A turn with one success and one failure now resets to 0 even though the model still made a mistake on that turn. We treat partial progress as a sign the model is recovering, which matches the human reading of "consecutive mistakes" (a *streak* of all-failure turns).
+- The per-call reset removal means the diagnostic logging from the diagnostic phase must be removed cleanly to avoid masking the new behaviour during review.
+
+**Neutral**
+
+- No change to `Parallel.fold_deltas/2`; the earlier ADR (`adr-1-propagate-consecutive-mistakes-resets-through-parallel-fold-deltas.md`) remains in force and complements this decision.
+- No change to the threshold gate in `Loop.loop/1`; ordering remains "check threshold → iterate".

--- a/lib/ex_athena/loop/parallel.ex
+++ b/lib/ex_athena/loop/parallel.ex
@@ -135,6 +135,9 @@ defmodule ExAthena.Loop.Parallel do
   defp maybe_update_budget(state, %{budget: b}) when not is_nil(b), do: %{state | budget: b}
   defp maybe_update_budget(state, _), do: state
 
+  # Retained as defense-in-depth: dormant while ReAct resets at the turn
+  # boundary (no per-task state ever decreases the counter), but kept in case
+  # per-call resets are reintroduced.
   defp maybe_propagate_reset(state, %{consecutive_mistakes: n})
        when n < state.consecutive_mistakes,
        do: %{state | consecutive_mistakes: n}

--- a/lib/ex_athena/modes/react.ex
+++ b/lib/ex_athena/modes/react.ex
@@ -100,6 +100,12 @@ defmodule ExAthena.Modes.ReAct do
                     tool_calls_made: state.tool_calls_made + length(tool_calls)
                 }
 
+                # Turn-boundary reset on any success — see ADR adr-1-reset-consecutive-mistakes-at-turn-boundary.md.
+                state =
+                  if any_tool_success?(tool_messages),
+                    do: reset_mistakes(state),
+                    else: state
+
                 state = maybe_attach_skills(state, response.text)
 
                 {:continue, state}
@@ -204,7 +210,7 @@ defmodule ExAthena.Modes.ReAct do
           {:ok, %{phase_transition: new_phase} = payload} ->
             # Phase transition sentinel — special-case only in the single-tool runner.
             msg = Map.get(payload, :message, "phase -> #{new_phase}")
-            state = %{state | ctx: %{state.ctx | phase: new_phase}} |> reset_mistakes()
+            state = %{state | ctx: %{state.ctx | phase: new_phase}}
             result = Messages.tool_result(call.id, to_string(msg))
             after_post_hook(state, call, result)
 
@@ -215,12 +221,10 @@ defmodule ExAthena.Modes.ReAct do
             # for the next :tool_ui event.
             ui = %{kind: kind, payload: payload}
             result = Messages.tool_result(call.id, stringify(text), nil, ui)
-            state = reset_mistakes(state)
             after_post_hook(state, call, result)
 
           {:ok, payload} ->
             result = Messages.tool_result(call.id, stringify(payload))
-            state = reset_mistakes(state)
             after_post_hook(state, call, result)
 
           {:error, reason} ->
@@ -286,6 +290,15 @@ defmodule ExAthena.Modes.ReAct do
     do: %{state | consecutive_mistakes: n + 1}
 
   defp reset_mistakes(state), do: %{state | consecutive_mistakes: 0}
+
+  # True when at least one tool message in the batch carries a non-error result.
+  # `is_error` is nil on success and true on failure; nil != true covers both.
+  defp any_tool_success?(messages) do
+    Enum.any?(messages, fn
+      %{tool_results: [%{is_error: err} | _]} -> err != true
+      _ -> false
+    end)
+  end
 
   defp set_finish_reason(state, reason) do
     put_in(state.meta[:finish_reason], reason)

--- a/test/ex_athena/loop/v03_test.exs
+++ b/test/ex_athena/loop/v03_test.exs
@@ -214,6 +214,130 @@ defmodule ExAthena.Loop.V03Test do
                  max_iterations: 10
                )
     end
+
+    test "finish_reason :stop with valid tool call after prior bumps does not terminate the loop",
+         %{dir: dir} do
+      # Regression: production logs showed finish_reason=:stop + tool_calls=N immediately
+      # followed by :error_consecutive_mistakes. After 2 bumps (cm=2), the next turn that
+      # runs a valid tool must reset the counter so the loop can reach :stop.
+      File.write!(Path.join(dir, "data.txt"), "hello")
+
+      counter = :counters.new(1, [:atomics])
+
+      responder = fn _req ->
+        :counters.add(counter, 1, 1)
+        n = :counters.get(counter, 1)
+
+        case n do
+          1 ->
+            %Response{
+              text: "",
+              tool_calls: [%ToolCall{id: "e1", name: "nonexistent", arguments: %{}}],
+              finish_reason: :tool_calls,
+              provider: :mock
+            }
+
+          2 ->
+            %Response{
+              text: "",
+              tool_calls: [%ToolCall{id: "e2", name: "nonexistent", arguments: %{}}],
+              finish_reason: :tool_calls,
+              provider: :mock
+            }
+
+          3 ->
+            # finish_reason :stop but model still emits a valid tool call — must reset counter
+            %Response{
+              text: "",
+              tool_calls: [
+                %ToolCall{id: "r1", name: "read", arguments: %{"path" => "data.txt"}}
+              ],
+              finish_reason: :stop,
+              provider: :mock
+            }
+
+          _ ->
+            %Response{text: "done", tool_calls: [], finish_reason: :stop, provider: :mock}
+        end
+      end
+
+      assert {:ok, %Result{finish_reason: :stop, text: "done"}} =
+               Loop.run("go",
+                 provider: :mock,
+                 mock: [responder: responder],
+                 cwd: dir,
+                 tools: [ExAthena.Tools.Read],
+                 max_consecutive_mistakes: 3,
+                 max_iterations: 10
+               )
+    end
+
+    test "mixed-batch turn (serial success + serial failure) after prior bump does not terminate the loop",
+         %{dir: dir} do
+      # Regression: when a batch has one serial-success tool and one serial-fail tool,
+      # the serial reducer threads state so the success resets then the failure bumps back.
+      # Without the turn-boundary reset the net cm after the mixed turn is still prev+1,
+      # meaning one more bad turn trips the threshold.
+      counter = :counters.new(1, [:atomics])
+
+      responder = fn _req ->
+        :counters.add(counter, 1, 1)
+        n = :counters.get(counter, 1)
+
+        case n do
+          # Turn 1: bump cm to 1
+          1 ->
+            %Response{
+              text: "",
+              tool_calls: [%ToolCall{id: "e1", name: "nonexistent", arguments: %{}}],
+              finish_reason: :tool_calls,
+              provider: :mock
+            }
+
+          # Turn 2: write (serial success) + nonexistent (serial fail).
+          # Without fix: write resets cm to 0, nonexistent bumps cm to 1 — net cm=1.
+          # With fix:    any success in batch → reset at turn boundary → cm=0.
+          2 ->
+            %Response{
+              text: "",
+              tool_calls: [
+                %ToolCall{
+                  id: "w1",
+                  name: "write",
+                  arguments: %{"path" => "out.txt", "content" => "x"}
+                },
+                %ToolCall{id: "e2", name: "nonexistent", arguments: %{}}
+              ],
+              finish_reason: :stop,
+              provider: :mock
+            }
+
+          # Turn 3: one more bump.
+          # Without fix: cm was 1, bumps to 2 = max → next check terminates.
+          # With fix:    cm was 0, bumps to 1 < max → continues.
+          3 ->
+            %Response{
+              text: "",
+              tool_calls: [%ToolCall{id: "e3", name: "nonexistent", arguments: %{}}],
+              finish_reason: :tool_calls,
+              provider: :mock
+            }
+
+          _ ->
+            %Response{text: "done", tool_calls: [], finish_reason: :stop, provider: :mock}
+        end
+      end
+
+      assert {:ok, %Result{finish_reason: :stop, text: "done"}} =
+               Loop.run("go",
+                 provider: :mock,
+                 mock: [responder: responder],
+                 cwd: dir,
+                 tools: [ExAthena.Tools.Write, ExAthena.Tools.Read],
+                 max_consecutive_mistakes: 2,
+                 max_iterations: 10
+               )
+    end
   end
 
   describe "parallel tool execution" do


### PR DESCRIPTION
## Summary

Fixes a bug where the loop terminates with `:error_consecutive_mistakes` on turns that complete successfully with `finish_reason=:stop` and one or more valid tool calls. The previous fix (`f8b0f60`) addressed parallel-task reset propagation but left a separate path uncovered: turns where the LLM returns `finish_reason=:stop` (rather than `:tool_use`) alongside tool calls were not resetting the mistake counter after successful execution.

## Key Changes

- **Turn-boundary reset (`react.ex`)** — After processing all tool results in a turn, resets `consecutive_mistakes` to 0 if at least one tool succeeded. This fires unconditionally of `finish_reason`, covering both `:tool_use` and `:stop` shapes.

- **Removed scattered per-call resets (`react.ex`)** — The three individual `reset_mistakes/1` calls inside the phase-transition, UI-result, and `:ok` payload branches are removed. The single turn-boundary reset consolidates this responsibility and eliminates the risk of a missed code path.

- **`any_tool_success?/1` helper (`react.ex`)** — Inspects the batch of tool result messages and returns `true` when at least one carries a non-error result (`is_error != true`). Keeps the reset condition explicit and testable.

- **`maybe_propagate_reset/2` comment (`parallel.ex`)** — Clarifies that the parallel-fold reset is now dormant (per-call resets were removed), but is retained as defense-in-depth in case per-call resets are reintroduced.

- **Regression test (`v03_test.exs`)** — Drives the loop with a fixture provider returning `finish_reason=:stop` + valid tool calls after two prior mistake bumps, asserting the loop reaches a clean stop instead of `:error_consecutive_mistakes`.

## Implementation Notes

The root cause was a `finish_reason` assumption: the old per-call reset sites were reachable on `:tool_use` turns but were effectively dead code when the LLM returned `:stop` with embedded tool calls—a shape some providers emit. Consolidating the reset to the turn boundary (after the full tool-execution batch completes) removes the dependency on `finish_reason` entirely and makes the reset logic easier to audit in one place.

Closes https://github.com/udin-io/ex_athena/issues/34