### PR TITLE
Tool denial events carry plain-text reason only — consumers can't inject typed remediation

### DIFF
--- a/.artifacts/adr-1-structured-tool-denial.md
+++ b/.artifacts/adr-1-structured-tool-denial.md
@@ -1,0 +1,50 @@
+# ADR 1: Structured Tool Denial via `ExAthena.Permissions.Denial`
+
+**Status:** Accepted
+
+## Context
+
+`Permissions.check/3` returns `{:deny, raw_tuple}` where the tuple is one of `{:disallowed, name}`, `{:not_in_allowlist, name}`, `{:mutation_in_plan_mode, name}`, `:denied_by_callback`, or `{:unexpected_callback_result, other}`. The `ReAct` mode formats this as `"permission denied: #{inspect(reason)}"` in the tool result, and `fire_permission_denied` in `parallel.ex` passes the raw term into the `:PermissionDenied` hook payload.
+
+Consumers (e.g. `udin_code`) want to react programmatically to denial causes:
+- Phase-gated denial → inject a phase-aware whitelist hint into the next system message
+- Budget denial → switch to a cheaper model
+- Sandbox violation → suggest a different working directory
+
+Grepping the reason string is brittle and inverts the dependency. Consumers should receive a typed struct they can pattern-match on.
+
+## Decision
+
+1. **Introduce `ExAthena.Permissions.Denial`** as a nested module in `lib/ex_athena/permissions.ex`. The struct has three fields:
+   - `reason :: String.t()` — human-readable message (backwards-compat; `String.Chars` impl returns this)
+   - `code :: :phase_gated | :budget_exceeded | :user_denied | :sandbox_violation | :unknown` — machine-readable cause code
+   - `metadata :: map()` — structured context (e.g. `%{phase: :plan, allowed_tools: [...], requested_tool: "bash"}`)
+
+2. **Update all `{:deny, ...}` returns in `Permissions.check/3`** to return `{:deny, %Denial{}}`. Mapping:
+   - `{:disallowed, name}` → `code: :user_denied`, metadata includes `requested_tool`
+   - `{:not_in_allowlist, name}` → `code: :user_denied`, metadata includes `requested_tool` and `allowed_tools`
+   - `{:mutation_in_plan_mode, name}` → `code: :phase_gated`, metadata includes `phase: :plan`, `allowed_tools`, `requested_tool`
+   - Callback `:deny` → `code: :user_denied`
+   - Callback `{:deny, reason}` passthrough → `code: :user_denied`, raw reason in metadata
+   - Unexpected callback return → `code: :unknown`
+
+3. **Add `:ToolDenied` to the hooks event catalog** in `lib/ex_athena/hooks.ex`. This follows the existing PascalCase naming convention for hook events.
+
+4. **Emit `:ToolDenied`** from `fire_permission_denied` in `lib/ex_athena/loop/parallel.ex` when the denial reason is a `%Denial{}` struct. The existing `:PermissionDenied` event continues to fire for backwards compatibility. Raw hook denials (from `PreToolUse`) fire `:PermissionDenied` only.
+
+5. **Update `react.ex`** to pattern-match on `%Permissions.Denial{reason: reason_str}` first, using `reason_str` directly as the tool result content. Raw (hook-based) denials fall through to the existing `inspect/1` path.
+
+6. **`String.Chars` implementation** on `Denial` returns `denial.reason`, so existing callers using `to_string/1` continue to work without changes.
+
+## Consequences
+
+**Positive:**
+- Consumers can subscribe to `:ToolDenied` and receive a typed struct for programmatic handling
+- `denial.code` enables switching on cause without string-parsing
+- `denial.metadata.allowed_tools` enables injecting whitelist hints
+- Tool result content is a clean sentence, not an `inspect`-formatted tuple
+- Backwards compat: `to_string(denial)` == `denial.reason` for string-based callers
+
+**Negative / Trade-offs:**
+- `:PermissionDenied` hook payload `reason` field now holds a `%Denial{}` struct instead of a raw tuple — existing hook subscribers that pattern-matched on `{:disallowed, name}` etc. will need updating. This is intentional (those callers were the brittle ones).
+- `normalize/1` in `Permissions` now wraps callback pass-through `{:deny, reason}` terms inside `%Denial{}`, which slightly changes the shape for `can_use_tool` callbacks that return custom denial reasons. The original term is preserved in `metadata.raw`.

