### PR TITLE
Support multimodal (image) content in Message / req_llm adapter

### DIFF
--- a/.artifacts/adr-1-images-shorthand-in-request-new.md
+++ b/.artifacts/adr-1-images-shorthand-in-request-new.md
@@ -1,0 +1,42 @@
+# ADR: `images:` shorthand implemented in `Request.new/2`
+
+## Status
+
+Accepted
+
+## Context
+
+Sub-tickets 1 and 2 introduced `ExAthena.Messages.ContentPart` and updated the req_llm adapter to forward multimodal content. The remaining gap is that callers must manually construct `[%ContentPart{...}, ...]` lists and wrap them in a `Messages.user/1` call. The parent issue requests an ergonomic shorthand so the common case (attach image to the current turn) is a single option.
+
+Two possible insertion points were considered:
+
+1. **`Request.new/2`** — the shared normalisation layer used by `query/2`, `stream/3`, and `run/2`
+2. **`ExAthena.Loop.build_initial_state/2`** — the loop-only state builder
+
+## Decision
+
+Implement `images:` handling in `Request.new/2`. This makes the shorthand available for all three public entry points (`query/2`, `stream/3`, `run/2`) at zero duplication cost.
+
+`normalize_images/1` maps each image spec to a `ContentPart` struct:
+- `%{data: binary(), media_type: String.t()}` → `ContentPart.image(data, media_type)`
+- `%{url: String.t()}` → `ContentPart.image_url(url)`
+- `%{data: binary()}` (no media_type) → `ContentPart.image(data, "image/png")`
+
+`build_messages/3` dispatches on `{prompt, image_parts}`:
+- No images → unchanged three-clause behaviour (preserves backward compatibility)
+- Images + non-empty prompt → `existing ++ [Messages.user([ContentPart.text(prompt) | image_parts])]`
+- Images + nil/empty prompt → merge into last user message in `existing`, or append a new user message with just image parts
+
+`find_last_user/1` uses `Enum.reverse` + `Enum.split_while` to locate and split around the last user-role message without requiring `Enum.reduce` with index tracking.
+
+## Consequences
+
+**Positive:**
+- Single implementation point; no duplication across `query/2` and `run/2`.
+- Existing text-only callers are entirely unaffected; the no-images clauses are identical to the previous implementation.
+- Type-safe: image specs are eagerly normalized to `ContentPart` structs before the messages list is assembled.
+- `stream/3` automatically gains `images:` support at no extra cost since it also calls `Request.new/2`.
+
+**Negative / watch:**
+- `Request.new/2` now silently consumes `:images` from opts. If a future caller passes `:images` for an unrelated purpose the key will be consumed without error. This is unlikely given the key's self-documenting name.
+- The `find_last_user/1` helper performs two `Enum.reverse` calls on the messages list; negligible for typical conversation lengths but worth noting for extremely long histories.

--- a/.artifacts/adr-1-introduce-exathenamessages-contentpart-thin-wrapper.md
+++ b/.artifacts/adr-1-introduce-exathenamessages-contentpart-thin-wrapper.md
@@ -1,0 +1,53 @@
+# ADR: Introduce ExAthena.Messages.ContentPart as a Thin Provider-Agnostic Wrapper
+
+## Status
+
+Accepted
+
+## Context
+
+`ExAthena.Messages.Message.content` is currently `String.t() | nil`. The `req_llm` library (which
+backs all ExAthena providers) already has full multimodal support via `ReqLLM.Message.ContentPart`
+with variants `:text`, `:image`, `:image_url`, `:video_url`, `:file`, `:thinking`. ExAthena cannot
+propagate image content to providers because there is no place in its data model to store it.
+
+Two design options were considered:
+
+1. **Re-export `ReqLLM.Message.ContentPart` directly** — use the upstream struct as ExAthena's
+   public content-part type.
+2. **Thin wrapper `ExAthena.Messages.ContentPart`** — introduce a new ExAthena-owned struct that
+   mirrors the relevant subset of `ReqLLM.Message.ContentPart`'s types and factory API.
+
+## Decision
+
+Introduce `ExAthena.Messages.ContentPart` as a **thin wrapper** (option 2).
+
+The struct has fields `[:type, :text, :url, :data, :media_type, :filename]` and supports four
+variants for the initial release: `:text`, `:image`, `:image_url`, `:file`. Factory functions
+(`text/1`, `image/1-2`, `image_url/1`, `file/2-3`) intentionally mirror `ReqLLM.Message.ContentPart`'s
+factory API so the mapping in the req_llm adapter is mechanical.
+
+`Message.content` is widened to `String.t() | [ExAthena.Messages.ContentPart.t()] | nil`. Existing
+string-content code paths are unaffected. A new `user/1` clause accepting `is_list(parts)` is added
+alongside the existing binary clause.
+
+The module lives at `lib/ex_athena/messages/content_part.ex` (its own file) rather than as a nested
+module in `messages.ex`, because it is a first-class public type that callers will import independently.
+
+## Consequences
+
+**Positive:**
+- ExAthena's public API does not depend on `req_llm` types; callers need not import `req_llm` directly.
+- Future providers (direct HTTP, native Anthropic SDK) map from `ExAthena.Messages.ContentPart` to
+  their own native format without changing the public data model.
+- The subset approach (four types, not six) avoids committing to `:thinking` and `:video_url` until
+  there is a clear use case and acceptance criteria.
+- Factory signatures are identical to `ReqLLM.Message.ContentPart`'s, making the adapter mapping in
+  sub-ticket 2 a one-to-one substitution with no cognitive overhead.
+- All existing callers pass string content; the widened union type is purely additive.
+
+**Negative:**
+- Introduces a thin wrapper that must be kept in sync with the upstream library when new content types
+  are needed (e.g., `:video_url`, `:thinking`).
+- Callers who already construct `ReqLLM.Message.ContentPart` directly cannot pass those structs into
+  `ExAthena.Messages.Message.content` without conversion.

