### PR TITLE
Loop has no no-progress detector

### DIFF
--- a/.artifacts/adr-1-loop-no-progress-detector.md
+++ b/.artifacts/adr-1-loop-no-progress-detector.md
@@ -1,0 +1,71 @@
+# ADR: Loop No-Progress Detector
+
+**Status:** Proposed
+
+---
+
+## Context
+
+`ExAthena.Loop` enforces three termination conditions — `max_iterations`, `max_consecutive_mistakes`, `max_budget_usd` — but has no mechanism to detect when consecutive iterations are producing identical tool calls with no new state. Modes have to build their own progress detectors, or they don't, and the loop happily spins for 25 iterations. In `udin_code`, this manifests as the SDK runner burning ~19 minutes of a 20-minute planning timeout retrying the same denied `bash` command.
+
+---
+
+## Decision
+
+### 1. New termination subtype: `:error_no_progress`
+
+Add `:error_no_progress` to `ExAthena.Loop.Terminations` with category `:capacity`. This is a capacity-class termination (the run hit a configured limit), consistent with `:error_consecutive_mistakes` and `:error_max_turns`.
+
+### 2. State additions
+
+Add four fields to `ExAthena.Loop.State`:
+
+- `max_unproductive_iterations: 3` — configurable threshold (default 3).
+- `unproductive_iterations: 0` — consecutive unproductive iteration counter.
+- `last_tool_fingerprint: nil` — sorted `[{name, args_binary}]` list from the previous iteration, used to detect identical tool calls.
+- `no_progress_snapshot: nil` — populated with the last `N*4` messages when the guard fires.
+
+### 3. Optional Mode callback: `productivity_signal/2`
+
+Add an optional `@callback productivity_signal(prev_state, new_state) :: boolean()` to `ExAthena.Loop.Mode`. Modes can override the kernel's default check with domain-specific logic.
+
+### 4. Kernel-level default productivity check
+
+When a mode does not implement `productivity_signal/2`, the loop kernel uses `default_productivity_signal/3`: an iteration is productive if its tool-call fingerprint differs from the previous iteration's fingerprint, OR if it produced new non-empty assistant text. The fingerprint is a sorted list of `{tool_name, args_binary}` pairs extracted from new assistant messages.
+
+Fingerprint computation:
+- `ToolCall.arguments` is a map → `Jason.encode!/1`
+- `ToolCall.arguments` is a binary (pre-encoded) → pass-through
+- `ToolCall.arguments` is nil → `"{}"`
+
+This mirrors the encoding convention established in the `format_tool_calls/1` ADR.
+
+### 5. Counter management in `loop/1`
+
+- After `{:continue, new_state}`: call `update_progress_tracking(prev_state, new_state)` to compute the fingerprint, check productivity, and increment or reset `unproductive_iterations`.
+- In the `cond` block (before `true ->`): check `state.unproductive_iterations >= state.max_unproductive_iterations`. If exceeded, capture snapshot and terminate with `:error_no_progress`.
+- The `handle_prompt_too_long/1` retry path has its own `{:continue, new_state}` arm — apply `update_progress_tracking/2` there too.
+
+### 6. Result snapshot field
+
+Add `no_progress_snapshot: nil` to `ExAthena.Result`. Populated from `state.no_progress_snapshot` in `to_result/2`. The snapshot is the last `max_unproductive_iterations * 4` messages, giving consumers the stuck-state context for a remediation reprompt.
+
+### 7. ReAct reference implementation
+
+`ExAthena.Modes.ReAct` implements `productivity_signal/2` as the reference implementation, mirroring the kernel default. This establishes the pattern for future modes without duplicating logic in the kernel.
+
+---
+
+## Consequences
+
+**Positive:**
+- Eliminates the 19-minute timeout burn in `udin_code` caused by stuck tool retries.
+- Adds a typed, categorised termination that consumers can handle distinctly from other capacity limits.
+- The `no_progress_snapshot` enables automated remediation reprompts.
+- The optional mode callback lets specialised modes (Reflexion, PlanAndSolve) define richer progress semantics without modifying the kernel.
+
+**Negative / Trade-offs:**
+- The fingerprint approach detects identical tool-call repetition but does not detect semantic stagnation (e.g., writing the same file content twice with different tool-call args). This is intentional — semantic stagnation requires mode-specific knowledge.
+- `max_unproductive_iterations: 0` would fire on the first iteration (counter starts at 0, check is `>=`). Callers must use `1` as the minimum meaningful value; this should be documented in the option's `@doc`.
+- The first iteration always has `last_tool_fingerprint: nil`, so any non-empty current fingerprint compares unequal to `nil`, correctly marking the first iteration as productive regardless of content.
+- Adding four fields to `State` grows the struct; all have sensible defaults so existing call sites are unaffected.