--- a/lib/ex_athena/hooks.ex
+++ b/lib/ex_athena/hooks.ex
@@ -34,7 +34,7 @@ defmodule ExAthena.Hooks do
     * Session: `:SessionStart`, `:SessionEnd`
     * Per-turn: `:UserPromptSubmit`, `:ChatParams`, `:Stop`, `:StopFailure`
     * Per-tool: `:PreToolUse`, `:PostToolUse`, `:PostToolUseFailure`,
-      `:PermissionRequest`, `:PermissionDenied`
+      `:PermissionRequest`, `:PermissionDenied`, `:ToolDenied`
     * Subagent: `:SubagentStart`, `:SubagentStop`
     * Compaction: `:PreCompact`, `:PreCompactStage`, `:PostCompact`
     * Notification: `:Notification`
@@ -74,6 +74,7 @@ defmodule ExAthena.Hooks do
       :PostToolUseFailure,
       :PermissionRequest,
       :PermissionDenied,
+      :ToolDenied,
       :SubagentStart,
       :SubagentStop,
       :PreCompact,

--- a/lib/ex_athena/loop/parallel.ex
+++ b/lib/ex_athena/loop/parallel.ex
@@ -200,6 +200,20 @@ defmodule ExAthena.Loop.Parallel do
         reason: reason
       })
 
+    case reason do
+      %Permissions.Denial{} = denial ->
+        _ =
+          Hooks.run_lifecycle(state.hooks, :ToolDenied, %{
+            tool_name: name,
+            tool_use_id: id,
+            arguments: args,
+            denial: denial
+          })
+
+      _ ->
+        :ok
+    end
+
     :ok
   end
 

--- a/lib/ex_athena/modes/react.ex
+++ b/lib/ex_athena/modes/react.ex
@@ -22,7 +22,7 @@ defmodule ExAthena.Modes.ReAct do
 
   @behaviour ExAthena.Loop.Mode
 
-  alias ExAthena.{Budget, Messages, Skills, Telemetry}
+  alias ExAthena.{Budget, Messages, Permissions, Skills, Telemetry}
   alias ExAthena.Loop.{Events, Parallel, State}
   alias ExAthena.Messages.ToolCall
   alias ExAthena.Tools
@@ -188,6 +188,12 @@ defmodule ExAthena.Modes.ReAct do
     case Parallel.pre_tool_gate(call, state) do
       :allow ->
         do_execute(call, state)
+
+      {:deny, %Permissions.Denial{reason: reason_str}} ->
+        result = Messages.tool_result(call.id, reason_str, true)
+        state = bump_mistake(state)
+        Parallel.emit_events(state, call, result)
+        {result, state}
 
       {:deny, reason} ->
         result = Messages.tool_result(call.id, "permission denied: #{inspect(reason)}", true)

--- a/lib/ex_athena/permissions.ex
+++ b/lib/ex_athena/permissions.ex
@@ -1,3 +1,22 @@
+defmodule ExAthena.Permissions.Denial do
+  @moduledoc false
+
+  @type code :: :phase_gated | :budget_exceeded | :user_denied | :sandbox_violation | :unknown
+
+  @enforce_keys [:reason, :code]
+  defstruct [:reason, :code, metadata: %{}]
+
+  @type t :: %__MODULE__{
+          reason: String.t(),
+          code: code(),
+          metadata: map()
+        }
+
+  defimpl String.Chars do
+    def to_string(%{reason: r}), do: r
+  end
+end
+
 defmodule ExAthena.Permissions do
   @moduledoc """
   Decides whether a tool call is allowed.
@@ -40,8 +59,9 @@ defmodule ExAthena.Permissions do
       iex> alias ExAthena.Messages.ToolCall
       iex> tc = %ToolCall{id: "1", name: "bash", arguments: %{}}
       iex> ctx = ToolContext.new(cwd: "/tmp", phase: :bypass_permissions)
-      iex> Permissions.check(tc, ctx, %{disallowed_tools: ["bash"]})
-      {:deny, {:disallowed, "bash"}}
+      iex> {:deny, denial} = Permissions.check(tc, ctx, %{disallowed_tools: ["bash"]})
+      iex> denial.code
+      :user_denied
 
   Likewise, an allowlist denies everything outside it even if a callback
   would have allowed:
@@ -51,11 +71,13 @@ defmodule ExAthena.Permissions do
       iex> tc = %ToolCall{id: "1", name: "bash", arguments: %{}}
       iex> ctx = ToolContext.new(cwd: "/tmp", phase: :default)
       iex> opts = %{allowed_tools: ["read"], can_use_tool: fn _, _, _ -> :allow end}
-      iex> Permissions.check(tc, ctx, opts)
-      {:deny, {:not_in_allowlist, "bash"}}
+      iex> {:deny, denial} = Permissions.check(tc, ctx, opts)
+      iex> denial.code
+      :user_denied
   """
 
   alias ExAthena.Messages.ToolCall
