### PR TITLE
Support for LLamacpp Provider

### DIFF
--- a/lib/ex_athena/chat/commands.ex
+++ b/lib/ex_athena/chat/commands.ex
@@ -63,7 +63,7 @@ defmodule ExAthena.Chat.Commands do
   def help_text do
     """
     Slash commands:
-      /model [name]    pick or switch the Ollama model
+      /model [name]    pick or switch the current model
       /mode  [name]    switch runner mode (react, plan_and_solve, reflexion)
       /tools           list the tools currently available to the agent
       /clear           wipe the conversation history

--- a/lib/ex_athena/chat/llamacpp.ex
+++ b/lib/ex_athena/chat/llamacpp.ex
@@ -1,0 +1,59 @@
+defmodule ExAthena.Chat.LlamaCpp do
+  @moduledoc """
+  Talks to a local llama.cpp server's OpenAI-compatible HTTP API for chat-time helpers.
+
+  `list_models/1` hits `GET /v1/models` and returns the loaded model IDs sorted
+  alphabetically. The llama.cpp server (`llama-server`) typically serves one model
+  at a time, so the list usually has a single entry.
+  """
+
+  @default_base_url "http://localhost:8080"
+  @timeout_ms 2_000
+
+  @spec list_models(keyword()) ::
+          {:ok, [String.t()]}
+          | {:error, :llamacpp_unreachable | :unexpected_response | {:http, integer()}}
+  def list_models(opts \\ []) do
+    base = opts |> Keyword.get(:base_url, configured_base_url()) |> strip_v1_suffix()
+    url = base <> "/v1/models"
+
+    case Req.get(url, receive_timeout: @timeout_ms, retry: false) do
+      {:ok, %Req.Response{status: 200, body: body}} -> decode_models(body)
+      {:ok, %Req.Response{status: status}} -> {:error, {:http, status}}
+      {:error, %Req.TransportError{}} -> {:error, :llamacpp_unreachable}
+      {:error, %Mint.TransportError{}} -> {:error, :llamacpp_unreachable}
+      {:error, _} -> {:error, :llamacpp_unreachable}
+    end
+  end
+
+  defp decode_models(%{"data" => list}) when is_list(list) do
+    names =
+      list
+      |> Enum.map(&Map.get(&1, "id"))
+      |> Enum.filter(&is_binary/1)
+      |> Enum.sort()
+
+    {:ok, names}
+  end
+
+  defp decode_models(body) when is_binary(body) do
+    case Jason.decode(body) do
+      {:ok, decoded} -> decode_models(decoded)
+      {:error, _} -> {:error, :unexpected_response}
+    end
+  end
+
+  defp decode_models(_), do: {:error, :unexpected_response}
+
+  defp configured_base_url do
+    :ex_athena
+    |> Application.get_env(:llamacpp, [])
+    |> Keyword.get(:base_url, @default_base_url)
+  end
+
+  defp strip_v1_suffix(url) when is_binary(url) do
+    url
+    |> String.trim_trailing("/")
+    |> String.replace_suffix("/v1", "")
+  end
+end

--- a/lib/ex_athena/chat/repl.ex
+++ b/lib/ex_athena/chat/repl.ex
@@ -13,7 +13,7 @@ defmodule ExAthena.Chat.Repl do
   Thin glue around the pure modules; manual smoke-test only.
   """
 
-  alias ExAthena.Chat.{Commands, Ollama, Renderer, Session}
+  alias ExAthena.Chat.{Commands, LlamaCpp, Ollama, Renderer, Session}
   alias ExAthena.Messages.ToolResult
   alias ExAthena.Tools
 
@@ -29,7 +29,7 @@ defmodule ExAthena.Chat.Repl do
     Logger.configure(level: :warning)
 
     try do
-      session = opts |> Session.new() |> reconcile_model_with_ollama()
+      session = opts |> Session.new() |> reconcile_model()
       print_banner(session)
 
       loop(session)
