### PR TITLE
Schema-validation rejection collapses into generic :error_during_execution

### DIFF
--- a/.artifacts/adr-1-error-schema-validation-finish-reason.md
+++ b/.artifacts/adr-1-error-schema-validation-finish-reason.md
@@ -1,0 +1,70 @@
+# ADR: Introduce :error_schema_validation and :error_provider_auth finish_reason subtypes
+
+**Status:** Accepted
+
+## Context
+
+`ExAthena.Loop.Terminations` defines typed termination subtypes for agent loop runs. Previously, all failure modes that were not capacity limits or halts fell through to `:error_during_execution`, which is classified as `:retryable`. This single bucket covered:
+
+- Model returning unparseable/schema-invalid output (consumer should retry with a reformat hint)
+- Provider returning HTTP 401/403 (consumer must fix credentials — never retry blindly)
+- Provider returning network/transport errors (transient; retry makes sense)
+
+Consumers using `Result.category/1` or pattern-matching on `Result.finish_reason` could not distinguish these cases, making it impossible to implement correct retry and user-surfacing logic downstream.
+
+The issue also noted that `Result` carried no structured validation payload — callers could inspect `halted_reason` but only as an opaque term.
+
+## Decision
+
+### 1. New termination subtypes
+
+Add two subtypes to `ExAthena.Loop.Terminations`:
+
+- `:error_schema_validation` — the loop terminated because the model's output could not be parsed as valid structured output or tool calls. Category: `:retryable` (caller may retry with a reformat prompt hint).
+- `:error_provider_auth` — the provider returned an HTTP 401 or 403. Category: `:fatal` (requires operator action to fix credentials; blind retry will not help).
+
+Both are added to `@all_subtypes`, the `@type subtype` union, `category/1` dispatch, and `@moduledoc`.
+
+### 2. error_diagnostic field on Result
+
+Add `error_diagnostic: nil` to `ExAthena.Result`. When `finish_reason` is `:error_schema_validation`, this field is populated with:
+
+```elixir
+%{
+  schema: request.response_format,   # the response_format that was active, if any
+  received: response.text,            # raw text returned by the model
+  violations: [%{reason: String.t()}] # list of violation descriptions
+}
+```
+
+The `path` key inside each violation is optional; current parsers do not emit structured paths so violations carry only a `reason` string derived from `inspect(parse_error)`. Future parsers that emit richer diagnostics can populate `path`.
+
+The field is `nil` for all other finish_reason values.
+
+### 3. Detection in ReAct mode
+
+`ExAthena.Modes.ReAct.do_iterate/2` has two `{:error, reason}` branches:
+
+**Branch A (ToolCalls.extract failure, previously lines 121-126):** Changed to set `finish_reason: :error_schema_validation` and populate `state.meta[:error_diagnostic]`. Both `response` and `request` are in lexical scope at this point, providing the raw text and the active response_format.
+
+**Branch B (provider query/stream failure, previously lines 129-134):** Inspects the error struct. `%ExAthena.Error{kind: :unauthorized}` routes to `:error_provider_auth`. All other errors remain `:error_during_execution`.
+
+### 4. Threading through the loop kernel
+
+`ExAthena.Loop.to_result/2` reads `state.meta[:error_diagnostic]` and assigns it to `result.error_diagnostic`. No changes to `ExAthena.Loop.State`'s typed fields are needed — `meta` is the existing free-form escape hatch for mode-specific data.
+
+### 5. No change to StructuredOutput helper
+
+`ExAthena.StructuredOutput.request/3` operates outside the loop and returns raw `{:ok, map()} | {:error, reason}` tuples. Its callers are not affected by this change.
+
+## Consequences
+
+**Positive:**
+- Consumers can dispatch on `Result.finish_reason` to implement correct retry logic without inspecting opaque `halted_reason` internals.
+- `Result.category/1` now returns `:fatal` for auth errors instead of `:retryable`, preventing futile retry storms.
+- `Result.error_diagnostic` provides a structured payload for logging and user-facing error messages on schema validation failures.
+
+**Negative / trade-offs:**
+- Adding `:error_provider_auth` is a new `:fatal` subtype. Consumers that previously handled all `:fatal` results identically (e.g., `category == :fatal -> surface_to_user`) will now see auth errors routed there without any code change, which is the desired behavior but is technically a behavior change for callers who pattern-matched on `finish_reason: :error_during_execution` for auth errors specifically.
+- The `violations` list currently contains only `inspect(reason)` strings, not structured paths. This is intentional — the ToolCalls parsers do not emit structured path information today. A future ADR can extend the diagnostic when richer parser output is available.
+- `state.meta[:error_diagnostic]` uses the existing escape hatch rather than a typed State field. This is consistent with how `finish_reason` itself is stored (`state.meta[:finish_reason]`) and avoids widening the public State type in a minor patch.