--- a/.artifacts/adr-1-multimodal-content-part-forwarding-in-req-llm-adapter.md
+++ b/.artifacts/adr-1-multimodal-content-part-forwarding-in-req-llm-adapter.md
@@ -1,0 +1,33 @@
+# ADR: Forward ExAthena.Messages.ContentPart through req_llm adapter
+
+## Status
+Accepted
+
+## Context
+
+Sub-ticket 1 introduced `ExAthena.Messages.ContentPart` and extended `Message.content` to `String.t() | [ContentPart.t()] | nil`. The req_llm adapter's `text_parts/1` function only handled binary strings, leaving list content unhandled. Without a conversion path, multimodal messages (containing `:image`, `:image_url`, or `:file` content parts) would raise a `FunctionClauseError` at runtime rather than being forwarded to providers.
+
+`ReqLLM.Message.ContentPart` already provides exact-matching constructors — `text/1`, `image/2`, `image_url/1`, `file/3` — so the mapping is one-to-one with no impedance mismatch.
+
+## Decision
+
+Add a `text_parts/1` clause for `is_list(parts)` that maps each `ExAthena.Messages.ContentPart` to its `ReqLLM.Message.ContentPart` counterpart via a private `to_req_llm_content_part/1` helper. The mapping covers all four current variants:
+
+- `:text` → `ReqLLM.Message.ContentPart.text(text)`
+- `:image` → `ReqLLM.Message.ContentPart.image(data, media_type)`
+- `:image_url` → `ReqLLM.Message.ContentPart.image_url(url)`
+- `:file` → `ReqLLM.Message.ContentPart.file(data, filename, media_type)`
+
+No changes to any `to_req_llm_message/1` clauses are required — all roles (`:user`, `:system`, `:assistant`, `:tool`) already delegate to `text_parts/1`.
+
+The helper is private, keeping the conversion logic encapsulated within the adapter module.
+
+## Consequences
+
+**Positive:**
+- Multimodal messages constructed as `[ContentPart.t()]` now flow correctly to all req_llm-backed providers (Ollama, OpenAI-compatible, Gemini).
+- All existing string-only callers are completely unaffected — the `nil`, `""`, and `binary` clauses are unchanged.
+- The change is purely additive — no public API signatures change.
+
+**Negative / Trade-offs:**
+- Any future `ContentPart` type added to `ExAthena.Messages.ContentPart` (e.g., `:video_url`) will require a corresponding `to_req_llm_content_part/1` clause. This is a deliberate explicit mapping rather than a dynamic passthrough, to maintain type safety at the provider boundary. A missing clause will raise `FunctionClauseError` at runtime, which is preferable to silently dropping content.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,20 @@ ExAthena.query("hi", provider: :ollama, model: "qwen2.5-coder")
 ExAthena.query("hi", provider: :gemini, model: "gemini-2.5-flash")
 ```
 
+Attach images with the `images:` shorthand — same API across every provider:
+
+```elixir
+png = File.read!("diagram.png")
+{:ok, response} = ExAthena.query("Describe this diagram",
+  provider: :ollama,
+  model: "llava",
+  images: [%{data: png, media_type: "image/png"}]
+)
+```
+
+See the [Multimodal guide](guides/multimodal.md) for inline images, URL
+references, and per-provider notes.
+
 ## Providers
 
 | Provider | Module | Notes |
@@ -203,6 +217,7 @@ a chosen UUID. See [sessions + checkpoints](guides/sessions_and_checkpoints.md).
 
 - [Getting started](guides/getting_started.md)
 - [Providers](guides/providers.md)
+- [Multimodal (vision)](guides/multimodal.md)
 - [Gemini setup](guides/gemini.md)
 - [Tool calls](guides/tool_calls.md)
 - [The agent loop](guides/agent_loop.md)

--- a/guides/multimodal.md
+++ b/guides/multimodal.md
@@ -1,0 +1,195 @@
+# Multimodal (Vision)
+
+ExAthena supports multimodal messages — text plus images — through the
+`ExAthena.Messages.ContentPart` struct. Two entry points are available: the
+ergonomic `images:` shorthand for quick one-liners, and full `ContentPart`
+construction for complex payloads.
+
+## Quick start: `images:` shorthand
+
+Pass `images: [...]` to `ExAthena.query/2`, `ExAthena.stream/3`, or
+`ExAthena.run/2` alongside a prompt string:
+
+```elixir
+png = File.read!("diagram.png")
+
+{:ok, response} =
+  ExAthena.query("Describe what you see",
+    provider: :ollama,
+    model: "llava",
+    images: [%{data: png, media_type: "image/png"}]
+  )
+
+IO.puts(response.text)
+```
+
+Each entry in the `images:` list may be one of:
+
+| Shape | Description |
+|---|---|
+| `%{data: binary(), media_type: String.t()}` | Inline image bytes |
+| `%{data: binary()}` | Inline image, media type defaults to `"image/png"` |
+| `%{url: String.t()}` | Remote image URL |
+
+ExAthena builds a multimodal user message with the text part first, followed
+by the image parts. When no prompt is given, the images are merged into the
+last user message in `:messages`, or appended as a new user message.
+
+## Full `ContentPart` approach
+
+For finer control — mixing text, images, and files in arbitrary order — build
+`ContentPart` structs directly and pass them as the message content:
+
+```elixir
+alias ExAthena.Messages
+alias ExAthena.Messages.ContentPart
+
+png = File.read!("chart.png")
+pdf = File.read!("report.pdf")
+
+parts = [
+  ContentPart.text("Summarize the chart and cross-reference the report:"),
+  ContentPart.image(png, "image/png"),
+  ContentPart.file(pdf, "report.pdf", "application/pdf")
+]
+
+{:ok, response} =
+  ExAthena.query(nil,
+    provider: :claude,
+    model: "claude-opus-4-7",
+    messages: [Messages.user(parts)]
+  )
+```
+
+### ContentPart factory functions
+
+| Function | Type | Fields |
+|---|---|---|
+| `ContentPart.text(content)` | `:text` | `text` |
+| `ContentPart.image(data, media_type \\ "image/png")` | `:image` | `data`, `media_type` |
+| `ContentPart.image_url(url)` | `:image_url` | `url` |
+| `ContentPart.file(data, filename, media_type \\ "application/octet-stream")` | `:file` | `data`, `filename`, `media_type` |
+
+## Provider examples
+
+### Ollama (llava, qwen2-vl)
+
+```elixir
+# config/config.exs
+config :ex_athena, :ollama,
+  base_url: "http://localhost:11434",
+  model: "llava"
+
+# usage
+png = File.read!("screenshot.png")
+
+{:ok, response} =
+  ExAthena.query("What is shown in this screenshot?",
+    provider: :ollama,
+    model: "llava",
+    images: [%{data: png, media_type: "image/png"}]
+  )
+```
+
+Pull a vision-capable model first:
+
+```bash
+ollama pull llava
+# or
+ollama pull qwen2-vl
+```
+
+Ollama vision support is model-dependent. Non-vision models will return an
+error or silently ignore image parts.
+
+### OpenAI-compatible (gpt-4o)
+
+```elixir
+{:ok, response} =
+  ExAthena.query("What's in this image?",
+    provider: :openai_compatible,
+    model: "gpt-4o",
+    images: [%{url: "https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/PNG_transparency_demonstration_1.png/280px-PNG_transparency_demonstration_1.png"}]
+  )
+```
+
+For inline images with the OpenAI API:
+
+```elixir
+png = File.read!("photo.jpg")
+
+{:ok, response} =
+  ExAthena.query("Describe the photo",
+    provider: :openai_compatible,
+    model: "gpt-4o-mini",
+    images: [%{data: png, media_type: "image/jpeg"}]
+  )
+```
+
+### Anthropic Claude
+
+```elixir
+png = File.read!("diagram.png")
+
+{:ok, response} =
+  ExAthena.query("Explain this architecture diagram",
+    provider: :claude,
+    model: "claude-opus-4-7",
+    images: [%{data: png, media_type: "image/png"}]
+  )
+```
+
+Claude supports PNG, JPEG, GIF, and WebP. Maximum image size is 5 MB per
+image.
+
+### Google Gemini
+
+```elixir
+png = File.read!("chart.png")
+
+{:ok, response} =
+  ExAthena.query("What trend does this chart show?",
+    provider: :gemini,
+    model: "gemini-2.5-flash",
+    images: [%{data: png, media_type: "image/png"}]
+  )
+```
+
+## Using `images:` in the agent loop
+
+`ExAthena.run/2` forwards `images:` to `Request.new/2` so the first turn
+has the image attached:
+
+```elixir
+png = File.read!("codebase_diagram.png")
+
+{:ok, result} =
+  ExAthena.run("Implement the architecture shown in this diagram",
+    provider: :claude,
+    model: "claude-opus-4-7",
+    cwd: "/path/to/project",
+    images: [%{data: png, media_type: "image/png"}]
+  )
+```
+
+## Image format notes
+
+- **Inline images** are sent as base64-encoded data to the provider. The
+  `req_llm` adapter handles encoding transparently.
+- **Image URLs** (`%{url: ...}`) are forwarded as-is. The provider fetches
+  the image at inference time. Not all providers support URL references —
+  prefer inline for maximum compatibility.
+- **media_type** should match the actual image format (`"image/png"`,
+  `"image/jpeg"`, `"image/gif"`, `"image/webp"`). Some providers are lenient;
+  others require an accurate MIME type.
+- **Multiple images** in one message are supported by all major providers
+  (Claude, OpenAI, Gemini). Ollama support is model-dependent.
+
+## Vision support by provider
+
+| Provider | Vision support | Notes |
+|---|---|---|
+| `:ollama` | Model-dependent | `llava`, `qwen2-vl`, `llava-phi3`, `bakllava` |
+| `:openai_compatible` | ✅ `gpt-4o`, `gpt-4o-mini` | URL + inline; other OAI-compat endpoints vary |
+| `:claude` | ✅ Any `claude-3`+ model | PNG, JPEG, GIF, WebP; max 5 MB per image |
+| `:gemini` | ✅ Any `gemini-1.5`+ model | Inline + URL; very generous size limits |

--- a/guides/providers.md
+++ b/guides/providers.md
@@ -135,6 +135,20 @@ ExAthena.stream("hi", fn _ -> :ok end,
   mock_events: events)
 ```
 