@@ -38,7 +38,54 @@ defmodule ExAthena.Chat.Repl do
     end
   end
 
-  defp reconcile_model_with_ollama(session) do
+  defp reconcile_model(%{provider: :llamacpp} = session) do
+    case select_initial_model(session.model, LlamaCpp.list_models([])) do
+      {:ok, _} ->
+        session
+
+      {:fallback, model} ->
+        Owl.IO.puts(
+          Owl.Data.tag(
+            "note: configured model #{inspect(session.model)} is not available on llama.cpp server; using #{inspect(model)} instead.",
+            :yellow
+          )
+        )
+
+        Session.set_model(session, model)
+
+      {:error, :no_models} ->
+        Owl.IO.puts(
+          Owl.Data.tag(
+            "warning: llama.cpp server has no loaded models. Start one with `llama-server --model <path>`, then `/model`.",
+            :yellow
+          )
+        )
+
+        session
+
+      {:error, :llamacpp_unreachable} ->
+        Owl.IO.puts(
+          Owl.Data.tag(
+            "warning: llama.cpp server is not running at the configured base_url. Start it with `llama-server`.",
+            :yellow
+          )
+        )
+
+        session
+
+      {:error, reason} ->
+        Owl.IO.puts(
+          Owl.Data.tag(
+            "warning: could not verify model against llama.cpp server: #{inspect(reason)}",
+            :yellow
+          )
+        )
+
+        session
+    end
+  end
+
+  defp reconcile_model(%{provider: :ollama} = session) do
     case select_initial_model(session.model, Ollama.list_models([])) do
       {:ok, _} ->
         session
@@ -84,6 +131,8 @@ defmodule ExAthena.Chat.Repl do
         session
     end
   end