--- a/lib/ex_athena/loop.ex
+++ b/lib/ex_athena/loop.ex
@@ -430,6 +430,7 @@ defmodule ExAthena.Loop do
       messages: state.messages,
       finish_reason: finish_reason,
       halted_reason: state.halted_reason,
+      error_diagnostic: state.meta[:error_diagnostic],
       iterations: state.iterations,
       tool_calls_made: state.tool_calls_made,
       usage: state.budget && state.budget.usage,

--- a/lib/ex_athena/loop/terminations.ex
+++ b/lib/ex_athena/loop/terminations.ex
@@ -27,6 +27,12 @@ defmodule ExAthena.Loop.Terminations do
       exceeded; the last N iterations produced identical tool calls with no
       new text. The `Result.no_progress_snapshot` field carries the stuck
       message pairs for remediation reprompts.
+    * `:error_schema_validation` — model output could not be parsed as valid
+      structured output or tool calls. Category `:retryable`; caller may retry
+      with a reformat prompt hint. `Result.error_diagnostic` carries the
+      structured failure payload.
+    * `:error_provider_auth` — provider returned HTTP 401 or 403. Category
+      `:fatal`; blind retry will not help — operator must fix credentials.
   """
 
   @type subtype ::
@@ -40,6 +46,8 @@ defmodule ExAthena.Loop.Terminations do
           | :error_compaction_failed
           | :error_prompt_too_long
           | :error_no_progress
+          | :error_schema_validation
+          | :error_provider_auth
 
   @all_subtypes [
     :stop,
@@ -51,7 +59,9 @@ defmodule ExAthena.Loop.Terminations do
     :error_halted,
     :error_compaction_failed,
     :error_prompt_too_long,
-    :error_no_progress
+    :error_no_progress,
+    :error_schema_validation,
+    :error_provider_auth
   ]
 
   @doc "All known termination subtypes."
@@ -84,8 +94,10 @@ defmodule ExAthena.Loop.Terminations do
   def category(:error_max_structured_output_retries), do: :capacity
   def category(:error_consecutive_mistakes), do: :capacity
   def category(:error_during_execution), do: :retryable
+  def category(:error_schema_validation), do: :retryable
   def category(:error_prompt_too_long), do: :capacity
   def category(:error_no_progress), do: :capacity
   def category(:error_halted), do: :fatal
   def category(:error_compaction_failed), do: :fatal
+  def category(:error_provider_auth), do: :fatal
 end

--- a/lib/ex_athena/modes/react.ex
+++ b/lib/ex_athena/modes/react.ex
@@ -134,12 +134,25 @@ defmodule ExAthena.Modes.ReAct do
             end
 
           {:error, reason} ->
-            state =
-              %{state | halted_reason: {:tool_call_parse_failed, reason}}
-              |> set_finish_reason(:error_during_execution)
+            diagnostic = %{
+              schema: request.response_format,
+              received: response.text,
+              violations: [%{reason: inspect(reason)}]
+            }
+
+            state = %{state | halted_reason: {:tool_call_parse_failed, reason}}
+            state = put_in(state.meta[:error_diagnostic], diagnostic)
+            state = set_finish_reason(state, :error_schema_validation)
 
             {:halt, state}
         end
+
+      {:error, %ExAthena.Error{kind: :unauthorized} = reason} ->
+        state =
+          %{state | halted_reason: reason}
+          |> set_finish_reason(:error_provider_auth)
+
+        {:halt, state}
 
       {:error, reason} ->
         state =

--- a/lib/ex_athena/result.ex
+++ b/lib/ex_athena/result.ex
@@ -26,6 +26,9 @@ defmodule ExAthena.Result do
       termination.
     * `:model` — the model identifier as reported by the provider.
     * `:provider` — the provider atom / module that served the run.
+    * `:error_diagnostic` — structured validation failure payload when
+      `finish_reason` is `:error_schema_validation`; `nil` otherwise. Shape:
+      `%{schema: term(), received: String.t() | nil, violations: [%{reason: String.t()}]}`.
     * `:telemetry` — span metadata summarising OTel attrs for the run
       (Phase 4).
     * `:no_progress_snapshot` — the last few message pairs (assistant +
@@ -42,10 +45,17 @@ defmodule ExAthena.Result do
           optional(:total_tokens) => non_neg_integer()
         }
 
+  @type error_diagnostic :: %{
+          schema: term(),
+          received: String.t() | nil,
+          violations: [%{reason: String.t()}]
+        }
+
   defstruct text: nil,
             messages: [],
             finish_reason: :stop,
             halted_reason: nil,
+            error_diagnostic: nil,
             iterations: 0,
             tool_calls_made: 0,
             usage: nil,
@@ -61,6 +71,7 @@ defmodule ExAthena.Result do
           messages: [Message.t()],
           finish_reason: Terminations.subtype(),
           halted_reason: term() | nil,
+          error_diagnostic: error_diagnostic() | nil,
           iterations: non_neg_integer(),
           tool_calls_made: non_neg_integer(),
           usage: usage() | nil,

--- a/test/ex_athena/loop/schema_validation_test.exs
+++ b/test/ex_athena/loop/schema_validation_test.exs
@@ -1,0 +1,61 @@
+defmodule ExAthena.Loop.SchemaValidationTest do
+  @moduledoc """
+  Acceptance tests for schema-validation and provider-auth error routing.
+  Drives the full Loop.run/2 pipeline via the Mock provider.
+  """
+  use ExUnit.Case, async: true
+
+  alias ExAthena.{Error, Loop}
+
+  setup do
+    dir = Path.join(System.tmp_dir!(), "schema_validation_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+    {:ok, dir: dir}
+  end
+
+  test "malformed tool-call text routes to :error_schema_validation with diagnostic", %{dir: dir} do
+    # The mock returns text that looks like a tool call but is malformed JSON — causes
+    # ToolCalls.extract to fail, which should be classified as :error_schema_validation.
+    assert {:ok, result} =
+             Loop.run("do something",
+               provider: :mock,
+               mock: [text: "~~~tool_call\n{invalid json\n~~~"],
+               cwd: dir,
+               tools: []
+             )
+
+    assert result.finish_reason == :error_schema_validation
+    assert is_map(result.error_diagnostic)
+    assert is_list(result.error_diagnostic.violations)
+    assert result.error_diagnostic.violations != []
+    assert result.error_diagnostic.received == "~~~tool_call\n{invalid json\n~~~"
+  end
+
+  test "generic provider error routes to :error_during_execution with nil diagnostic", %{dir: dir} do
+    assert {:ok, result} =
+             Loop.run("do something",
+               provider: :mock,
+               mock: [error: :boom],
+               cwd: dir,
+               tools: []
+             )
+
+    assert result.finish_reason == :error_during_execution
+    assert result.error_diagnostic == nil
+  end
+
+  test "provider auth error (:unauthorized) routes to :error_provider_auth with nil diagnostic",
+       %{dir: dir} do
+    assert {:ok, result} =
+             Loop.run("do something",
+               provider: :mock,
+               mock: [error: %Error{kind: :unauthorized, message: "invalid api key"}],
+               cwd: dir,
+               tools: []
+             )
+
+    assert result.finish_reason == :error_provider_auth
+    assert result.error_diagnostic == nil
+  end
+end

--- a/test/ex_athena/loop/terminations_test.exs
+++ b/test/ex_athena/loop/terminations_test.exs
@@ -15,6 +15,8 @@ defmodule ExAthena.Loop.TerminationsTest do
       assert :error_compaction_failed in Terminations.all()
       assert :error_prompt_too_long in Terminations.all()
       assert :error_no_progress in Terminations.all()
+      assert :error_schema_validation in Terminations.all()
+      assert :error_provider_auth in Terminations.all()
     end
   end
 
@@ -50,9 +52,17 @@ defmodule ExAthena.Loop.TerminationsTest do
       assert Terminations.category(:error_during_execution) == :retryable
     end
 
+    test "schema validation errors are :retryable" do
+      assert Terminations.category(:error_schema_validation) == :retryable
+    end
+
     test "halts and compaction failures are :fatal" do
       assert Terminations.category(:error_halted) == :fatal
       assert Terminations.category(:error_compaction_failed) == :fatal
+    end
+
+    test "provider auth errors are :fatal" do
+      assert Terminations.category(:error_provider_auth) == :fatal
     end
   end
 end

--- a/test/ex_athena/result_test.exs
+++ b/test/ex_athena/result_test.exs
@@ -12,6 +12,8 @@ defmodule ExAthena.ResultTest do
     refute Result.error?(%Result{finish_reason: :stop})
     assert Result.error?(%Result{finish_reason: :error_halted})
     assert Result.error?(%Result{finish_reason: :error_during_execution})
+    assert Result.error?(%Result{finish_reason: :error_schema_validation})
+    assert Result.error?(%Result{finish_reason: :error_provider_auth})
   end
 
   test "category/1 delegates to Terminations" do
@@ -19,6 +21,14 @@ defmodule ExAthena.ResultTest do
     assert Result.category(%Result{finish_reason: :error_max_turns}) == :capacity
     assert Result.category(%Result{finish_reason: :error_during_execution}) == :retryable
     assert Result.category(%Result{finish_reason: :error_halted}) == :fatal
+  end
+
+  test "category/1 returns :fatal for provider auth errors" do
+    assert Result.category(%Result{finish_reason: :error_provider_auth}) == :fatal
+  end
+
+  test "category/1 returns :retryable for schema validation errors" do
+    assert Result.category(%Result{finish_reason: :error_schema_validation}) == :retryable
   end
 
   test "default struct has sane zero values" do
@@ -29,7 +39,8 @@ defmodule ExAthena.ResultTest do
              iterations: 0,
              tool_calls_made: 0,
              usage: nil,
-             cost_usd: nil
+             cost_usd: nil,
+             error_diagnostic: nil
            } = %Result{}
   end
 


### PR DESCRIPTION
*   **Summary**
    This PR refines the failure reporting mechanism in ExAthena by replacing the generic `:error_during_execution` finish reason with more specific, distinct error states. This significantly improves failure diagnostics for consumers, allowing them to differentiate between data quality issues, credential failures, and runtime crashes.

*   **Key Changes**

    *   **Schema Validation Failure (Structured Output):** Introduced `:error_schema_validation` finish reason. When a model output fails to conform to the expected structured schema (e.g., JSON schema violation), the result now reports this specific reason and attaches a detailed diagnostic payload containing schema information and violation paths.
    *   **Authentication Failure (401/403):** Added support for detecting provider-level authentication failures, resulting in the `:error_provider_auth` finish reason. This ensures users know when the failure is due to invalid credentials, requiring a hard fail rather than a blind retry.
    *   **Propagation:** Updated `ExAthena.Result` and `ExAthena.Loop.Terminations` to incorporate the new termination reasons (`:error_schema_validation`, `:error_provider_auth`) and their associated metadata.
    *   **Affected Logic:** Modified pattern matching in `ExAthena.Modes.ReAct` to specifically detect and handle schema validation failures and unauthenticated API errors, directing them to the appropriate new finish reasons.
    *   **Looping Logic:** Updated `ExAthena.Loop` to accept and pass the `error_diagnostic` metadata when terminating due to these specific failures.

*   **Implementation Details**
    The introduction of these distinct reasons separates failure categories:

    *   **:error_schema_validation**: Used when the model output is syntactically or semantically incorrect relative to the requested structured schema. This is marked as `:retryable` with a specific remediation hint (re-prompting with a format hint).
    *   **:error_provider_auth**: Used when the external provider returns an HTTP 401 or 403. This is marked as `:fatal`, indicating that user intervention (fixing credentials) is required.

    These changes allow consumers of the API to implement smarter retry logic, distinguishing between *data remediation* (schema failure) and *system failure* (auth error/runtime crash).

Closes https://github.com/udin-io/ex_athena/issues/47