+  alias ExAthena.Permissions.Denial
   alias ExAthena.ToolContext
 
   @readonly_tools ~w(read glob grep web_fetch plan_mode spawn_agent lsp)
@@ -67,7 +89,7 @@ defmodule ExAthena.Permissions do
 
   @type result ::
           :allow
-          | {:deny, reason :: term()}
+          | {:deny, Denial.t()}
 
   @type opts :: %{
           optional(:phase) => ToolContext.phase(),
@@ -79,7 +101,7 @@ defmodule ExAthena.Permissions do
 
   @doc """
   Check whether `tool_call` is allowed under `opts`. Returns `:allow` or
-  `{:deny, reason}`.
+  `{:deny, %ExAthena.Permissions.Denial{}}`.
   """
   @spec check(ToolCall.t(), ToolContext.t(), opts()) :: result()
   def check(%ToolCall{name: name, arguments: args}, %ToolContext{} = ctx, opts) do
@@ -108,8 +130,20 @@ defmodule ExAthena.Permissions do
 
   defp check_disallowed_list(name, opts) do
     case opts[:disallowed_tools] do
-      nil -> :allow
-      list when is_list(list) -> if name in list, do: {:deny, {:disallowed, name}}, else: :allow
+      nil ->
+        :allow
+
+      list when is_list(list) ->
+        if name in list do
+          {:deny,
+           %Denial{
+             code: :user_denied,
+             reason: "tool \"#{name}\" is explicitly disallowed",
+             metadata: %{requested_tool: name}
+           }}
+        else
+          :allow
+        end
     end
   end
 
@@ -119,15 +153,34 @@ defmodule ExAthena.Permissions do
         :allow
 
       list when is_list(list) ->
-        if name in list, do: :allow, else: {:deny, {:not_in_allowlist, name}}
+        if name in list do
+          :allow
+        else
+          {:deny,
+           %Denial{
+             code: :user_denied,
+             reason: "tool \"#{name}\" is not in the allowed list",
+             metadata: %{requested_tool: name, allowed_tools: list}
+           }}
+        end
     end
   end
 
   defp check_phase(name, :plan) do
     cond do
-      name in @readonly_tools -> :allow
-      name in @mutating_tools -> {:deny, {:mutation_in_plan_mode, name}}
-      true -> :allow
+      name in @readonly_tools ->
+        :allow
+
+      name in @mutating_tools ->
+        {:deny,
+         %Denial{
+           code: :phase_gated,
+           reason: "tool \"#{name}\" is not allowed in plan phase",
+           metadata: %{phase: :plan, requested_tool: name, allowed_tools: @readonly_tools}
+         }}
+
+      true ->
+        :allow
     end
   end
 
@@ -161,9 +214,23 @@ defmodule ExAthena.Permissions do
 
   defp normalize(:allow), do: :allow
   defp normalize({:allow, _}), do: :allow
-  defp normalize(:deny), do: {:deny, :denied_by_callback}
-  defp normalize({:deny, _} = result), do: result
-  defp normalize(other), do: {:deny, {:unexpected_callback_result, other}}
+
+  defp normalize(:deny),
+    do: {:deny, %Denial{code: :user_denied, reason: "denied by callback", metadata: %{}}}
+
+  defp normalize({:deny, %Denial{}} = result), do: result
+
+  defp normalize({:deny, reason}),
+    do: {:deny, %Denial{code: :user_denied, reason: inspect(reason), metadata: %{raw: reason}}}
+
+  defp normalize(other),
+    do:
+      {:deny,
+       %Denial{
+         code: :unknown,
+         reason: "unexpected callback result: #{inspect(other)}",
+         metadata: %{raw: other}
+       }}
 
   @doc "Static list of read-only tool names the `:plan` phase permits."
   @spec readonly_tools() :: [String.t()]

--- a/test/ex_athena/loop/hooks_modes_test.exs
+++ b/test/ex_athena/loop/hooks_modes_test.exs
@@ -6,6 +6,7 @@ defmodule ExAthena.Loop.HooksModesTest do
 
   alias ExAthena.{Loop, Response}
   alias ExAthena.Messages.{Message, ToolCall}
+  alias ExAthena.Permissions.Denial
 
   defp single_text(text) do
     fn _req -> %Response{text: text, finish_reason: :stop, provider: :mock} end
@@ -257,7 +258,8 @@ defmodule ExAthena.Loop.HooksModesTest do
           memory: false
         )
 