--- a/lib/ex_athena/loop.ex
+++ b/lib/ex_athena/loop.ex
@@ -133,11 +133,7 @@ defmodule ExAthena.Loop do
 
       state.max_unproductive_iterations > 0 and
           state.unproductive_iterations >= state.max_unproductive_iterations ->
-        snapshot =
-          Enum.take(
-            state.messages,
-            -min(length(state.messages), state.max_unproductive_iterations * 4)
-          )
+        snapshot = Enum.take(state.messages, -(state.max_unproductive_iterations * 4))
 
         %{state | no_progress_snapshot: snapshot}
         |> set_finish_reason(:error_no_progress)
@@ -311,8 +307,7 @@ defmodule ExAthena.Loop do
 
   # ── No-progress tracking ──────────────────────────────────────────
 
-  @doc false
-  def update_progress_tracking(prev_state, new_state) do
+  defp update_progress_tracking(prev_state, new_state) do
     current_fp = compute_tool_fingerprint(prev_state, new_state)
     productive? = check_productivity(prev_state, new_state, current_fp)
 
@@ -347,7 +342,8 @@ defmodule ExAthena.Loop do
     current_fp != prev_state.last_tool_fingerprint or has_new_text?
   end
 
-  defp compute_tool_fingerprint(prev_state, new_state) do
+  @doc false
+  def compute_tool_fingerprint(prev_state, new_state) do
     new_state.messages
     |> Enum.drop(length(prev_state.messages))
     |> Enum.flat_map(fn

--- a/lib/ex_athena/loop.ex
+++ b/lib/ex_athena/loop.ex
@@ -39,6 +39,10 @@ defmodule ExAthena.Loop do
     * `:max_iterations` (default 25) — hard iteration cap.
     * `:max_consecutive_mistakes` (default 3) — counter threshold at
       which the loop terminates with `:error_consecutive_mistakes`.
+    * `:max_unproductive_iterations` (default 3) — consecutive-iteration
+      cap for detecting loops with no new tool name+args or assistant text.
+      Trips `:error_no_progress` before `:error_max_turns` fires. Pass
+      `0` to disable the guard.
     * `:max_budget_usd` — optional float. Trips
       `:error_max_budget_usd` when cumulative cost crosses it.
     * `:tool_timeout_ms` (default 60_000) — per-call timeout for parallel
@@ -81,6 +85,7 @@ defmodule ExAthena.Loop do
 
   @default_max_iterations 25
   @default_max_mistakes 3
+  @default_max_unproductive_iterations 3
   @default_max_concurrency 4
   @default_tool_timeout_ms 60_000
 
@@ -126,6 +131,17 @@ defmodule ExAthena.Loop do
         state
         |> set_finish_reason(:error_max_budget_usd)
 
+      state.max_unproductive_iterations > 0 and
+          state.unproductive_iterations >= state.max_unproductive_iterations ->
+        snapshot =
+          Enum.take(
+            state.messages,
+            -min(length(state.messages), state.max_unproductive_iterations * 4)
+          )
+
+        %{state | no_progress_snapshot: snapshot}
+        |> set_finish_reason(:error_no_progress)
+
       true ->
         case maybe_compact(state) do
           {:ok, state} ->
@@ -133,6 +149,7 @@ defmodule ExAthena.Loop do
 
             case state.mode.iterate(state) do
               {:continue, new_state} ->
+                new_state = update_progress_tracking(state, new_state)
                 loop(%{new_state | iterations: new_state.iterations + 1})
 
               {:halt, new_state} ->
@@ -166,6 +183,7 @@ defmodule ExAthena.Loop do
         {:ok, state} ->
           case state.mode.iterate(state) do
             {:continue, new_state} ->
+              new_state = update_progress_tracking(state, new_state)
               loop(%{new_state | iterations: new_state.iterations + 1})
 
             {:halt, new_state} ->
@@ -291,6 +309,64 @@ defmodule ExAthena.Loop do
     put_in(state.meta[:finish_reason], reason)
   end
 
+  # ── No-progress tracking ──────────────────────────────────────────
+
+  @doc false
+  def update_progress_tracking(prev_state, new_state) do
+    current_fp = compute_tool_fingerprint(prev_state, new_state)
+    productive? = check_productivity(prev_state, new_state, current_fp)
+
+    if productive? do
+      %{new_state | unproductive_iterations: 0, last_tool_fingerprint: current_fp}
+    else
+      %{
+        new_state
+        | unproductive_iterations: new_state.unproductive_iterations + 1,
+          last_tool_fingerprint: current_fp
+      }
+    end
+  end
+
+  defp check_productivity(prev_state, new_state, current_fp) do
+    if function_exported?(new_state.mode, :productivity_signal, 2) do
+      new_state.mode.productivity_signal(prev_state, new_state)
+    else
+      default_productivity_signal(prev_state, new_state, current_fp)
+    end
+  end
+
+  defp default_productivity_signal(prev_state, new_state, current_fp) do
+    has_new_text? =
+      new_state.messages
+      |> Enum.drop(length(prev_state.messages))
+      |> Enum.any?(fn
+        %{role: :assistant, content: c} when is_binary(c) and byte_size(c) > 0 -> true
+        _ -> false
+      end)
+
+    current_fp != prev_state.last_tool_fingerprint or has_new_text?
+  end
+
+  defp compute_tool_fingerprint(prev_state, new_state) do
+    new_state.messages
+    |> Enum.drop(length(prev_state.messages))
+    |> Enum.flat_map(fn
+      %{role: :assistant, tool_calls: calls} when is_list(calls) -> calls
+      _ -> []
+    end)
+    |> Enum.map(fn tc ->
+      args_bin =
+        cond do
+          is_nil(tc.arguments) -> "{}"
+          is_binary(tc.arguments) -> tc.arguments
+          true -> Jason.encode!(tc.arguments)
+        end
+
+      {tc.name, args_bin}
+    end)
+    |> Enum.sort()
+  end
+
   # ── Result construction ───────────────────────────────────────────
 
   defp to_result({:error, _} = err, _), do: err
@@ -313,7 +389,8 @@ defmodule ExAthena.Loop do
       duration_ms: duration_ms,
       model: state.request_template && state.request_template.model,
       provider: state.provider_mod,
-      telemetry: %{}
+      telemetry: %{},
+      no_progress_snapshot: state.no_progress_snapshot
     }
 
     fire_terminal_hooks(state, result)