+## Vision / multimodal
+
+Vision support varies by provider. Pass `images: [%{data: binary(), media_type: String.t()}]`
+(or `%{url: String.t()}` entries) to any `ExAthena.query/2`, `ExAthena.stream/3`, or
+`ExAthena.run/2` call. See the **[Multimodal guide](multimodal.md)** for the full
+walkthrough including examples for each provider.
+
+| Provider | Vision support | Notes |
+|---|---|---|
+| `:ollama` | Model-dependent | `llava`, `qwen2-vl`, `llava-phi3`, `bakllava` |
+| `:openai_compatible` | ✅ gpt-4o, gpt-4o-mini | URL + inline |
+| `:claude` | ✅ Any `claude-3`+ model | PNG, JPEG, GIF, WebP |
+| `:gemini` | ✅ Any `gemini-1.5`+ model | Inline + URL |
+
 ## Custom providers
 
 Implement the `ExAthena.Provider` behaviour:

--- a/lib/ex_athena.ex
+++ b/lib/ex_athena.ex
@@ -70,6 +70,11 @@ defmodule ExAthena do
     * `:timeout_ms` — request timeout (default 60_000).
     * `:provider_opts` — escape hatch keyword list passed through to the
       underlying provider.
+    * `:images` — list of image maps to attach to the trailing user message.
+      Each entry is `%{data: binary(), media_type: String.t()}` for inline
+      images or `%{url: String.t()}` for remote image URLs. Merged into the
+      user message created from `prompt`, or the last user message in
+      `:messages` when no prompt is given.
   """
   @spec query(String.t() | nil, keyword()) :: {:ok, Response.t()} | {:error, term()}
   def query(prompt \\ nil, opts \\ []) do
@@ -86,7 +91,7 @@ defmodule ExAthena do
   and its return value is ignored. Callbacks must not block the caller; if you
   need to do expensive work per-delta, hand off to a `Task`.
 
-  Options are the same as `query/3`.
+  Options are the same as `query/2`, including `:images`.
   """
   @spec stream(String.t() | nil, function(), keyword()) ::
           {:ok, Response.t()} | {:error, term()}

