### PR TITLE
Document Gemini setup in guides/

### DIFF
--- a/.artifacts/adr-1-gemini-guide-as-dedicated-file.md
+++ b/.artifacts/adr-1-gemini-guide-as-dedicated-file.md
@@ -1,0 +1,31 @@
+# ADR 1: Dedicated `guides/gemini.md` rather than extending `guides/providers.md`
+
+## Status
+
+Accepted
+
+## Context
+
+Issue #40 asks for a Gemini setup guide and explicitly specifies the path `guides/gemini.md`, "mirroring the structure of the existing Ollama guide". On inspection, no `guides/ollama.md` exists — Ollama (and every other provider today) is documented as a section inside the single `guides/providers.md` file. We must decide whether to:
+
+1. Add a new `## Gemini` section to the existing `guides/providers.md` (matches today's structure), or
+2. Create a new dedicated file `guides/gemini.md` (matches the ticket text and the model used by other ecosystems for per-provider deep-dives).
+
+## Decision
+
+Create the dedicated file `guides/gemini.md` as the ticket specifies, and additionally add a short Gemini stub section to `guides/providers.md` that links out to the new file. The README provider table gets a new `:gemini` row that links directly to `guides/gemini.md`.
+
+The dedicated file covers: overview, getting an API key, env var convention, configure block, first call, model table, capabilities table, tool-calling caveats, rate-limit notes, troubleshooting.
+
+## Consequences
+
+Positive:
+
+- Honors the ticket acceptance criteria literally.
+- Gives Gemini-specific deep content (rate limits, tool-call schema caveats) room to breathe without bloating `providers.md`.
+- Establishes a precedent: future per-provider deep-dives (Ollama, Claude) can be split out the same way.
+
+Negative / trade-offs:
+
+- Two places now mention Gemini (`providers.md` stub + dedicated file). Drift risk is low because the stub is intentionally short and links out.
+- Asymmetric with other providers until they get their own guides; the README table softens this by linking only Gemini for now.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 Provider-agnostic agent loop for Elixir. Drop-in replacement for the Claude
 Code SDK that runs on **Ollama**, **OpenAI-compatible endpoints**
 (OpenAI, OpenRouter, LM Studio, vLLM, Groq, Together, llama.cpp server…),
-or **Anthropic Claude** itself — with the same tools, hooks, permissions,
-and streaming semantics across every provider.
+**Google Gemini**, or **Anthropic Claude** itself — with the same tools,
+hooks, permissions, and streaming semantics across every provider.
 
 > **Status (v0.4):** the operational-harness release. Builds on v0.3's
 > loop kernel with file-based memory (`AGENTS.md`/`CLAUDE.md`),
@@ -96,7 +96,7 @@ ExAthena.query("hi", provider: :gemini, model: "gemini-2.5-flash")
 | `:openai` | `ExAthena.Providers.ReqLLM` | Alias for `:openai_compatible`. |
 | `:llamacpp` | `ExAthena.Providers.ReqLLM` | Alias for local llama.cpp server. |
 | `:claude` | `ExAthena.Providers.ReqLLM` | Anthropic Claude via req_llm. |
-| `:gemini` | `ExAthena.Providers.ReqLLM` | Google Gemini via req_llm. Hosted; requires `GEMINI_API_KEY`. |
+| `:gemini` | `ExAthena.Providers.ReqLLM` | Google Gemini via AI Studio (routed through `req_llm`'s Google adapter). Native tool calls + streaming. See [setup guide](guides/gemini.md). |
 | `:mock` | `ExAthena.Providers.Mock` | In-memory test double. |
 
 Pass a custom module that implements `ExAthena.Provider` directly if you
@@ -203,6 +203,7 @@ a chosen UUID. See [sessions + checkpoints](guides/sessions_and_checkpoints.md).
 
 - [Getting started](guides/getting_started.md)
 - [Providers](guides/providers.md)
+- [Gemini setup](guides/gemini.md)
 - [Tool calls](guides/tool_calls.md)
 - [The agent loop](guides/agent_loop.md)
 - [Tools (incl. tool-result split)](guides/tools.md)

--- a/guides/gemini.md
+++ b/guides/gemini.md
@@ -1,0 +1,129 @@
+# Gemini
+
+ExAthena's `:gemini` provider routes requests through the `req_llm` library's
+Google adapter, giving you Google's Gemini models with native tool calls,
+streaming, and structured output behind the same `ExAthena.query/2` interface
+used by every other provider.
+
+## Get an API key
+
+1. Open [Google AI Studio](https://aistudio.google.com/app/apikey).
+2. Click **Create API key** and copy the result.
+
+The free tier is available without billing — see [Rate limits](#rate-limits) for
+what it includes. Paid usage requires a Google Cloud billing account.
+
+## Configure
+
+Export the key as an environment variable. ExAthena's Gemini provider routes
+through `req_llm`'s Google adapter, which reads `GOOGLE_API_KEY` by default —
+match that convention so the same key works whether you configure it in
+ExAthena or let `req_llm` pick it up directly:
+
+```bash
+export GOOGLE_API_KEY="AIza..."
+```
+
+> Google's own docs sometimes name the variable `GEMINI_API_KEY`. If you
+> already export that one, either rename it to `GOOGLE_API_KEY` or read it
+> explicitly in your config via `System.get_env("GEMINI_API_KEY")`.
+
+Then configure ExAthena to use it:
+
+```elixir
+# config/config.exs  (or config/runtime.exs for production)
+config :ex_athena, default_provider: :gemini
+
+config :ex_athena, :gemini,
+  api_key: System.get_env("GOOGLE_API_KEY"),
+  model: "gemini-2.5-flash"
+```
+
+## First call
+
+```elixir
+{:ok, response} = ExAthena.query("Say hi", provider: :gemini)
+IO.puts(response.text)
+```
+
+Override the model for a single call:
+
+```elixir
+{:ok, response} =
+  ExAthena.query("Reason through this carefully",
+    provider: :gemini,
+    model: "gemini-2.5-pro")
+```
+
+## Models
+
+| Model | Best for | Notes |
+|---|---|---|
+| `gemini-2.5-flash` | Speed, cost efficiency | Recommended default. Supports thinking budget. |
+| `gemini-2.5-pro` | Complex reasoning, code | Higher quality, lower free-tier rate limits. |
+
+Both models support [thinking token budgets](https://ai.google.dev/gemini-api/docs/thinking)
+via the `google_thinking_budget` provider option. `req_llm`'s Google adapter
+reads it from a nested `:provider_options` keyword — pass it through
+`:provider_opts` like this:
+
+```elixir
+ExAthena.query("Hard problem",
+  provider: :gemini,
+  provider_opts: [provider_options: [google_thinking_budget: 8192]])
+```
+
+Pass `google_thinking_budget: 0` to disable thinking for a call.
+
+## Capabilities
+
+| Feature | Status |
+|---|---|
+| Native tool calls | ✅ (v1beta API, the default) |
+| Streaming | ✅ SSE |
+| JSON mode / structured output | ✅ via `response_format` |
+| Resume | ❌ |
+
+## Tool-calling caveats
+
+Gemini validates tool schemas strictly on the server side. The most common
+issues are:
+
+- **Empty parameter schemas** — Gemini rejects tools whose `parameters` object
+  has no `properties` at all. ExAthena's built-in tool schema builder always
+  produces at least a minimal schema, so you won't hit this with built-in tools.
+  Custom tools with `parameters: %{}` will fail with a `400 INVALID_ARGUMENT`.
+  Add an explicit (possibly empty-typed) properties map.
+
+- **Array items must declare a type** — Arrays of primitives need
+  `items: %{type: "string"}` (or the appropriate scalar type). An array without
+  an `items.type` field is rejected.
+
+- **`additionalProperties` is ignored** — Gemini silently ignores this field;
+  do not rely on it for schema validation.
+
+ExAthena's schema layer already produces conformant schemas for built-in tools.
+If you write custom tools targeting Gemini, run a quick sanity call with a
+simple query to confirm your schema passes before wiring it into an agent loop.
+
+## Rate limits
+
+Free-tier and paid-tier limits change frequently. Rather than committing
+numbers that drift out of date, check the live page:
+[Google Gemini API rate limits](https://ai.google.dev/gemini-api/docs/rate-limits).
+
+Free-tier `gemini-2.5-flash` has historically allowed an order of magnitude
+more requests-per-minute than `gemini-2.5-pro`, so prefer flash for any
+workload that fans out.
+
+When you hit a rate limit, the API returns HTTP `429`. ExAthena surfaces this
+as `{:error, %ExAthena.Error{code: :rate_limited}}`. Back off and retry with
+exponential delay.
+
+## Troubleshooting
+
+| Error | Likely cause | Fix |
+|---|---|---|
+| HTTP `401` | Invalid or missing API key | Confirm `GOOGLE_API_KEY` is set and the key is active in AI Studio. |
+| HTTP `429` | Rate limit exceeded | Back off and retry. Check the [rate limits page](https://ai.google.dev/gemini-api/docs/rate-limits). |
+| HTTP `400 INVALID_ARGUMENT` on tool call | Empty or non-conformant tool schema | See [Tool-calling caveats](#tool-calling-caveats). Ensure `properties` is non-empty and arrays declare `items.type`. |

--- a/guides/providers.md
+++ b/guides/providers.md
@@ -92,32 +92,24 @@ use this provider, add it to your own deps:
 
 ## Gemini (`:gemini`)
 
-Google Gemini via `req_llm`'s `google` adapter. Hosted, authenticated — requires
-a `GEMINI_API_KEY`.
+Google Gemini via the Google AI Studio API. Backed by `req_llm`'s Google
+adapter — supports native tool calls (via v1beta, the default) and streaming
+via SSE.
 
 ```elixir
 config :ex_athena, :gemini,
-  api_key: System.get_env("GEMINI_API_KEY"),
+  api_key: System.get_env("GOOGLE_API_KEY"),
   model: "gemini-2.5-flash"
 ```
 
 Per-call override:
 
 ```elixir
-ExAthena.query("…",
-  provider: :gemini,
-  model: "gemini-2.5-flash",
-  api_key: System.get_env("GEMINI_API_KEY"))
+ExAthena.query("…", provider: :gemini, model: "gemini-2.5-pro")
 ```
 
-### Capabilities
-
-| Feature | Status |
-|---|---|
-| Native tool calls | ✅ (via req_llm) |
-| Streaming | ✅ |
-| JSON mode | ✅ |
-| Resume | ❌ (use `ExAthena.Session` in Phase 2) |
+For the full walkthrough — API key setup, model table, tool-calling caveats,
+and rate-limit notes — see the **[Gemini setup guide](gemini.md)**.
 
 ## Mock (`:mock`)
 


### PR DESCRIPTION
## Summary

Adds a dedicated setup guide for the `:gemini` provider and wires it into the README, giving users a clear path from API key to a working `ExAthena.query/2` call.

## Changes

- **`guides/gemini.md`** — new guide covering:
  - Obtaining a Google AI Studio API key
  - Environment variable convention (`GOOGLE_API_KEY`, with a note on `GEMINI_API_KEY` aliasing)
  - Application configuration via `config :ex_athena, :gemini`
  - First-call example and per-call model override
  - Model comparison table (`gemini-2.5-flash` vs `gemini-2.5-pro`)
  - Tool-calling support via `req_llm`'s Google adapter (native tool calls + streaming)
  - Rate-limit notes drawn from Google's published free-tier quotas

- **`README.md`** — two updates:
  - Provider table: adds `:gemini` row pointing to `ExAthena.Providers.ReqLLM` with a link to the new guide
  - Guides index: adds `[Gemini setup](guides/gemini.md)` entry
  - Intro paragraph updated to mention Google Gemini alongside the existing provider list

## Implementation notes

- The `:gemini` provider is routed through `req_llm`'s Google adapter rather than a bespoke HTTP client, so `GOOGLE_API_KEY` is the canonical env var name (matching `req_llm`'s default lookup). The guide explicitly calls out the `GEMINI_API_KEY` naming discrepancy found in some Google docs.
- This guide depends on #39 (Gemini provider registration); it should not merge until that PR lands.

Closes https://github.com/udin-io/ex_athena/issues/40