@@ -451,6 +528,8 @@ defmodule ExAthena.Loop do
         max_iterations: Keyword.get(opts, :max_iterations, @default_max_iterations),
         max_consecutive_mistakes:
           Keyword.get(opts, :max_consecutive_mistakes, @default_max_mistakes),
+        max_unproductive_iterations:
+          Keyword.get(opts, :max_unproductive_iterations, @default_max_unproductive_iterations),
         max_budget_usd: Keyword.get(opts, :max_budget_usd),
         tool_timeout_ms: Keyword.get(opts, :tool_timeout_ms, @default_tool_timeout_ms),
         max_concurrency: Keyword.get(opts, :max_concurrency, @default_max_concurrency),

--- a/lib/ex_athena/loop/mode.ex
+++ b/lib/ex_athena/loop/mode.ex
@@ -48,6 +48,16 @@ defmodule ExAthena.Loop.Mode do
   """
   @callback iterate(State.t()) :: {:continue, State.t()} | {:halt, State.t()} | {:error, term()}
 
+  @doc """
+  Optional. Called after each `{:continue, new_state}` to determine whether
+  the iteration was productive. Return `true` if the run made progress (new
+  tool name+args pair OR new assistant text), `false` otherwise. When not
+  implemented, the kernel uses its own default check.
+  """
+  @callback productivity_signal(prev_state :: State.t(), new_state :: State.t()) :: boolean()
+
+  @optional_callbacks [productivity_signal: 2]
+
   @builtins %{
     react: ExAthena.Modes.ReAct,
     plan_and_solve: ExAthena.Modes.PlanAndSolve,

--- a/lib/ex_athena/loop/state.ex
+++ b/lib/ex_athena/loop/state.ex
@@ -21,7 +21,15 @@ defmodule ExAthena.Loop.State do
   - `budget` — `ExAthena.Budget` accumulator.
   - `max_iterations`, `max_consecutive_mistakes`, `max_budget_usd`,
     `tool_timeout_ms`, `max_concurrency` — reliability knobs.
+  - `max_unproductive_iterations` — consecutive unproductive-iteration cap
+    (default 3); halts with `:error_no_progress` when exceeded.
   - `iterations`, `tool_calls_made`, `consecutive_mistakes` — counters.
+  - `unproductive_iterations` — consecutive iterations with no new tool
+    name+args combination and no new assistant text.
+  - `last_tool_fingerprint` — sorted `[{name, args_binary}]` list from the
+    previous iteration, used to detect identical tool calls.
+  - `no_progress_snapshot` — last few message pairs captured when
+    `:error_no_progress` fires; included in `Result` for remediation.
   - `mode`, `mode_state` — Mode module + its private state.
   - `halted_reason` — populated when a tool / hook returns `:halt`.
   - `session_id` — stable id for this run. Distinct from `ctx.session_id`,
@@ -52,11 +60,15 @@ defmodule ExAthena.Loop.State do
             max_iterations: 25,
             max_consecutive_mistakes: 3,
             max_budget_usd: nil,
+            max_unproductive_iterations: 3,
             tool_timeout_ms: 60_000,
             max_concurrency: 4,
             iterations: 0,
             tool_calls_made: 0,
             consecutive_mistakes: 0,
+            unproductive_iterations: 0,
+            last_tool_fingerprint: nil,
+            no_progress_snapshot: nil,
             mode: nil,
             mode_state: %{},
             halted_reason: nil,
@@ -79,11 +91,15 @@ defmodule ExAthena.Loop.State do
           max_iterations: non_neg_integer(),
           max_consecutive_mistakes: non_neg_integer(),
           max_budget_usd: float() | nil,
+          max_unproductive_iterations: non_neg_integer(),
           tool_timeout_ms: pos_integer(),
           max_concurrency: pos_integer(),
           iterations: non_neg_integer(),
           tool_calls_made: non_neg_integer(),
           consecutive_mistakes: non_neg_integer(),
+          unproductive_iterations: non_neg_integer(),
+          last_tool_fingerprint: list() | nil,
+          no_progress_snapshot: [Message.t()] | nil,
           mode: module() | nil,
           mode_state: map(),
           halted_reason: term() | nil,

--- a/lib/ex_athena/loop/terminations.ex
+++ b/lib/ex_athena/loop/terminations.ex
@@ -23,6 +23,10 @@ defmodule ExAthena.Loop.Terminations do
       assembled prompt exceeded the model's context window. Modes signal this
       to the kernel so the compaction pipeline can attempt reactive recovery
       before the run terminates.
+    * `:error_no_progress` — consecutive-iteration productivity threshold
+      exceeded; the last N iterations produced identical tool calls with no
+      new text. The `Result.no_progress_snapshot` field carries the stuck
+      message pairs for remediation reprompts.
   """
 
   @type subtype ::