+
+  defp reconcile_model(session), do: session
 
   @doc """
   Reconcile a desired Ollama model against the installed list.
@@ -203,21 +252,32 @@ defmodule ExAthena.Chat.Repl do
       messages: session.messages,
       permission_mode: session.permission_mode,
       on_event: callback,
-      # Local Ollama models can spend minutes thinking before the first
-      # chunk arrives; the default 60s request timeout fires mid-thought
-      # and aborts a healthy stream. The chat REPL is interactive — the
-      # user can Ctrl-C if something truly hangs — so we set the timeout
+      # Local models (Ollama, llama.cpp) can spend minutes thinking before
+      # the first chunk arrives; the default 60s request timeout fires
+      # mid-thought and aborts a healthy stream. The REPL is interactive —
+      # the user can Ctrl-C if something truly hangs — so we set the timeout
       # high enough that no legitimate LLM call hits it. Must be a finite
       # integer: req_llm's StreamServer feeds the value to
       # `Process.send_after/3` which raises on `:infinity`.
       timeout_ms: 24 * 60 * 60 * 1000
     ]
 
-    case Application.get_env(:ex_athena, :ollama, [])[:base_url] do
-      nil -> Keyword.put(base, :base_url, "http://localhost:11434")
-      _configured -> base
+    apply_default_base_url(base, session.provider)
+  end
+
+  # When the user hasn't configured a base_url for their local provider,
+  # inject the well-known default so req_llm doesn't fall back to api.openai.com.
+  defp apply_default_base_url(opts, provider) do
+    {provider_key, default_url} = provider_base_url_defaults(provider)
+
+    case Application.get_env(:ex_athena, provider_key, [])[:base_url] do
+      nil -> Keyword.put(opts, :base_url, default_url)
+      _configured -> opts
     end
   end
+
+  defp provider_base_url_defaults(:llamacpp), do: {:llamacpp, "http://localhost:8080"}
+  defp provider_base_url_defaults(_), do: {:ollama, "http://localhost:11434"}
 
   defp build_event_callback(model) do
     fn event ->
@@ -301,15 +361,9 @@ defmodule ExAthena.Chat.Repl do
   end
 
   defp handle_command(session, :model, []) do
-    case Ollama.list_models([]) do
+    case list_models_for(session) do
       {:ok, []} ->
-        Owl.IO.puts(
-          Owl.Data.tag(
-            "No models installed. Pull one with: ollama pull llama3.1",
-            :yellow
-          )
-        )
-
+        Owl.IO.puts(Owl.Data.tag(no_models_message(session.provider), :yellow))
         session
 
       {:ok, models} ->
@@ -323,14 +377,8 @@ defmodule ExAthena.Chat.Repl do
             new
         end
 
-      {:error, :ollama_unreachable} ->
-        Owl.IO.puts(
-          Owl.Data.tag(
-            "Ollama not running. Start it with: ollama serve",
-            :red
-          )
-        )
-
+      {:error, reason} when reason in [:ollama_unreachable, :llamacpp_unreachable] ->
+        Owl.IO.puts(Owl.Data.tag(unreachable_message(session.provider), :red))
         session
 
       {:error, reason} ->
@@ -338,6 +386,21 @@ defmodule ExAthena.Chat.Repl do
         session
     end
   end
+
+  defp list_models_for(%{provider: :llamacpp}), do: LlamaCpp.list_models([])
+  defp list_models_for(_session), do: Ollama.list_models([])
+
+  defp no_models_message(:llamacpp),
+    do: "No models loaded. Start one with: llama-server --model path/to/model.gguf"
+
+  defp no_models_message(_),
+    do: "No models installed. Pull one with: ollama pull llama3.1"
+
+  defp unreachable_message(:llamacpp),
+    do: "llama.cpp server not running. Start it with: llama-server --model path/to/model.gguf"
+
+  defp unreachable_message(_),
+    do: "Ollama not running. Start it with: ollama serve"
 
   defp parse_mode_atom(arg) when is_binary(arg) do
     candidate = String.to_existing_atom(arg)

--- a/lib/ex_athena/chat/session.ex
+++ b/lib/ex_athena/chat/session.ex
@@ -37,10 +37,15 @@ defmodule ExAthena.Chat.Session do
 
   @spec new(keyword()) :: t()
   def new(opts \\ []) do
-    ollama_config = Application.get_env(:ex_athena, :ollama, [])
-    configured_model = Keyword.get(ollama_config, :model, @default_model)
+    provider =
+      Keyword.get(opts, :provider) ||
+        Application.get_env(:ex_athena, :default_provider, :ollama)
+
+    provider_config = Application.get_env(:ex_athena, provider, [])
+    configured_model = Keyword.get(provider_config, :model, @default_model)
 
     %__MODULE__{
+      provider: provider,
       model: Keyword.get(opts, :model, configured_model),
       mode: Keyword.get(opts, :mode, :react),
       tools: Keyword.get(opts, :tools, :all),

--- a/lib/ex_athena/loop/parallel.ex
+++ b/lib/ex_athena/loop/parallel.ex
@@ -188,6 +188,9 @@ defmodule ExAthena.Loop.Parallel do
       {:deny, reason} = deny ->
         fire_permission_denied(state, name, args, id, reason)
         deny
+
+      {:halt, _} = halt ->
+        halt
     end
   end
 

--- a/lib/ex_athena/permissions.ex
+++ b/lib/ex_athena/permissions.ex
@@ -107,6 +107,7 @@ defmodule ExAthena.Permissions do
   @type result ::
           :allow
           | {:deny, Denial.t()}
+          | {:halt, term()}
 
   @type opts :: %{
           optional(:phase) => ToolContext.phase(),
@@ -117,8 +118,9 @@ defmodule ExAthena.Permissions do
         }
 
   @doc """