--- a/lib/ex_athena/loop.ex
+++ b/lib/ex_athena/loop.ex
@@ -23,8 +23,9 @@ defmodule ExAthena.Loop do
       `ExAthena.Provider`.
     * `:model`, `:system_prompt`, `:messages`, `:temperature`, `:top_p`,
       `:max_tokens`, `:stop`, `:timeout_ms`, `:tool_choice`,
-      `:response_format`, `:provider_opts`, `:metadata` — forwarded to
-      `ExAthena.Request.new/2`.
+      `:response_format`, `:provider_opts`, `:metadata`, `:images` —
+      forwarded to `ExAthena.Request.new/2`. See `ExAthena.query/2` for
+      the `:images` shorthand (inline and URL images).
     * `:tools` — list of modules implementing `ExAthena.Tool` or `:all`
       (default — all builtins). `nil` falls back to `config :ex_athena,
       tools: …`.

--- a/lib/ex_athena/messages.ex
+++ b/lib/ex_athena/messages.ex
@@ -109,7 +109,7 @@ defmodule ExAthena.Messages do
   def from_map(map) when is_map(map) do
     %Message{
       role: fetch_role(map),
-      content: fetch(map, :content),
+      content: maybe_content_parts(fetch(map, :content)),
       tool_calls: maybe_tool_calls(fetch(map, :tool_calls)),
       tool_results: maybe_tool_results(fetch(map, :tool_results)),
       name: fetch(map, :name)
@@ -127,6 +127,35 @@ defmodule ExAthena.Messages do
 
   defp fetch(map, key) when is_atom(key) do
     Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  end
+
+  defp maybe_content_parts(nil), do: nil
+  defp maybe_content_parts(str) when is_binary(str), do: str
+
+  defp maybe_content_parts(parts) when is_list(parts),
+    do: Enum.map(parts, &to_content_part/1)
+
+  defp to_content_part(%ExAthena.Messages.ContentPart{} = cp), do: cp
+
+  defp to_content_part(map) when is_map(map) do
+    type = fetch_atom(map, :type)
+
+    %ExAthena.Messages.ContentPart{
+      type: type,
+      text: fetch(map, :text),
+      url: fetch(map, :url),
+      data: fetch(map, :data),
+      media_type: fetch(map, :media_type),
+      filename: fetch(map, :filename)
+    }
+  end
+
+  defp fetch_atom(map, key) do
+    case fetch(map, key) do
+      nil -> nil
+      v when is_atom(v) -> v
+      v when is_binary(v) -> String.to_existing_atom(v)
+    end
   end
 
   defp maybe_tool_calls(nil), do: nil

--- a/lib/ex_athena/messages.ex
+++ b/lib/ex_athena/messages.ex
@@ -57,7 +57,7 @@ defmodule ExAthena.Messages do
     @type role :: :system | :user | :assistant | :tool
     @type t :: %__MODULE__{
             role: role(),
-            content: String.t() | nil,
+            content: String.t() | [ExAthena.Messages.ContentPart.t()] | nil,
             tool_calls: [ToolCall.t()] | nil,
             tool_results: [ToolResult.t()] | nil,
             name: String.t() | nil
@@ -65,9 +65,12 @@ defmodule ExAthena.Messages do
   end
 
   @doc "Build a user message."
-  @spec user(String.t()) :: Message.t()
+  @spec user(String.t() | [ExAthena.Messages.ContentPart.t()]) :: Message.t()
   def user(content) when is_binary(content),
     do: %Message{role: :user, content: content}
+
+  def user(parts) when is_list(parts),
+    do: %Message{role: :user, content: parts}
 
   @doc "Build an assistant message (optionally with tool calls)."
   @spec assistant(String.t() | nil, [ToolCall.t()] | nil) :: Message.t()

--- a/lib/ex_athena/messages/content_part.ex
+++ b/lib/ex_athena/messages/content_part.ex
@@ -1,0 +1,36 @@
+defmodule ExAthena.Messages.ContentPart do
+  @moduledoc """
+  A single piece of content within a message — text, inline image, image URL, or file.
+
+  Provider-agnostic counterpart to `ReqLLM.Message.ContentPart`. The req_llm adapter
+  maps each variant to the matching `ReqLLM.Message.ContentPart` factory.
+  """
+
+  @enforce_keys [:type]
+  defstruct [:type, :text, :url, :data, :media_type, :filename]
+
+  @type type :: :text | :image | :image_url | :file
+
+  @type t :: %__MODULE__{
+          type: type(),
+          text: String.t() | nil,
+          url: String.t() | nil,
+          data: binary() | nil,
+          media_type: String.t() | nil,
+          filename: String.t() | nil
+        }
+
+  @spec text(String.t()) :: t()
+  def text(content), do: %__MODULE__{type: :text, text: content}
+
+  @spec image(binary(), String.t()) :: t()
+  def image(data, media_type \\ "image/png"),
+    do: %__MODULE__{type: :image, data: data, media_type: media_type}
+
+  @spec image_url(String.t()) :: t()
+  def image_url(url), do: %__MODULE__{type: :image_url, url: url}
+
+  @spec file(binary(), String.t(), String.t()) :: t()
+  def file(data, filename, media_type \\ "application/octet-stream"),
+    do: %__MODULE__{type: :file, data: data, filename: filename, media_type: media_type}
+end

--- a/lib/ex_athena/providers/req_llm.ex
+++ b/lib/ex_athena/providers/req_llm.ex
@@ -198,6 +198,30 @@ defmodule ExAthena.Providers.ReqLLM do
   defp text_parts(content) when is_binary(content),
     do: [ReqLLM.Message.ContentPart.text(content)]
 
+  defp text_parts(parts) when is_list(parts),
+    do: Enum.map(parts, &to_req_llm_content_part/1)
+
+  defp to_req_llm_content_part(%ExAthena.Messages.ContentPart{type: :text, text: text}),
+    do: ReqLLM.Message.ContentPart.text(text)
+
+  defp to_req_llm_content_part(%ExAthena.Messages.ContentPart{
+         type: :image,
+         data: data,
+         media_type: media_type
+       }),
+       do: ReqLLM.Message.ContentPart.image(data, media_type)
+
+  defp to_req_llm_content_part(%ExAthena.Messages.ContentPart{type: :image_url, url: url}),
+    do: ReqLLM.Message.ContentPart.image_url(url)
+
+  defp to_req_llm_content_part(%ExAthena.Messages.ContentPart{
+         type: :file,
+         data: data,
+         filename: filename,
+         media_type: media_type
+       }),
+       do: ReqLLM.Message.ContentPart.file(data, filename, media_type)
+
   defp format_tool_calls(calls) do
     Enum.map(calls, fn tc ->
       ReqLLM.ToolCall.new(tc.id, tc.name, encode_arguments(tc.arguments))

--- a/lib/ex_athena/request.ex
+++ b/lib/ex_athena/request.ex
@@ -108,24 +108,26 @@ defmodule ExAthena.Request do
     end
   end
 
-  @doc false
-  @spec normalize_images([map()]) :: [ContentPart.t()]
-  def normalize_images([]), do: []
+  defp normalize_images([]), do: []
 
-  def normalize_images(images) do
+  defp normalize_images(images) do
     Enum.map(images, fn
-      %{url: url} -> ContentPart.image_url(url)
-      %{data: data, media_type: media_type} -> ContentPart.image(data, media_type)
-      %{data: data} -> ContentPart.image(data, "image/png")
+      %{url: url} ->
+        ContentPart.image_url(url)
+
+      %{data: data, media_type: media_type} ->
+        ContentPart.image(data, media_type)
+
+      %{data: data} ->
+        ContentPart.image(data, "image/png")
+
+      other ->
+        raise ArgumentError,
+              "invalid image spec #{inspect(other)}; expected %{data: binary(), media_type: String.t()}, %{data: binary()}, or %{url: String.t()}"
     end)
   end
 
-  # Split messages around the last user-role message.
-  # Returns {before, last_user_msg, after} or :none.
-  @doc false
-  @spec find_last_user([Message.t()]) ::
-          {[Message.t()], Message.t(), [Message.t()]} | :none
-  def find_last_user(messages) do
+  defp find_last_user(messages) do
     reversed = Enum.reverse(messages)
 
     case Enum.split_while(reversed, fn m -> m.role != :user end) do

--- a/lib/ex_athena/request.ex
+++ b/lib/ex_athena/request.ex
@@ -8,7 +8,7 @@ defmodule ExAthena.Request do
   """
 
   alias ExAthena.Messages
-  alias ExAthena.Messages.Message
+  alias ExAthena.Messages.{ContentPart, Message}
 
   @enforce_keys [:messages]
   defstruct [
@@ -48,17 +48,21 @@ defmodule ExAthena.Request do
 
   The prompt is prepended to `opts[:messages]` as a user message. Pass `nil`
   to start from a pre-built message list.
+
+  ## Images shorthand
+
+  Pass `images: [%{data: binary(), media_type: String.t()}]` to attach inline
+  images to the trailing user message. Each entry may also use
+  `%{url: String.t()}` for remote image URLs. When a non-empty prompt is
+  given, a multimodal user message is built with the text first followed by
+  image parts. When prompt is `nil` or `""`, image parts are merged into the
+  last user message in `:messages`, or appended as a new user message.
   """
   @spec new(String.t() | nil, keyword()) :: t()
   def new(prompt, opts) do
     existing = opts |> Keyword.get(:messages, []) |> Enum.map(&Messages.from_map/1)
-
-    messages =
-      case prompt do
-        nil -> existing
-        "" -> existing
-        str when is_binary(str) -> existing ++ [Messages.user(str)]
-      end
+    image_parts = opts |> Keyword.get(:images, []) |> normalize_images()
+    messages = build_messages(prompt, existing, image_parts)
 
     %__MODULE__{
       messages: messages,
@@ -75,5 +79,61 @@ defmodule ExAthena.Request do
       provider_opts: Keyword.get(opts, :provider_opts),
       metadata: Keyword.get(opts, :metadata)
     }
+  end
+
+  # No images — existing behavior unchanged
+  defp build_messages(nil, existing, []), do: existing
+  defp build_messages("", existing, []), do: existing
+  defp build_messages(str, existing, []) when is_binary(str), do: existing ++ [Messages.user(str)]
+
+  # Non-empty prompt + images → multimodal user message (text first, then images)
+  defp build_messages(str, existing, image_parts) when is_binary(str) and str != "" do
+    existing ++ [Messages.user([ContentPart.text(str) | image_parts])]
+  end
+
+  # No prompt (nil or "") + images → merge into last user message or append new one
+  defp build_messages(_prompt, existing, image_parts) do
+    case find_last_user(existing) do
+      {before, %Message{content: text} = msg, after_msgs} when is_binary(text) ->
+        before ++ [%{msg | content: [ContentPart.text(text) | image_parts]}] ++ after_msgs
+
+      {before, %Message{content: parts} = msg, after_msgs} when is_list(parts) ->
+        before ++ [%{msg | content: parts ++ image_parts}] ++ after_msgs
+
+      {before, %Message{} = msg, after_msgs} ->
+        before ++ [%{msg | content: image_parts}] ++ after_msgs
+
+      :none ->
+        existing ++ [Messages.user(image_parts)]
+    end
+  end
+
+  @doc false
+  @spec normalize_images([map()]) :: [ContentPart.t()]
+  def normalize_images([]), do: []
+
+  def normalize_images(images) do
+    Enum.map(images, fn
+      %{url: url} -> ContentPart.image_url(url)
+      %{data: data, media_type: media_type} -> ContentPart.image(data, media_type)
+      %{data: data} -> ContentPart.image(data, "image/png")
+    end)
+  end
+
+  # Split messages around the last user-role message.
+  # Returns {before, last_user_msg, after} or :none.
+  @doc false
+  @spec find_last_user([Message.t()]) ::
+          {[Message.t()], Message.t(), [Message.t()]} | :none
+  def find_last_user(messages) do
+    reversed = Enum.reverse(messages)
+
+    case Enum.split_while(reversed, fn m -> m.role != :user end) do
+      {_suffix, []} ->
+        :none
+
+      {suffix_rev, [last_user | rest_rev]} ->
+        {Enum.reverse(rest_rev), last_user, Enum.reverse(suffix_rev)}
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -72,6 +72,7 @@ defmodule ExAthena.MixProject do
         "CHANGELOG.md",
         "guides/getting_started.md",
         "guides/providers.md",
+        "guides/multimodal.md",
         "guides/tool_calls.md",
         "guides/tools.md",
         "guides/agent_loop.md",

--- a/test/ex_athena/loop_test.exs
+++ b/test/ex_athena/loop_test.exs
@@ -265,4 +265,30 @@ defmodule ExAthena.LoopTest do
     assert result.text == "done"
     assert File.read!(Path.join(dir, "new.txt")) == "hi"
   end
+
+  test "images: shorthand reaches the provider as ContentPart content", %{dir: dir} do
+    alias ExAthena.Messages.ContentPart
+
+    png = <<0::8>>
+
+    responder = fn request ->
+      user_msg = Enum.find(request.messages, &(&1.role == :user))
+
+      assert [%ContentPart{type: :text, text: "describe"}, %ContentPart{type: :image}] =
+               user_msg.content
+
+      %Response{text: "saw image", tool_calls: [], finish_reason: :stop, provider: :mock}
+    end
+
+    assert {:ok, result} =
+             Loop.run("describe",
+               provider: :mock,
+               mock: [responder: responder],
+               cwd: dir,
+               tools: [],
+               images: [%{data: png, media_type: "image/png"}]
+             )
+
+    assert result.text == "saw image"
+  end
 end

--- a/test/ex_athena/messages/content_part_test.exs
+++ b/test/ex_athena/messages/content_part_test.exs
@@ -1,0 +1,48 @@
+defmodule ExAthena.Messages.ContentPartTest do
+  use ExUnit.Case, async: true
+  alias ExAthena.Messages.ContentPart
+
+  describe "text/1" do
+    test "returns a :text content part" do
+      assert %ContentPart{type: :text, text: "hello"} = ContentPart.text("hello")
+    end
+  end
+
+  describe "image/2" do
+    test "returns an :image content part with explicit media_type" do
+      data = <<0, 1, 2>>
+
+      assert %ContentPart{type: :image, data: ^data, media_type: "image/jpeg"} =
+               ContentPart.image(data, "image/jpeg")
+    end
+
+    test "defaults media_type to image/png" do
+      assert %ContentPart{type: :image, media_type: "image/png"} = ContentPart.image(<<0>>)
+    end
+  end
+
+  describe "image_url/1" do
+    test "returns an :image_url content part" do
+      assert %ContentPart{type: :image_url, url: "https://example.com/img.png"} =
+               ContentPart.image_url("https://example.com/img.png")
+    end
+  end
+
+  describe "file/3" do
+    test "returns a :file content part with explicit media_type" do
+      data = "pdf bytes"
+
+      assert %ContentPart{
+               type: :file,
+               data: ^data,
+               filename: "doc.pdf",
+               media_type: "application/pdf"
+             } = ContentPart.file(data, "doc.pdf", "application/pdf")
+    end
+
+    test "defaults media_type to application/octet-stream" do
+      assert %ContentPart{type: :file, media_type: "application/octet-stream"} =
+               ContentPart.file("bytes", "file.bin")
+    end
+  end
+end

--- a/test/ex_athena/messages_test.exs
+++ b/test/ex_athena/messages_test.exs
@@ -2,7 +2,7 @@ defmodule ExAthena.MessagesTest do
   use ExUnit.Case, async: true
 
   alias ExAthena.Messages
-  alias ExAthena.Messages.{Message, ToolCall, ToolResult}
+  alias ExAthena.Messages.{ContentPart, Message, ToolCall, ToolResult}
 
   describe "constructors" do
     test "user/1" do
@@ -24,6 +24,17 @@ defmodule ExAthena.MessagesTest do
                role: :tool,
                tool_results: [%ToolResult{tool_call_id: "c1", content: "done"}]
              } = Messages.tool_result("c1", "done")
+    end
+  end
+
+  describe "multimodal user/1" do
+    test "accepts a list of content parts" do
+      parts = [ContentPart.text("describe"), ContentPart.image_url("https://example.com/x.png")]
+      assert %Message{role: :user, content: ^parts} = Messages.user(parts)
+    end
+
+    test "existing string behaviour is unchanged" do
+      assert %Message{role: :user, content: "hello"} = Messages.user("hello")
     end
   end
 

--- a/test/ex_athena/providers/req_llm_test.exs
+++ b/test/ex_athena/providers/req_llm_test.exs
@@ -314,4 +314,67 @@ defmodule ExAthena.Providers.ReqLLMTest do
       refute Keyword.has_key?(opts, :response_format)
     end
   end
+
+  describe "to_req_llm_message/1 multimodal content" do
+    alias ExAthena.Messages
+    alias ExAthena.Messages.ContentPart
+
+    test "text ContentPart list converts to ReqLLM text parts" do
+      msg = Messages.user([ContentPart.text("hello")])
+      result = Adapter.to_req_llm_message(msg)
+      assert [%ReqLLM.Message.ContentPart{type: :text, text: "hello"}] = result.content
+    end
+
+    test "image ContentPart converts to ReqLLM image part" do
+      data = "base64data"
+      msg = Messages.user([ContentPart.image(data, "image/png")])
+      result = Adapter.to_req_llm_message(msg)
+
+      assert [%ReqLLM.Message.ContentPart{type: :image, data: ^data, media_type: "image/png"}] =
+               result.content
+    end
+
+    test "image_url ContentPart converts to ReqLLM image_url part" do
+      msg = Messages.user([ContentPart.image_url("https://example.com/img.png")])
+      result = Adapter.to_req_llm_message(msg)
+
+      assert [%ReqLLM.Message.ContentPart{type: :image_url, url: "https://example.com/img.png"}] =
+               result.content
+    end
+
+    test "file ContentPart converts to ReqLLM file part" do
+      msg = Messages.user([ContentPart.file("filedata", "doc.pdf", "application/pdf")])
+      result = Adapter.to_req_llm_message(msg)
+
+      assert [
+               %ReqLLM.Message.ContentPart{
+                 type: :file,
+                 data: "filedata",
+                 filename: "doc.pdf",
+                 media_type: "application/pdf"
+               }
+             ] = result.content
+    end
+
+    test "mixed ContentParts (text + image_url) convert in order" do
+      parts = [
+        ContentPart.text("describe this"),
+        ContentPart.image_url("https://example.com/img.png")
+      ]
+
+      msg = Messages.user(parts)
+      result = Adapter.to_req_llm_message(msg)
+
+      assert [
+               %ReqLLM.Message.ContentPart{type: :text, text: "describe this"},
+               %ReqLLM.Message.ContentPart{type: :image_url, url: "https://example.com/img.png"}
+             ] = result.content
+    end
+
+    test "existing text-only messages still work" do
+      msg = Messages.user("plain text")
+      result = Adapter.to_req_llm_message(msg)
+      assert [%ReqLLM.Message.ContentPart{type: :text, text: "plain text"}] = result.content
+    end
+  end
 end

--- a/test/ex_athena/request_test.exs
+++ b/test/ex_athena/request_test.exs
@@ -1,0 +1,143 @@
+defmodule ExAthena.RequestTest do
+  use ExUnit.Case, async: true
+
+  alias ExAthena.{Messages, Request}
+  alias ExAthena.Messages.{ContentPart, Message}
+
+  describe "new/2 — text-only (existing behaviour unchanged)" do
+    test "nil prompt with no messages yields empty messages list" do
+      req = Request.new(nil, [])
+      assert req.messages == []
+    end
+
+    test "empty string prompt yields empty messages list" do
+      req = Request.new("", [])
+      assert req.messages == []
+    end
+
+    test "string prompt appended as user message with string content" do
+      req = Request.new("hello", [])
+      assert [%Message{role: :user, content: "hello"}] = req.messages
+    end
+
+    test "pre-built :messages preserved and prompt appended" do
+      existing = [Messages.user("first")]
+      req = Request.new("second", messages: existing)
+      assert [%Message{content: "first"}, %Message{content: "second"}] = req.messages
+    end
+
+    test "empty images list leaves string content unchanged" do
+      req = Request.new("hello", images: [])
+      assert [%Message{role: :user, content: "hello"}] = req.messages
+    end
+  end
+
+  describe "new/2 — images: shorthand" do
+    test "inline image + prompt → user message with [text_part | image_part]" do
+      png = <<0::8>>
+      req = Request.new("describe", images: [%{data: png, media_type: "image/png"}])
+
+      assert [%Message{role: :user, content: parts}] = req.messages
+      assert [%ContentPart{type: :text, text: "describe"}, %ContentPart{type: :image}] = parts
+    end
+
+    test "image_url + prompt → user message with [text_part, image_url_part]" do
+      req = Request.new("describe", images: [%{url: "https://example.com/img.png"}])
+
+      assert [%Message{role: :user, content: parts}] = req.messages
+
+      assert [
+               %ContentPart{type: :text},
+               %ContentPart{type: :image_url, url: "https://example.com/img.png"}
+             ] =
+               parts
+    end
+
+    test "image without explicit media_type defaults to image/png" do
+      req = Request.new("describe", images: [%{data: <<1, 2, 3>>}])
+
+      assert [%Message{role: :user, content: [_text, img]}] = req.messages
+      assert %ContentPart{type: :image, media_type: "image/png"} = img
+    end
+
+    test "nil prompt + images → user message containing only image parts" do
+      req = Request.new(nil, images: [%{data: <<0>>, media_type: "image/jpeg"}])
+
+      assert [%Message{role: :user, content: [%ContentPart{type: :image}]}] = req.messages
+    end
+
+    test "empty prompt + images → user message containing only image parts" do
+      req = Request.new("", images: [%{data: <<0>>, media_type: "image/jpeg"}])
+
+      assert [%Message{role: :user, content: [%ContentPart{type: :image}]}] = req.messages
+    end
+
+    test "images + pre-built messages with string user message → image parts appended to last user" do
+      existing = [Messages.user("first")]
+
+      req =
+        Request.new(nil, messages: existing, images: [%{data: <<0>>, media_type: "image/png"}])
+
+      assert [%Message{role: :user, content: parts}] = req.messages
+      assert [%ContentPart{type: :text, text: "first"}, %ContentPart{type: :image}] = parts
+    end
+
+    test "images + pre-built messages with already-list content → image parts appended" do
+      existing = [Messages.user([ContentPart.text("first")])]
+
+      req =
+        Request.new(nil, messages: existing, images: [%{data: <<0>>, media_type: "image/png"}])
+
+      assert [%Message{role: :user, content: parts}] = req.messages
+      assert [%ContentPart{type: :text, text: "first"}, %ContentPart{type: :image}] = parts
+    end
+
+    test "images + pre-built messages with no user message → new user message appended" do
+      existing = [Messages.system("system msg")]
+
+      req =
+        Request.new(nil, messages: existing, images: [%{data: <<0>>, media_type: "image/png"}])
+
+      assert [
+               %Message{role: :system},
+               %Message{role: :user, content: [%ContentPart{type: :image}]}
+             ] =
+               req.messages
+    end
+
+    test "multiple images in list → all converted to ContentParts" do
+      req =
+        Request.new("look",
+          images: [
+            %{data: <<1>>, media_type: "image/png"},
+            %{data: <<2>>, media_type: "image/jpeg"}
+          ]
+        )
+
+      assert [%Message{role: :user, content: parts}] = req.messages
+      assert length(parts) == 3
+
+      assert [%ContentPart{type: :text}, %ContentPart{type: :image}, %ContentPart{type: :image}] =
+               parts
+    end
+
+    test "images + prompt with pre-built messages → prompt+images appended, existing preserved" do
+      existing = [Messages.system("sys"), Messages.user("prior")]
+
+      req =
+        Request.new("new prompt",
+          messages: existing,
+          images: [%{data: <<0>>, media_type: "image/png"}]
+        )
+
+      assert [
+               %Message{role: :system},
+               %Message{role: :user, content: "prior"},
+               %Message{role: :user, content: parts}
+             ] =
+               req.messages
+
+      assert [%ContentPart{type: :text, text: "new prompt"}, %ContentPart{type: :image}] = parts
+    end
+  end
+end

--- a/test/ex_athena_test.exs
+++ b/test/ex_athena_test.exs
@@ -33,6 +33,35 @@ defmodule ExAthenaTest do
         ExAthena.query("hi")
       end
     end
+
+    test "images: shorthand reaches the provider as ContentPart content" do
+      alias ExAthena.Messages.ContentPart
+
+      png = <<0::8>>
+
+      responder = fn request ->
+        assert [user_msg] = request.messages
+
+        assert [%ContentPart{type: :text, text: "describe"}, %ContentPart{type: :image}] =
+                 user_msg.content
+
+        %ExAthena.Response{
+          text: "saw image",
+          tool_calls: [],
+          finish_reason: :stop,
+          provider: :mock
+        }
+      end
+
+      assert {:ok, response} =
+               ExAthena.query("describe",
+                 provider: :mock,
+                 mock: [responder: responder],
+                 images: [%{data: png, media_type: "image/png"}]
+               )
+
+      assert response.text == "saw image"
+    end
   end
 
   describe "stream/3" do

--- a/test/ex_athena_test.exs
+++ b/test/ex_athena_test.exs
@@ -85,6 +85,35 @@ defmodule ExAthenaTest do
       assert_receive {:event, %ExAthena.Streaming.Event{type: :text_delta, data: "lo"}}
       assert_receive {:event, %ExAthena.Streaming.Event{type: :stop}}
     end
+
+    test "images: shorthand reaches the provider as ContentPart content via stream" do
+      alias ExAthena.Messages.ContentPart
+
+      png = <<0::8>>
+
+      responder = fn request ->
+        assert [user_msg] = request.messages
+
+        assert [%ContentPart{type: :text, text: "describe"}, %ContentPart{type: :image}] =
+                 user_msg.content
+
+        %ExAthena.Response{
+          text: "saw image",
+          tool_calls: [],
+          finish_reason: :stop,
+          provider: :mock
+        }
+      end
+
+      assert {:ok, response} =
+               ExAthena.stream("describe", fn _ -> :ok end,
+                 provider: :mock,
+                 mock: [responder: responder],
+                 images: [%{data: png, media_type: "image/png"}]
+               )
+
+      assert response.text == "saw image"
+    end
   end
 
   describe "capabilities/1" do


### PR DESCRIPTION
### ✨ Feature: Multimodal Content Support (Images/Vision)

This PR introduces full support for multimodal content (specifically images) across all configured AI providers, allowing users to attach screenshots and diagrams directly within conversations.

Previously, the `Message.content` structure was limited to `String.t()`, causing image data to be silently dropped by the `req_llm` adapter and other downstream behaviors when handling provider calls. This change updates content modeling and API entry points to handle structured parts alongside text.

### 🚀 Key Changes

*   **Content Structure Update:** Extended `ExAthena.Messages.Message` to allow `content` to be a list of `ContentPart` structs or `String.t()`, enabling structured payload passing.
*   **API Ergonomics:** Added a convenient `images:` shorthand to `ExAthena.query/2`, `ExAthena.stream/3`, and `ExAthena.run/2`. This simplifies the common use case of attaching an image to a prompt without needing to manually construct complex message lists.
*   **Adapter Overhaul:** Updated `ExAthena.Providers.ReqLLM` adapters (`to_req_llm_message/1` and related private functions) to correctly map structured `ContentPart` payloads (including images) to the provider's expected format.
*   **Documentation:** Added comprehensive documentation in `README.md` and created a new `guides/multimodal.md` guide, detailing the common `images:` shorthand usage and the advanced `ContentPart` construction method.

### 💡 Technical Details

1.  **`ContentPart` Wrapper:** A new `ExAthena.Messages.ContentPart` module was introduced to abstract the different supported media types (`:text`, `:image`, `:image_url`, `:file`), mirroring key structures used by LLM APIs.
2.  **Adaptation:** The core message adapters now traverse the `ContentPart` list, recognizing structured payloads and serializing them appropriately for the downstream provider's API schema (e.g., embedding base64 data in the `req_llm` message format).
3.  **Backward Compatibility:** Existing callers relying on default `String.t()` content for basic chat functionality are unaffected, ensuring non-multimodal workflows continue uninterrupted.

Closes https://github.com/udin-io/ex_athena/issues/43