@@ -35,6 +39,7 @@ defmodule ExAthena.Loop.Terminations do
           | :error_halted
           | :error_compaction_failed
           | :error_prompt_too_long
+          | :error_no_progress
 
   @all_subtypes [
     :stop,
@@ -45,7 +50,8 @@ defmodule ExAthena.Loop.Terminations do
     :error_consecutive_mistakes,
     :error_halted,
     :error_compaction_failed,
-    :error_prompt_too_long
+    :error_prompt_too_long,
+    :error_no_progress
   ]
 
   @doc "All known termination subtypes."
@@ -79,6 +85,7 @@ defmodule ExAthena.Loop.Terminations do
   def category(:error_consecutive_mistakes), do: :capacity
   def category(:error_during_execution), do: :retryable
   def category(:error_prompt_too_long), do: :capacity
+  def category(:error_no_progress), do: :capacity
   def category(:error_halted), do: :fatal
   def category(:error_compaction_failed), do: :fatal
 end

--- a/lib/ex_athena/modes/react.ex
+++ b/lib/ex_athena/modes/react.ex
@@ -31,6 +31,38 @@ defmodule ExAthena.Modes.ReAct do
   def init(%State{} = state), do: {:ok, state}
 
   @impl true
+  def productivity_signal(prev_state, new_state) do
+    prev_count = length(prev_state.messages)
+    new_messages = Enum.drop(new_state.messages, prev_count)
+
+    current_fingerprint =
+      new_messages
+      |> Enum.flat_map(fn
+        %{role: :assistant, tool_calls: calls} when is_list(calls) -> calls
+        _ -> []
+      end)
+      |> Enum.map(fn tc ->
+        args_bin =
+          cond do
+            is_nil(tc.arguments) -> "{}"
+            is_binary(tc.arguments) -> tc.arguments
+            true -> Jason.encode!(tc.arguments)
+          end
+
+        {tc.name, args_bin}
+      end)
+      |> Enum.sort()
+
+    has_new_text? =
+      Enum.any?(new_messages, fn
+        %{role: :assistant, content: c} when is_binary(c) and byte_size(c) > 0 -> true
+        _ -> false
+      end)
+
+    current_fingerprint != prev_state.last_tool_fingerprint or has_new_text?
+  end
+
+  @impl true
   def iterate(%State{} = state) do
     request = build_request(state)
 