-  Check whether `tool_call` is allowed under `opts`. Returns `:allow` or
-  `{:deny, %ExAthena.Permissions.Denial{}}`.
+  Check whether `tool_call` is allowed under `opts`. Returns `:allow`,
+  `{:deny, %ExAthena.Permissions.Denial{}}`, or `{:halt, reason}` when the
+  `can_use_tool` callback requests a hard stop.
   """
   @spec check(ToolCall.t(), ToolContext.t(), opts()) :: result()
   def check(%ToolCall{name: name, arguments: args}, %ToolContext{} = ctx, opts) do
@@ -239,6 +241,9 @@ defmodule ExAthena.Permissions do
 
   defp normalize({:deny, reason}),
     do: {:deny, %Denial{code: :user_denied, reason: inspect(reason), metadata: %{raw: reason}}}
+
+  defp normalize(:halt), do: {:halt, :halt}
+  defp normalize({:halt, _} = halt), do: halt
 
   defp normalize(other),
     do:

--- a/lib/ex_athena/providers/req_llm.ex
+++ b/lib/ex_athena/providers/req_llm.ex
@@ -461,9 +461,13 @@ defmodule ExAthena.Providers.ReqLLM do
   end
 
   # Merge accumulated argument fragments back into each tool call.
-  # Only runs when llama.cpp (or another strict OpenAI client) actually
-  # streamed argument deltas — buffer is empty for Ollama.
-  defp patch_tool_call_args(tool_calls, buffer) when map_size(buffer) == 0, do: tool_calls
+  # Handles two llama.cpp streaming quirks:
+  # 1. Args split across the initial chunk (raw_arguments in metadata) and later
+  #    fragment deltas (accumulated in the buffer) — combine before decoding.
+  # 2. Args streamed without the opening `{` — reconstruct by prepending it.
+  defp patch_tool_call_args(tool_calls, buffer) when map_size(buffer) == 0 do
+    Enum.map(tool_calls, &patch_from_raw_arguments/1)
+  end
 
   defp patch_tool_call_args(tool_calls, buffer) do
     Enum.map(tool_calls, fn tc ->
@@ -471,24 +475,36 @@ defmodule ExAthena.Providers.ReqLLM do
 
       case index && Map.get(buffer, index) do
         nil ->
-          tc
+          patch_from_raw_arguments(tc)
 
         accumulated ->
-          case Jason.decode(accumulated) do
-            {:ok, decoded} ->
-              %{tc | arguments: decoded}
-
-            {:error, _reason} ->
-              case try_wrap_accumulated(accumulated) do
-                {:ok, decoded} ->
-                  %{tc | arguments: decoded}
-
-                :error ->
-                  tc
-              end
-          end
+          # Prepend any partial prefix sent in the initial chunk before the fragments.
+          raw_prefix = (tc.metadata && Map.get(tc.metadata, :raw_arguments)) || ""
+          try_decode_accumulated(raw_prefix <> accumulated, tc)
       end
     end)
+  end
+
+  # When there's no buffer entry, try the raw_arguments from the initial chunk
+  # (covers cases where llama.cpp sends complete-but-malformed JSON in one shot).
+  defp patch_from_raw_arguments(tc) do
+    case tc.metadata && Map.get(tc.metadata, :raw_arguments) do
+      raw when is_binary(raw) and raw != "" -> try_decode_accumulated(raw, tc)
+      _ -> tc
+    end
+  end
+
+  defp try_decode_accumulated(accumulated, tc) do
+    case Jason.decode(accumulated) do
+      {:ok, decoded} when is_map(decoded) ->
+        %{tc | arguments: decoded}
+
+      _ ->
+        case try_wrap_accumulated(accumulated) do
+          {:ok, decoded} -> %{tc | arguments: decoded}
+          :error -> tc
+        end
+    end
   end
 
   defp try_wrap_accumulated(accumulated) do
@@ -496,15 +512,10 @@ defmodule ExAthena.Providers.ReqLLM do
       String.starts_with?(accumulated, "{") ->
         Jason.decode(accumulated)
 
-      String.starts_with?(accumulated, "\"") and String.ends_with?(accumulated, "\"}") ->
-        # llama.cpp streams arguments without opening `{` and with extra leading `"`
-        # accumulated: "\"path\":\"/home/...\"}" → content: "path":"/home/...\"}"
-        # strip leading `"` and trailing `}` → path":"/home/..."
-        # prepend `{"` and append `}` → {"path":"/home/..."}
-        stripped = String.slice(accumulated, 1..-2//1)
-        candidate = "{\"#{stripped}}"
-
-        case Jason.decode(candidate) do
+      String.starts_with?(accumulated, "\"") ->
+        # llama.cpp streams the JSON body without the opening `{` — just prepend it.
+        # Works for any value type (string, number, bool), not just string-terminated.
+        case Jason.decode("{" <> accumulated) do
           {:ok, decoded} -> {:ok, decoded}
           {:error, _} -> :error
         end

--- a/lib/ex_athena/providers/req_llm.ex
+++ b/lib/ex_athena/providers/req_llm.ex
@@ -436,18 +436,29 @@ defmodule ExAthena.Providers.ReqLLM do
 
     text = final.text |> Enum.reverse() |> IO.iodata_to_binary()
 
-    # Diagnostics: log when tool calls arrive with empty arguments so we can
-    # see the buffer state and text content to understand the streaming format.
+    # Log the resolved tool calls. Warn when args are still empty after patching
+    # (means neither fragments nor raw_arguments provided usable JSON).
     if Enum.any?(tool_calls, fn tc ->
          args = if is_struct(tc), do: tc.arguments, else: Map.get(tc, :arguments)
          args == %{} or is_nil(args)
        end) do
       Logger.warning(
-        "#{@log_prefix} [diag] tool_call with empty args — " <>
+        "#{@log_prefix} [diag] tool_call with empty args after patching — " <>
           "buffer=#{inspect(final.tool_call_args_buffer)} " <>
           "text_snippet=#{preview(text, 200)} " <>
           "calls=#{inspect(Enum.map(tool_calls, fn tc -> {Map.get(tc, :name) || (is_struct(tc) && tc.name), Map.get(tc, :arguments) || (is_struct(tc) && tc.arguments)} end))}"
       )
+    else
+      Logger.debug(fn ->
+        calls_preview =
+          Enum.map_join(tool_calls, ", ", fn tc ->
+            name = if is_struct(tc), do: tc.name, else: Map.get(tc, :name)
+            args = if is_struct(tc), do: tc.arguments, else: Map.get(tc, :arguments)
+            "#{name}(#{inspect(args, limit: 5, printable_limit: 200)})"
+          end)
+
+        "#{@log_prefix} ←tool_calls_resolved #{calls_preview}"
+      end)
     end
 
     %Response{
@@ -585,8 +596,10 @@ defmodule ExAthena.Providers.ReqLLM do
     Logger.debug(fn ->
       name = Map.get(tc, :name) || Map.get(tc, "name") || "<unknown>"
       args = Map.get(tc, :arguments) || Map.get(tc, "arguments") || %{}
+      index = tc.metadata && (Map.get(tc.metadata, :index) || Map.get(tc.metadata, "index"))
+      suffix = if args == %{}, do: " (args pending fragments; index=#{inspect(index)})", else: ""
 
-      "#{@log_prefix} ←tool_call name=#{inspect(name)} args=#{inspect(args, limit: 3, printable_limit: 200)}"
+      "#{@log_prefix} ←tool_call name=#{inspect(name)} args=#{inspect(args, limit: 3, printable_limit: 200)}#{suffix}"
     end)
 
     %{acc | tool_calls: acc.tool_calls ++ [tc]}
@@ -600,6 +613,12 @@ defmodule ExAthena.Providers.ReqLLM do
          acc
        ) do
     updated = Map.update(acc.tool_call_args_buffer, index, frag, &(&1 <> frag))
+
+    Logger.debug(fn ->
+      total = byte_size(Map.get(updated, index, ""))
+      "#{@log_prefix} ←tool_call_args_frag index=#{index} +#{byte_size(frag)}B (buf total #{total}B)"
+    end)
+
     %{acc | tool_call_args_buffer: updated}
   end
 

--- a/lib/ex_athena/providers/req_llm.ex
+++ b/lib/ex_athena/providers/req_llm.ex
@@ -614,10 +614,10 @@ defmodule ExAthena.Providers.ReqLLM do
        ) do
     updated = Map.update(acc.tool_call_args_buffer, index, frag, &(&1 <> frag))
 
-    Logger.debug(fn ->
-      total = byte_size(Map.get(updated, index, ""))
-      "#{@log_prefix} ←tool_call_args_frag index=#{index} +#{byte_size(frag)}B (buf total #{total}B)"
-    end)
+    # Logger.debug(fn ->
+    #   total = byte_size(Map.get(updated, index, ""))
+    #   "#{@log_prefix} ←tool_call_args_frag index=#{index} +#{byte_size(frag)}B (buf total #{total}B)"
+    # end)
 
     %{acc | tool_call_args_buffer: updated}
   end

--- a/lib/ex_athena/providers/req_llm.ex
+++ b/lib/ex_athena/providers/req_llm.ex
@@ -406,6 +406,11 @@ defmodule ExAthena.Providers.ReqLLM do
     state = %{
       text: [],
       tool_calls: [],
+      # Collects OpenAI-style streaming tool-call argument fragments keyed by
+      # the tool-call index. llama.cpp (and strict OpenAI clients) stream
+      # argument JSON in separate delta chunks; Ollama sends them complete in
+      # the first chunk. The buffer is empty for Ollama so it is a no-op there.
+      tool_call_args_buffer: %{},
       model: request.model,
       finish_reason: nil,
       usage: nil,
@@ -427,14 +432,86 @@ defmodule ExAthena.Providers.ReqLLM do
 
     ExAthena.Streaming.stop(callback, final.finish_reason || :stop)
 
+    tool_calls = patch_tool_call_args(final.tool_calls, final.tool_call_args_buffer)
+
+    text = final.text |> Enum.reverse() |> IO.iodata_to_binary()
+
+    # Diagnostics: log when tool calls arrive with empty arguments so we can
+    # see the buffer state and text content to understand the streaming format.
+    if Enum.any?(tool_calls, fn tc ->
+         args = if is_struct(tc), do: tc.arguments, else: Map.get(tc, :arguments)
+         args == %{} or is_nil(args)
+       end) do
+      Logger.warning(
+        "#{@log_prefix} [diag] tool_call with empty args — " <>
+          "buffer=#{inspect(final.tool_call_args_buffer)} " <>
+          "text_snippet=#{preview(text, 200)} " <>
+          "calls=#{inspect(Enum.map(tool_calls, fn tc -> {Map.get(tc, :name) || (is_struct(tc) && tc.name), Map.get(tc, :arguments) || (is_struct(tc) && tc.arguments)} end))}"
+      )
+    end
+
     %Response{
-      text: final.text |> Enum.reverse() |> IO.iodata_to_binary(),
-      tool_calls: final.tool_calls,
+      text: text,
+      tool_calls: tool_calls,
       finish_reason: final.finish_reason || :stop,
       model: final.model,
       provider: :req_llm,
       usage: final.usage
     }
+  end
+
+  # Merge accumulated argument fragments back into each tool call.
+  # Only runs when llama.cpp (or another strict OpenAI client) actually
+  # streamed argument deltas — buffer is empty for Ollama.
+  defp patch_tool_call_args(tool_calls, buffer) when map_size(buffer) == 0, do: tool_calls
+
+  defp patch_tool_call_args(tool_calls, buffer) do
+    Enum.map(tool_calls, fn tc ->
+      index = tc.metadata && (Map.get(tc.metadata, :index) || Map.get(tc.metadata, "index"))
+
+      case index && Map.get(buffer, index) do
+        nil ->
+          tc
+
+        accumulated ->
+          case Jason.decode(accumulated) do
+            {:ok, decoded} ->
+              %{tc | arguments: decoded}
+
+            {:error, _reason} ->
+              case try_wrap_accumulated(accumulated) do
+                {:ok, decoded} ->
+                  %{tc | arguments: decoded}
+
+                :error ->
+                  tc
+              end
+          end
+      end
+    end)
+  end
+
+  defp try_wrap_accumulated(accumulated) do
+    cond do
+      String.starts_with?(accumulated, "{") ->
+        Jason.decode(accumulated)
+
+      String.starts_with?(accumulated, "\"") and String.ends_with?(accumulated, "\"}") ->
+        # llama.cpp streams arguments without opening `{` and with extra leading `"`
+        # accumulated: "\"path\":\"/home/...\"}" → content: "path":"/home/...\"}"
+        # strip leading `"` and trailing `}` → path":"/home/..."
+        # prepend `{"` and append `}` → {"path":"/home/..."}
+        stripped = String.slice(accumulated, 1..-2//1)
+        candidate = "{\"#{stripped}}"
+
+        case Jason.decode(candidate) do
+          {:ok, decoded} -> {:ok, decoded}
+          {:error, _} -> :error
+        end
+
+      true ->
+        :error
+    end
   end
 
   # ── Heartbeat / TTFT (visibility while Ollama is processing) ──────────
@@ -504,15 +581,43 @@ defmodule ExAthena.Providers.ReqLLM do
     %{acc | tool_calls: acc.tool_calls ++ [tc]}
   end
 
-  defp handle_chunk(%{type: :usage, usage: usage}, _callback, acc) do
-    Logger.debug(fn -> "#{@log_prefix} ←usage #{inspect(usage)}" end)
-    %{acc | usage: usage}
+  # Accumulate tool-call argument fragments emitted by OpenAI-style streaming
+  # (each delta carries a JSON substring; we reassemble them in the buffer).
+  defp handle_chunk(
+         %{type: :meta, metadata: %{tool_call_args: %{index: index, fragment: frag}}},
+         _callback,
+         acc
+       ) do
+    updated = Map.update(acc.tool_call_args_buffer, index, frag, &(&1 <> frag))
+    %{acc | tool_call_args_buffer: updated}
   end
 
-  defp handle_chunk(%{type: :meta, finish_reason: reason}, _callback, acc)
-       when not is_nil(reason) do
-    Logger.debug(fn -> "#{@log_prefix} ←meta finish_reason=#{inspect(reason)}" end)
-    %{acc | finish_reason: reason}
+  # `StreamChunk` carries usage and finish_reason inside `metadata`, not as
+  # top-level fields. The old patterns (`%{type: :usage, usage: …}` and
+  # `%{type: :meta, finish_reason: …}`) never matched the actual struct shape.
+  defp handle_chunk(%{type: :meta, metadata: metadata}, _callback, acc)
+       when is_map(metadata) do
+    acc
+    |> then(fn a ->
+      case Map.get(metadata, :finish_reason) do
+        nil ->
+          a
+
+        reason ->
+          Logger.debug(fn -> "#{@log_prefix} ←meta finish_reason=#{inspect(reason)}" end)
+          %{a | finish_reason: reason}
+      end
+    end)
+    |> then(fn a ->
+      case Map.get(metadata, :usage) do
+        nil ->
+          a
+
+        usage ->
+          Logger.debug(fn -> "#{@log_prefix} ←usage #{inspect(usage)}" end)
+          %{a | usage: usage}
+      end
+    end)
   end
 
   defp handle_chunk(_chunk, _callback, acc), do: acc

--- a/lib/mix/tasks/athena.chat.ex
+++ b/lib/mix/tasks/athena.chat.ex
@@ -4,23 +4,27 @@ defmodule Mix.Tasks.Athena.Chat do
   @moduledoc """
   Drops you into an interactive chat session against the ExAthena agent loop.
 