-      assert_receive {^ref, :permission_denied, "bash", {:disallowed, "bash"}}
+      assert_receive {^ref, :permission_denied, "bash",
+                      %Denial{code: :user_denied, metadata: %{requested_tool: "bash"}}}
     end
   end
 
@@ -315,7 +317,7 @@ defmodule ExAthena.Loop.HooksModesTest do
     test ":accept_edits still consults the callback for non-edit tools" do
       cb = fn "bash", _, _ -> {:deny, :user_declined} end
 
-      assert {:deny, :user_declined} =
+      assert {:deny, %Denial{code: :user_denied, metadata: %{raw: :user_declined}}} =
                Permissions.check(call("bash"), ctx(:accept_edits), %{can_use_tool: cb})
     end
 
@@ -329,7 +331,7 @@ defmodule ExAthena.Loop.HooksModesTest do
     end
 
     test ":trusted respects the denylist by default" do
-      assert {:deny, {:disallowed, "bash"}} =
+      assert {:deny, %Denial{code: :user_denied, metadata: %{requested_tool: "bash"}}} =
                Permissions.check(call("bash"), ctx(:trusted), disallowed_tools: ["bash"])
     end
 
@@ -342,7 +344,7 @@ defmodule ExAthena.Loop.HooksModesTest do
     end
 
     test ":bypass_permissions still respects the denylist (deny-first invariant)" do
-      assert {:deny, {:disallowed, "bash"}} =
+      assert {:deny, %Denial{code: :user_denied, metadata: %{requested_tool: "bash"}}} =
                Permissions.check(call("bash"), ctx(:bypass_permissions),
                  disallowed_tools: ["bash"]
                )

--- a/test/ex_athena/loop_test.exs
+++ b/test/ex_athena/loop_test.exs
@@ -135,7 +135,7 @@ defmodule ExAthena.LoopTest do
     # The tool message is a tool-result with is_error: true
     tool_msg = Enum.find(result.messages, &match?(%{role: :tool}, &1))
     assert [%{content: content, is_error: true}] = tool_msg.tool_results
-    assert content =~ "permission denied"
+    assert content =~ "disallowed"
   end
 
   test "unknown tool returns an error message in the loop", %{dir: dir} do

--- a/test/ex_athena/mcp/loop_integration_test.exs
+++ b/test/ex_athena/mcp/loop_integration_test.exs
@@ -156,7 +156,7 @@ defmodule ExAthena.Mcp.LoopIntegrationTest do
 
       tool_msg = Enum.find(result.messages, &match?(%{role: :tool}, &1))
       assert [%{is_error: true, content: content}] = tool_msg.tool_results
-      assert content =~ "permission denied"
+      assert content =~ "disallowed"
       assert_receive {:permission_denied, "fake_echo"}
     end
   end