--- a/lib/ex_athena/modes/react.ex
+++ b/lib/ex_athena/modes/react.ex
@@ -32,34 +32,17 @@ defmodule ExAthena.Modes.ReAct do
 
   @impl true
   def productivity_signal(prev_state, new_state) do
-    prev_count = length(prev_state.messages)
-    new_messages = Enum.drop(new_state.messages, prev_count)
-
-    current_fingerprint =
-      new_messages
-      |> Enum.flat_map(fn
-        %{role: :assistant, tool_calls: calls} when is_list(calls) -> calls
-        _ -> []
-      end)
-      |> Enum.map(fn tc ->
-        args_bin =
-          cond do
-            is_nil(tc.arguments) -> "{}"
-            is_binary(tc.arguments) -> tc.arguments
-            true -> Jason.encode!(tc.arguments)
-          end
-
-        {tc.name, args_bin}
-      end)
-      |> Enum.sort()
+    current_fp = ExAthena.Loop.compute_tool_fingerprint(prev_state, new_state)
 
     has_new_text? =
-      Enum.any?(new_messages, fn
+      new_state.messages
+      |> Enum.drop(length(prev_state.messages))
+      |> Enum.any?(fn
         %{role: :assistant, content: c} when is_binary(c) and byte_size(c) > 0 -> true
         _ -> false
       end)
 
-    current_fingerprint != prev_state.last_tool_fingerprint or has_new_text?
+    current_fp != prev_state.last_tool_fingerprint or has_new_text?
   end
 
   @impl true

--- a/lib/ex_athena/result.ex
+++ b/lib/ex_athena/result.ex
@@ -28,6 +28,9 @@ defmodule ExAthena.Result do
     * `:provider` — the provider atom / module that served the run.
     * `:telemetry` — span metadata summarising OTel attrs for the run
       (Phase 4).
+    * `:no_progress_snapshot` — the last few message pairs (assistant +
+      tool results) captured when `finish_reason` is `:error_no_progress`.
+      `nil` for all other terminations.
   """
 
   alias ExAthena.Loop.Terminations
@@ -50,7 +53,8 @@ defmodule ExAthena.Result do
             duration_ms: nil,
             model: nil,
             provider: nil,
-            telemetry: %{}
+            telemetry: %{},
+            no_progress_snapshot: nil
 
   @type t :: %__MODULE__{
           text: String.t() | nil,
@@ -64,7 +68,8 @@ defmodule ExAthena.Result do
           duration_ms: non_neg_integer() | nil,
           model: String.t() | nil,
           provider: atom() | module() | nil,
-          telemetry: map()
+          telemetry: map(),
+          no_progress_snapshot: [Message.t()] | nil
         }
 
   @doc "Whether the run finished normally (no error termination)."

--- a/test/ex_athena/loop/no_progress_test.exs
+++ b/test/ex_athena/loop/no_progress_test.exs
@@ -1,0 +1,127 @@
+defmodule ExAthena.Loop.NoProgressTest do
+  @moduledoc """
+  Verifies :max_unproductive_iterations trips :error_no_progress before
+  :error_max_turns, and that no_progress_snapshot is populated.
+  """
+  use ExUnit.Case, async: true
+
+  alias ExAthena.{Loop, Response, Result}
+  alias ExAthena.Messages.ToolCall
+
+  setup do
+    dir = Path.join(System.tmp_dir!(), "no_progress_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+    {:ok, dir: dir}
+  end
+
+  test "halts with :error_no_progress after 3 identical denied calls (before :error_max_turns)",
+       %{dir: dir} do
+    stuck_response = %Response{
+      text: "",
+      tool_calls: [
+        %ToolCall{id: "c1", name: "bash", arguments: %{"command" => "echo stuck"}}
+      ],
+      finish_reason: :tool_calls,
+      provider: :mock,
+      usage: %{input_tokens: 10, output_tokens: 5, total_tokens: 15}
+    }
+
+    assert {:ok, %Result{finish_reason: :error_no_progress} = r} =
+             Loop.run("do the thing",
+               provider: :mock,
+               mock: [responder: fn _ -> stuck_response end],
+               cwd: dir,
+               tools: [ExAthena.Tools.Bash],
+               max_iterations: 25,
+               max_unproductive_iterations: 3,
+               max_consecutive_mistakes: 100,
+               disallowed_tools: ["bash"]
+             )
+
+    assert Result.category(r) == :capacity
+    assert r.iterations < 10
+    assert is_list(r.no_progress_snapshot) and length(r.no_progress_snapshot) > 0
+  end
+
+  test "does NOT trip when each iteration uses a different tool call", %{dir: dir} do
+    counter = :counters.new(1, [])
+
+    responder = fn _ ->
+      n = :counters.get(counter, 1)
+      :counters.add(counter, 1, 1)
+
+      if n >= 2 do
+        %Response{
+          text: "done",
+          tool_calls: [],
+          finish_reason: :stop,
+          provider: :mock,
+          usage: %{input_tokens: 10, output_tokens: 5, total_tokens: 15}
+        }
+      else
+        %Response{
+          text: "",
+          tool_calls: [
+            %ToolCall{id: "c#{n}", name: "glob", arguments: %{"pattern" => "*.#{n}"}}
+          ],
+          finish_reason: :tool_calls,
+          provider: :mock,
+          usage: %{input_tokens: 10, output_tokens: 5, total_tokens: 15}
+        }
+      end
+    end
+
+    assert {:ok, %Result{finish_reason: :stop}} =
+             Loop.run("search files",
+               provider: :mock,
+               mock: [responder: responder],
+               cwd: dir,
+               tools: [ExAthena.Tools.Glob],
+               max_unproductive_iterations: 3
+             )
+  end
+
+  test "respects custom max_unproductive_iterations: 1", %{dir: dir} do
+    stuck_response = %Response{
+      text: "",
+      tool_calls: [
+        %ToolCall{id: "c1", name: "bash", arguments: %{"command" => "whoami"}}
+      ],
+      finish_reason: :tool_calls,
+      provider: :mock,
+      usage: %{input_tokens: 10, output_tokens: 5, total_tokens: 15}
+    }
+
+    assert {:ok, %Result{finish_reason: :error_no_progress, iterations: iters}} =
+             Loop.run("go",
+               provider: :mock,
+               mock: [responder: fn _ -> stuck_response end],
+               cwd: dir,
+               tools: [ExAthena.Tools.Bash],
+               max_unproductive_iterations: 1,
+               max_consecutive_mistakes: 100,
+               disallowed_tools: ["bash"]
+             )
+
+    assert iters <= 3
+  end
+
+  test "no_progress_snapshot is nil when loop ends normally", %{dir: dir} do
+    response = %Response{
+      text: "done",
+      tool_calls: [],
+      finish_reason: :stop,
+      provider: :mock,
+      usage: %{input_tokens: 10, output_tokens: 5, total_tokens: 15}
+    }
+
+    assert {:ok, %Result{finish_reason: :stop, no_progress_snapshot: nil}} =
+             Loop.run("hi",
+               provider: :mock,
+               mock: [responder: fn _ -> response end],
+               cwd: dir,
+               tools: []
+             )
+  end
+end

--- a/test/ex_athena/loop/terminations_test.exs
+++ b/test/ex_athena/loop/terminations_test.exs
@@ -14,6 +14,7 @@ defmodule ExAthena.Loop.TerminationsTest do
       assert :error_halted in Terminations.all()
       assert :error_compaction_failed in Terminations.all()
       assert :error_prompt_too_long in Terminations.all()
+      assert :error_no_progress in Terminations.all()
     end
   end
 
@@ -42,6 +43,7 @@ defmodule ExAthena.Loop.TerminationsTest do
       assert Terminations.category(:error_max_structured_output_retries) == :capacity
       assert Terminations.category(:error_consecutive_mistakes) == :capacity
       assert Terminations.category(:error_prompt_too_long) == :capacity
+      assert Terminations.category(:error_no_progress) == :capacity
     end
 
     test "execution errors are :retryable" do

--- a/test/ex_athena/result_test.exs
+++ b/test/ex_athena/result_test.exs
@@ -32,4 +32,14 @@ defmodule ExAthena.ResultTest do
              cost_usd: nil
            } = %Result{}
   end
+
+  test "no_progress_snapshot is nil by default" do
+    assert %Result{no_progress_snapshot: nil} = %Result{}
+  end
+
+  test "no_progress_snapshot is populated for :error_no_progress" do
+    msgs = [%{role: :assistant, content: "stuck"}]
+    result = %Result{finish_reason: :error_no_progress, no_progress_snapshot: msgs}
+    assert result.no_progress_snapshot == msgs
+  end
 end


### PR DESCRIPTION
This PR introduces a dedicated mechanism to detect and halt execution when the AI agent enters an unproductive loop, significantly improving resource consumption and reliability for demanding planning tasks.

### Key Changes

*   **Added Unproductive Progress Detection:** Implemented `:max_unproductive_iterations` to cap the number of consecutive iterations that fail to produce new state or output.
*   **Introduced `:productivity_signal`:** Exposes a callback in the loop options, allowing different agent modes (ReAct, PlanAndSolve, etc.) to define what constitutes "progress" for their specific workflow.
*   **Stagnation Termination:** When the unproductive threshold is met, the loop now halts with `finish_reason: :error_no_progress`, rather than relying only on general timeouts.
*   **Improved Result Payload:** The resulting state now includes a `no_progress_snapshot`, containing the history of tool calls and outputs leading up to the stall, facilitating advanced debugging and remediation by consumers.

### Important Implementation Details

*   **State Tracking:** The `Loop` now maintains `unproductive_iterations` and a `last_tool_fingerprint` to track state stability between turns.
*   **Productivity Logic:**
    *   The default productivity signal checks for two conditions: (1) any new assistant text content, or (2) a change in the sequence of tool calls/arguments.
    *   The provided `productivity_signal` callback takes precedence, allowing modes to implement specialized progress checks (e.g., checking for new file writes).
*   **Termination Flow:** This new guard acts *before* general iteration limits are reached, ensuring the loop fails fast when the model is repeating the same non-productive steps (e.g., retrying an erroring command).

Closes https://github.com/udin-io/ex_athena/issues/45