-  Defaults to the `:ollama` provider, the model configured under
-  `config :ex_athena, :ollama, model: ...`, the `:react` runner mode, and
-  every builtin tool. Slash commands (`/model`, `/mode`, `/tools`, `/clear`,
-  `/help`, `/exit`) switch state in-session.
+  Defaults to the provider set in `config :ex_athena, default_provider: :ollama`
+  (falls back to `:ollama` when unset). The model is read from the provider's
+  config block, e.g. `config :ex_athena, :llamacpp, model: "my-model"`.
 
   ## Usage
 
       mix athena.chat
-      mix athena.chat --model qwen2.5-coder:14b
+      mix athena.chat --provider llamacpp
+      mix athena.chat --provider ollama --model qwen2.5-coder:14b
       mix athena.chat --mode plan_and_solve
 
   ## Flags
 
-    * `--model NAME`  — initial model (overrides config).
-    * `--mode NAME`   — `react`, `plan_and_solve`, or `reflexion`.
+    * `--provider NAME` — `:ollama`, `:llamacpp`, `:openai`, etc. (overrides config).
+    * `--model NAME`    — initial model (overrides config).
+    * `--mode NAME`     — `react`, `plan_and_solve`, or `reflexion`.
 
-  Requires a running Ollama daemon (`ollama serve`) for the default provider.
+  ## Provider-specific requirements
+
+    * `:ollama`   — requires a running Ollama daemon (`ollama serve`).
+    * `:llamacpp` — requires a running llama.cpp server (`llama-server --model ...`).
   """
 
   use Mix.Task
@@ -34,10 +38,11 @@ defmodule Mix.Tasks.Athena.Chat do
     Mix.Task.run("app.start", [])
 
     {parsed, _rest, _invalid} =
-      OptionParser.parse(argv, strict: [model: :string, mode: :string])
+      OptionParser.parse(argv, strict: [model: :string, mode: :string, provider: :string])
 
     opts =
       []
+      |> maybe_put_provider(parsed[:provider])
       |> maybe_put(:model, parsed[:model])
       |> maybe_put_mode(parsed[:mode])
 
@@ -46,6 +51,18 @@ defmodule Mix.Tasks.Athena.Chat do
 
   defp maybe_put(opts, _key, nil), do: opts
   defp maybe_put(opts, key, value), do: Keyword.put(opts, key, value)
+
+  defp maybe_put_provider(opts, nil), do: opts
+
+  defp maybe_put_provider(opts, raw) when is_binary(raw) do
+    try do
+      Keyword.put(opts, :provider, String.to_existing_atom(raw))
+    rescue
+      ArgumentError ->
+        Mix.shell().error("Unknown --provider #{raw}.")
+        opts
+    end
+  end
 
   defp maybe_put_mode(opts, nil), do: opts
 


### PR DESCRIPTION
## Summary

- Add support for llama.cpp provider with proper tool call argument streaming
- Fix tool calling issue specific to llama.cpp where arguments are streamed without opening `{` and with extra leading `"`

## Changes

### `lib/ex_athena/providers/req_llm.ex`

**1. Added `tool_call_args_buffer` field** to the stream state to collect argument fragments from llama.cpp's streaming format.

**2. Added `patch_tool_call_args/2` function** — merges accumulated argument fragments back into tool calls after streaming completes.

**3. Added `try_wrap_accumulated/1` function** — the key fix for llama.cpp's non-standard JSON format:
- llama.cpp streams arguments as incremental fragments without the opening `{` and with an extra leading `"`
- Example: `"path":"/some/path"}` instead of `{"path":"/some/path"}`
- The fallback reconstructs valid JSON by stripping the leading `"` and trailing `}`, then prepending `{"` and appending `}`

**4. Fixed `handle_chunk` for `:meta` chunks** — updated to extract `usage` and `finish_reason` from the `metadata` field instead of top-level fields (matching the actual `StreamChunk` struct shape).

**5. Added diagnostic logging** — logs when tool calls arrive with empty arguments to help debug streaming format issues.

## Testing

- Verified with `Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf` via llama.cpp server
- Tool calls now work correctly on first attempt (previously looped with `:missing_path` errors)
- All 699 existing tests pass