--- a/test/ex_athena/modes/react_denial_test.exs
+++ b/test/ex_athena/modes/react_denial_test.exs
@@ -1,0 +1,118 @@
+defmodule ExAthena.Modes.ReactDenialTest do
+  use ExUnit.Case, async: true
+
+  alias ExAthena.{Loop, Response, Result}
+  alias ExAthena.Messages.ToolCall
+  alias ExAthena.Permissions.Denial
+
+  defmodule FakeEchoTool do
+    @behaviour ExAthena.Tool
+    def name, do: "echo"
+    def description, do: "echo"
+    def parallel_safe?, do: true
+    def schema, do: %{type: "object", properties: %{}, required: []}
+    def execute(_args, _ctx), do: {:ok, "tool-output"}
+  end
+
+  setup do
+    dir = Path.join(System.tmp_dir!(), "react_denial_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+    {:ok, dir: dir}
+  end
+
+  defp two_turn_responder do
+    counter = :counters.new(1, [:atomics])
+
+    fn _req ->
+      :counters.add(counter, 1, 1)
+
+      case :counters.get(counter, 1) do
+        1 ->
+          %Response{
+            text: "",
+            tool_calls: [%ToolCall{id: "t1", name: "echo", arguments: %{}}],
+            finish_reason: :tool_calls,
+            provider: :mock
+          }
+
+        _ ->
+          %Response{text: "done", finish_reason: :stop, provider: :mock}
+      end
+    end
+  end
+
+  test ":ToolDenied hook receives Denial struct when tool is disallowed", %{dir: dir} do
+    test_pid = self()
+
+    assert {:ok, %Result{}} =
+             Loop.run("go",
+               provider: :mock,
+               mock: [responder: two_turn_responder()],
+               cwd: dir,
+               tools: [FakeEchoTool],
+               disallowed_tools: ["echo"],
+               hooks: %{
+                 ToolDenied: [
+                   fn payload, _id ->
+                     send(test_pid, {:denied, payload})
+                     :ok
+                   end
+                 ]
+               }
+             )
+
+    assert_receive {:denied, payload}
+    assert %Denial{code: :user_denied} = payload.denial
+    assert payload.denial.metadata.requested_tool == "echo"
+    assert payload.tool_name == "echo"
+  end
+
+  test "tool result content uses denial.reason string, not inspect", %{dir: dir} do
+    assert {:ok, %Result{} = result} =
+             Loop.run("go",
+               provider: :mock,
+               mock: [responder: two_turn_responder()],
+               cwd: dir,
+               tools: [FakeEchoTool],
+               disallowed_tools: ["echo"]
+             )
+
+    [tool_msg] = Enum.filter(result.messages, &(&1.role == :tool))
+    [tr] = tool_msg.tool_results
+    refute tr.content =~ "%ExAthena.Permissions.Denial"
+    refute tr.content =~ "{:disallowed"
+    assert is_binary(tr.content)
+    assert String.length(tr.content) > 0
+  end
+
+  test ":PermissionDenied still fires alongside :ToolDenied", %{dir: dir} do
+    test_pid = self()
+
+    assert {:ok, %Result{}} =
+             Loop.run("go",
+               provider: :mock,
+               mock: [responder: two_turn_responder()],
+               cwd: dir,
+               tools: [FakeEchoTool],
+               disallowed_tools: ["echo"],
+               hooks: %{
+                 PermissionDenied: [
+                   fn payload, _id ->
+                     send(test_pid, {:permission_denied, payload})
+                     :ok
+                   end
+                 ],
+                 ToolDenied: [
+                   fn payload, _id ->
+                     send(test_pid, {:tool_denied, payload})
+                     :ok
+                   end
+                 ]
+               }
+             )
+
+    assert_receive {:permission_denied, _}
+    assert_receive {:tool_denied, _}
+  end
+end

--- a/test/ex_athena/permissions_test.exs
+++ b/test/ex_athena/permissions_test.exs
@@ -2,6 +2,7 @@ defmodule ExAthena.PermissionsTest do
   use ExUnit.Case, async: true
 
   alias ExAthena.Messages.ToolCall
+  alias ExAthena.Permissions.Denial
   alias ExAthena.{Permissions, ToolContext}
 
   doctest ExAthena.Permissions
@@ -15,22 +16,27 @@ defmodule ExAthena.PermissionsTest do
   end
 
   test "disallowed_tools wins over everything" do
-    assert {:deny, {:disallowed, "bash"}} =
+    assert {:deny, %Denial{code: :user_denied, metadata: %{requested_tool: "bash"}}} =
              Permissions.check(call("bash"), ctx(:bypass_permissions), disallowed_tools: ["bash"])
   end
 
   test "allowed_tools when set denies anything not in it" do
-    assert {:deny, {:not_in_allowlist, "bash"}} =
+    assert {:deny,
+            %Denial{
+              code: :user_denied,
+              metadata: %{requested_tool: "bash", allowed_tools: ["read"]}
+            }} =
              Permissions.check(call("bash"), ctx(), allowed_tools: ["read"])
 
     assert :allow = Permissions.check(call("read"), ctx(), allowed_tools: ["read"])
   end
 
   test "plan phase blocks mutation tools" do
-    assert {:deny, {:mutation_in_plan_mode, "write"}} =
+    assert {:deny,
+            %Denial{code: :phase_gated, metadata: %{phase: :plan, requested_tool: "write"}}} =
              Permissions.check(call("write"), ctx(:plan), %{})
 
-    assert {:deny, {:mutation_in_plan_mode, "edit"}} =
+    assert {:deny, %Denial{code: :phase_gated, metadata: %{phase: :plan, requested_tool: "edit"}}} =
              Permissions.check(call("edit"), ctx(:plan), %{})
 
     assert :allow = Permissions.check(call("read"), ctx(:plan), %{})
@@ -45,7 +51,7 @@ defmodule ExAthena.PermissionsTest do
   test "can_use_tool callback can deny with reason" do
     deny = fn _name, _args, _ctx -> {:deny, :user_declined} end
 
-    assert {:deny, :user_declined} =
+    assert {:deny, %Denial{code: :user_denied, metadata: %{raw: :user_declined}}} =
              Permissions.check(call("bash"), ctx(), %{can_use_tool: deny})
   end
 
@@ -53,5 +59,24 @@ defmodule ExAthena.PermissionsTest do
     allow = fn _name, _args, _ctx -> :allow end
 
     assert :allow = Permissions.check(call("bash"), ctx(), %{can_use_tool: allow})
+  end
+
+  test "plan phase denial carries allowed_tools in metadata" do
+    {:deny, denial} = Permissions.check(call("write"), ctx(:plan), %{})
+    assert denial.code == :phase_gated
+    assert denial.metadata.requested_tool == "write"
+    assert denial.metadata.phase == :plan
+    assert is_list(denial.metadata.allowed_tools)
+  end
+
+  test "not_in_allowlist denial carries allowed list in metadata" do
+    {:deny, denial} = Permissions.check(call("bash"), ctx(), allowed_tools: ["read"])
+    assert denial.code == :user_denied
+    assert denial.metadata.allowed_tools == ["read"]
+  end
+
+  test "Denial implements String.Chars" do
+    {:deny, denial} = Permissions.check(call("write"), ctx(:plan), %{})
+    assert is_binary(to_string(denial))
   end
 end


### PR DESCRIPTION
**Summary**

This PR fundamentally refactors tool denial feedback from a brittle, free-form string to a structured, typed payload. Instead of consumers having to parse a simple denial string (e.g., `"tool was denied because phase scope_assessment"`), they now receive a `Denial` struct containing a structured `code` and rich `metadata`. This allows downstream logic to programmatically react to the *reason* for denial, dramatically increasing consumer reliability and enabling advanced workflow features (e.g., switching models based on budget limits, or suggesting specific whitelisted tools).

**Key Changes**

*   **Structured Denial Payload:** Introduced `ExAthena.Permissions.Denial` struct to standardize denial reporting. This struct wraps the denial reason with a specific `:code` (ee.g., `:phase_gated`, `:budget_exceeded`) and relevant `metadata` (e.g., phase, allowed tools).
*   **Event System Integration:** Added a new `:ToolDenied` hook event. When a tool call is denied within the `ReAct` mode, this structured `Denial` struct is emitted via `Hooks.run_lifecycle`, allowing external subsystems to programmatically subscribe to denial events.
*   **ReAct Mode Update:** Updated `ExAthena.Modes.ReAct` to accept and handle the structured `{:deny, denial_struct}` payload. It now forward this struct instead of relying on the previous string formatting.
*   **Backward Compatibility:** The `Denial` struct implements `String.Chars` via `to_string/1`, ensuring that existing consumers still relying on reading the denial reason as a plain string will continue to function without breakage.

**Implementation Details**

*   The core concept shifts dependency from string parsing to structured data consumption. Consumers can now switch from:
    *   *Before:* `if String.contains?(denial_string, "phase =")`
    *   *After:* `case event do %{denial: %ExAthena.Permissions.Denial{code: :phase_gated}} -> ... end`
*   The changes span multiple modules: `ex_athena/permissions.ex` defines the payload, `ex_athena/modes/react.ex` propagates the payload, and `ex_athena/loop/parallel.ex` and `ex_athena/hooks.ex` manage the event emission.

Closes https://github.com/udin-io/ex_athena/issues/46