### PR TITLE
feat: split chat (TUI + web) into messages + details panes

### DIFF
--- a/lib/ex_athena/chat/commands.ex
+++ b/lib/ex_athena/chat/commands.ex
@@ -62,15 +62,36 @@ defmodule ExAthena.Chat.Commands do
   @spec help_text() :: String.t()
   def help_text do
     """
+    ExAthena chat — full usage
+
     Slash commands:
-      /model [name]    pick or switch the current model
-      /mode  [name]    switch runner mode (react, plan_and_solve, reflexion)
-      /tools           list the tools currently available to the agent
-      /clear           wipe the conversation history
-      /expand [N]      show the Nth-most-recent tool result in full (default 1)
-      /help, /?        show this help
-      /exit, /quit, /q leave the chat
-    Anything else is sent to the agent as a user message.
+      /model [name]      open the model picker, or set model directly
+      /mode  [name]      open the mode picker, or set mode directly
+                         (modes: react, plan_and_solve, reflexion)
+      /tools             list the tools currently available to the agent
+      /clear             wipe the conversation history (new session)
+      /expand [N]        show the Nth-most-recent tool result in full
+                         (default 1 = most recent)
+      /help, /?          show this help
+      /exit, /quit, /q   leave the chat
+
+    Keyboard:
+      Enter              send the current message
+      Shift+Enter        insert a newline in the message
+      Ctrl+C             quit the chat
+      ↑ / k              (in picker) move selection up
+      ↓ / j              (in picker) move selection down
+      Enter              (in picker) confirm selection
+      Esc                (in picker) close without selecting
+
+    Launch flags (mix athena.chat):
+      --provider NAME    ollama, llamacpp, openai, claude, gemini, ...
+      --model NAME       initial model (overrides config)
+      --mode NAME        react | plan_and_solve | reflexion
+
+    Anything that isn't a slash command is sent to the agent as a user
+    message. Tool calls and results stream inline; use /expand N to see
+    the full text of a truncated tool result.
     """
   end
 end

--- a/lib/ex_athena/chat/tui.ex
+++ b/lib/ex_athena/chat/tui.ex
@@ -256,7 +256,15 @@ defmodule ExAthena.Chat.Tui do
   end
 
   defp dispatch_command(:help, _args, state) do
-    append_and_noreply(state, {:info, Commands.help_text()})
+    # Each event row renders as one line, so split the help text and append
+    # one :info row per line (otherwise only the first line is visible).
+    state =
+      Commands.help_text()
+      |> String.trim_trailing("\n")
+      |> String.split("\n")
+      |> Enum.reduce(state, fn line, s -> State.append_event(s, {:info, line}) end)
+
+    {:noreply, state}
   end
 
   defp dispatch_command(:clear, _args, state) do

--- a/lib/ex_athena/chat/tui/state.ex
+++ b/lib/ex_athena/chat/tui/state.ex
@@ -28,6 +28,8 @@ defmodule ExAthena.Chat.Tui.State do
           | :warning
           | :info
           | :status
+          | :thinking
+          | :detail_header
 
   @type event_row :: {event_kind(), String.t()}
 
@@ -43,6 +45,10 @@ defmodule ExAthena.Chat.Tui.State do
             loading?: false,
             popup: nil,
             events: [],
+            details: [],
+            details_scroll_offset: 0,
+            details_stream_buffer: "",
+            details_thinking_buffer: "",
             footer: @default_footer,
             prior_log_level: :info,
             run_task: nil
@@ -55,6 +61,10 @@ defmodule ExAthena.Chat.Tui.State do
           loading?: boolean(),
           popup: popup(),
           events: [event_row()],
+          details: [event_row()],
+          details_scroll_offset: non_neg_integer(),
+          details_stream_buffer: String.t(),
+          details_thinking_buffer: String.t(),
           footer: String.t(),
           prior_log_level: atom(),
           run_task: pid() | nil
@@ -74,21 +84,32 @@ defmodule ExAthena.Chat.Tui.State do
   @doc """
   Apply an `ExAthena.Loop.Events.t()` to the UI state.
 
-  `:content` deltas accumulate into `stream_buffer` and are materialized
-  by `flush_stream/1` (the App calls this every tick). Other event kinds
-  produce a row immediately. Silent events (`:iteration`, `:usage`,
-  `:tool_ui`, `:done`) and unknown events are no-ops.
+  `:content` deltas accumulate into `stream_buffer` (left pane) and
+  `details_stream_buffer` (right pane); both are materialized by
+  `flush_stream/1`. Most other events produce a one-line row in the
+  left pane and a full-detail block in the right pane.
   """
   @spec append_loop_event(t(), term()) :: t()
   def append_loop_event(%__MODULE__{} = state, {:content, text}) when is_binary(text) do
-    %{state | stream_buffer: state.stream_buffer <> text}
+    %{
+      state
+      | stream_buffer: state.stream_buffer <> text,
+        details_stream_buffer: state.details_stream_buffer <> text
+    }
+  end
+
+  def append_loop_event(%__MODULE__{} = state, {:thinking, text}) when is_binary(text) do
+    %{state | details_thinking_buffer: state.details_thinking_buffer <> text}
   end
 
   def append_loop_event(
         %__MODULE__{} = state,
         {:tool_call, %ToolCall{name: name, arguments: args}}
       ) do
-    append_event(state, {:tool_call, "→ #{name}(#{preview_args(args)})"})
+    state
+    |> append_event({:tool_call, "→ #{name}(#{preview_args(args)})"})
+    |> append_detail_header("→ #{name}")
+    |> append_detail_lines(:tool_call, format_args_full(args))
   end
 
   def append_loop_event(
@@ -96,38 +117,77 @@ defmodule ExAthena.Chat.Tui.State do
         {:tool_result, %ToolResult{content: content, is_error: is_error}}
       ) do
     kind = if is_error, do: :tool_result_error, else: :tool_result
-    append_event(state, {kind, "← #{summarize_result(content)}"})
+    arrow = if is_error, do: "✗", else: "←"
+
+    state
+    |> append_event({kind, "← #{summarize_result(content)}"})
+    |> append_detail_header("#{arrow} result")
+    |> append_detail_lines(kind, to_string(content))
   end
 
-  def append_loop_event(%__MODULE__{} = state, {:error, reason}) do
-    append_event(state, {:warning, "warn: #{inspect(reason)}"})
+  def append_loop_event(%__MODULE__{} = state, {:tool_ui, %{kind: kind, payload: payload}}) do
+    state
+    |> append_detail_header("ui · #{kind}")
+    |> append_detail_lines(:info, format_tool_ui(kind, payload))
+  end
+
+  def append_loop_event(%__MODULE__{} = state, {:iteration, n}) do
+    append_detail_header(state, "iteration #{n}")
   end
 
   def append_loop_event(%__MODULE__{} = state, {:compaction, %{before: before, after: aft}}) do
-    append_event(state, {:info, "⤵ compacted #{before}→#{aft} tokens"})
+    state
+    |> append_event({:info, "⤵ compacted #{before}→#{aft} tokens"})
+    |> append_detail_header("⤵ compacted #{before}→#{aft} tokens")
   end
 
   def append_loop_event(%__MODULE__{} = state, {:subagent_spawn, %{prompt: p}}) do
-    append_event(state, {:info, "  ↳ subagent: #{truncate(p, 80)}"})
+    state
+    |> append_event({:info, "  ↳ subagent: #{truncate(p, 80)}"})
+    |> append_detail_header("↳ subagent spawn")
+    |> append_detail_lines(:info, p)
   end
 
   def append_loop_event(%__MODULE__{} = state, {:subagent_result, %{text: t}}) do
-    append_event(state, {:info, "  ↳ subagent done: #{truncate(t, 80)}"})
+    state
+    |> append_event({:info, "  ↳ subagent done: #{truncate(t, 80)}"})
+    |> append_detail_header("↳ subagent result")
+    |> append_detail_lines(:info, t)
+  end
+
+  def append_loop_event(%__MODULE__{} = state, {:error, reason}) do
+    state
+    |> append_event({:warning, "warn: #{inspect(reason)}"})
+    |> append_detail_header("⚠ error")
+    |> append_detail_lines(:error, inspect(reason, pretty: true))
+  end
+
+  def append_loop_event(%__MODULE__{} = state, {:usage, usage}) do
+    append_detail_header(state, "usage · #{inspect(usage)}")
   end
 
   def append_loop_event(%__MODULE__{} = state, _other), do: state
 
   @doc """
-  Materialize `stream_buffer` into the events list and clear it.
+  Materialize `stream_buffer` into the events list, and the
+  `details_stream_buffer` / `details_thinking_buffer` into the details
+  list. Clears all three buffers.
 
-  If the most recent event is already `:assistant`, the buffered text is
-  appended to it (streaming continues into the same row). Otherwise a
-  fresh `:assistant` row is created.
+  For each pane, if the most recent row is already the same kind
+  (`:assistant` / `:thinking`), the buffered text is appended in place.
+  Otherwise a fresh row is started.
   """
   @spec flush_stream(t()) :: t()
-  def flush_stream(%__MODULE__{stream_buffer: ""} = state), do: state
+  def flush_stream(%__MODULE__{} = state) do
+    state
+    |> flush_main_stream()
+    |> flush_details_assistant_stream()
+    |> flush_details_thinking_stream()
+  end
 
-  def flush_stream(%__MODULE__{stream_buffer: buf, events: events} = state) do
+  defp flush_main_stream(%__MODULE__{stream_buffer: ""} = state), do: state
+
+  defp flush_main_stream(%__MODULE__{stream_buffer: buf, events: events} = state) do
     new_events =
       case Enum.reverse(events) do
         [{:assistant, prior} | rest] ->
@@ -139,6 +199,45 @@ defmodule ExAthena.Chat.Tui.State do
 
     %{state | events: new_events, stream_buffer: ""}
   end
+
+  defp flush_details_assistant_stream(%__MODULE__{details_stream_buffer: ""} = state), do: state
+
+  defp flush_details_assistant_stream(%__MODULE__{details_stream_buffer: buf} = state) do
+    state
+    |> merge_details_buffer(:assistant, buf)
+    |> Map.put(:details_stream_buffer, "")
+  end
+
+  defp flush_details_thinking_stream(%__MODULE__{details_thinking_buffer: ""} = state), do: state
+
+  defp flush_details_thinking_stream(%__MODULE__{details_thinking_buffer: buf} = state) do
+    state
+    |> merge_details_buffer(:thinking, buf)
+    |> Map.put(:details_thinking_buffer, "")
+  end
+
+  # Append `buf` to the last detail row of the given kind if it's the tail
+  # (continuing a stream), otherwise start a new block. The buffer is
+  # split into one detail row per source line so the right pane wraps
+  # naturally with one widget per row.
+  defp merge_details_buffer(%__MODULE__{details: details} = state, kind, buf) do
+    new_lines = split_lines(buf)
+
+    new_details =
+      case {Enum.reverse(details), new_lines} do
+        {[{^kind, prior} | rest], [first | more]} ->
+          merged_first = {kind, prior <> first}
+          Enum.reverse([merged_first | rest]) ++ Enum.map(more, &{kind, &1})
+
+        _ ->
+          details ++ Enum.map(new_lines, &{kind, &1})
+      end
+
+    %{state | details: new_details}
+  end
+
+  defp split_lines(""), do: [""]
+  defp split_lines(text), do: String.split(text, "\n")
 
   @spec set_loading(t(), boolean()) :: t()
   def set_loading(%__MODULE__{} = state, flag) when is_boolean(flag) do
@@ -162,7 +261,16 @@ defmodule ExAthena.Chat.Tui.State do
 
   @spec clear_session(t()) :: t()
   def clear_session(%__MODULE__{session: session} = state) do
-    %{state | session: Session.clear_messages(session), events: [], stream_buffer: ""}
+    %{
+      state
+      | session: Session.clear_messages(session),
+        events: [],
+        stream_buffer: "",
+        details: [],
+        details_scroll_offset: 0,
+        details_stream_buffer: "",
+        details_thinking_buffer: ""
+    }
   end
 
   # ─ Popups ─────────────────────────────────────────────────────────────────
@@ -191,6 +299,50 @@ defmodule ExAthena.Chat.Tui.State do
   def current_popup_selection(%__MODULE__{popup: nil}), do: nil
   def current_popup_selection(%__MODULE__{popup: {_, [], _}}), do: nil
   def current_popup_selection(%__MODULE__{popup: {_, items, idx}}), do: Enum.at(items, idx)
+
+  # ─ Details-pane helpers ──────────────────────────────────────────────────
+
+  @doc false
+  def append_detail_header(%__MODULE__{details: details} = state, label)
+      when is_binary(label) do
+    %{state | details: details ++ [{:detail_header, label}]}
+  end
+
+  @doc false
+  def append_detail_lines(%__MODULE__{details: details} = state, kind, text)
+      when is_atom(kind) do
+    rows =
+      text
+      |> to_string()
+      |> String.trim_trailing("\n")
+      |> String.split("\n")
+      |> Enum.map(&{kind, &1})
+
+    %{state | details: details ++ rows}
+  end
+
+  defp format_args_full(args) when is_map(args) do
+    case Jason.encode(args, pretty: true) do
+      {:ok, json} -> json
+      _ -> inspect(args, pretty: true, limit: :infinity)
+    end
+  end
+
+  defp format_args_full(other), do: inspect(other, pretty: true)
+
+  defp format_tool_ui(:diff, %{path: path, before: before, after: aft}) do
+    "diff: #{path}\n--- before\n#{before}\n+++ after\n#{aft}"
+  end
+
+  defp format_tool_ui(:process, %{command: cmd, exit_code: code, stdout: out, duration_ms: ms}) do
+    "$ #{cmd}\n[exit=#{code}, #{ms}ms]\n#{out}"
+  end
+
+  defp format_tool_ui(:file, %{path: path, content: content}) do
+    "file: #{path}\n#{content}"
+  end
+
+  defp format_tool_ui(kind, payload), do: "#{kind}: #{inspect(payload, pretty: true)}"
 
   # ─ Helpers ────────────────────────────────────────────────────────────────
 

--- a/lib/ex_athena/chat/tui/view.ex
+++ b/lib/ex_athena/chat/tui/view.ex
@@ -6,8 +6,12 @@ defmodule ExAthena.Chat.Tui.View do
   Layout (top-to-bottom):
 
     1. Header (1 row) — `provider · model · mode · iter=N · in/out tok · $cost`.
-    2. Messages (flex) — a `WidgetList` of one `{Paragraph, 1}` per event row.
-       If `state.loading? == true`, a `Throbber` is appended to the list.
+    2. Body (flex) — split horizontally 50/50 into:
+         * Left  — `messages` WidgetList (one `{Paragraph, 1}` per event row).
+           If `state.loading? == true`, a `Throbber` is appended.
+         * Right — `details` WidgetList: full args, full tool results, thinking,
+           tool UI payloads, and every loop event. Wrapped in a titled `Block`
+           with a left border.
     3. Input (3 rows) — `Textarea` bound to `state.input_ref` inside a
        titled `Block`.
     4. Footer (1 row) — shortcut hints (changes when a popup is open).
@@ -39,7 +43,7 @@ defmodule ExAthena.Chat.Tui.View do
   def build_frame(%State{} = state, %Frame{width: w, height: h}) do
     area = %Rect{x: 0, y: 0, width: w, height: h}
 
-    [header_rect, messages_rect, input_rect, footer_rect] =
+    [header_rect, body_rect, input_rect, footer_rect] =
       Layout.split(area, :vertical, [
         {:length, 1},
         {:min, 0},
@@ -47,9 +51,16 @@ defmodule ExAthena.Chat.Tui.View do
         {:length, @footer_height}
       ])
 
+    [messages_rect, details_rect] =
+      Layout.split(body_rect, :horizontal, [
+        {:percentage, 50},
+        {:percentage, 50}
+      ])
+
     widgets = [
       {header(state), header_rect},
       {messages(state), messages_rect},
+      {details(state), details_rect},
       {input(state), input_rect},
       {footer(state), footer_rect}
     ]
@@ -98,6 +109,60 @@ defmodule ExAthena.Chat.Tui.View do
       |> append_throbber(loading?)
 
     %WidgetList{items: items, scroll_offset: scroll}
+  end
+
+  @details_block %Block{
+    title: " details ",
+    borders: [:left, :top, :bottom, :right],
+    border_type: :rounded,
+    border_style: %Style{fg: :dark_gray}
+  }
+
+  defp details(%State{details: details, details_scroll_offset: scroll}) do
+    items = Enum.map(details, &detail_row_widget/1)
+    %WidgetList{items: items, scroll_offset: scroll, block: @details_block}
+  end
+
+  defp detail_row_widget({:detail_header, text}) do
+    {%Paragraph{
+       text: text,
+       style: %Style{fg: :light_yellow, modifiers: [:bold]}
+     }, 1}
+  end
+
+  defp detail_row_widget({:thinking, text}) do
+    {%Paragraph{
+       text: text,
+       style: %Style{fg: :magenta, modifiers: [:italic]}
+     }, 1}
+  end
+
+  defp detail_row_widget({:assistant, text}) do
+    {%Paragraph{text: text, style: %Style{fg: :white}}, 1}
+  end
+
+  defp detail_row_widget({:tool_call, text}) do
+    {%Paragraph{text: text, style: %Style{fg: :cyan}}, 1}
+  end
+
+  defp detail_row_widget({:tool_result, text}) do
+    {%Paragraph{text: text, style: %Style{fg: :dark_gray}}, 1}
+  end
+
+  defp detail_row_widget({:tool_result_error, text}) do
+    {%Paragraph{text: text, style: %Style{fg: :red}}, 1}
+  end
+
+  defp detail_row_widget({:error, text}) do
+    {%Paragraph{text: text, style: %Style{fg: :red, modifiers: [:bold]}}, 1}
+  end
+
+  defp detail_row_widget({:info, text}) do
+    {%Paragraph{text: text, style: %Style{fg: :dark_gray}}, 1}
+  end
+
+  defp detail_row_widget({_kind, text}) do
+    {%Paragraph{text: text, style: %Style{fg: :dark_gray}}, 1}
   end
 
   defp row_widget({:user, text}, _model) do

--- a/lib/ex_athena/loop/events.ex
+++ b/lib/ex_athena/loop/events.ex
@@ -10,6 +10,10 @@ defmodule ExAthena.Loop.Events do
   Events:
 
     * `{:content, text}` — partial or full assistant text.
+    * `{:thinking, text}` — partial or full model reasoning/thinking
+      content (Anthropic `thinking` blocks, OpenAI `reasoning`
+      content). Distinct from `:content` so hosts can display it
+      separately (e.g. in a side pane).
     * `{:tool_call, ToolCall.t()}` — model requested a tool call.
     * `{:tool_result, ToolResult.t()}` — tool produced a result (or error).
     * `{:tool_ui, %{tool_call_id:, kind:, payload:}}` — structured UI
@@ -34,6 +38,7 @@ defmodule ExAthena.Loop.Events do
 
   @type t ::
           {:content, String.t()}
+          | {:thinking, String.t()}
           | {:tool_call, ToolCall.t()}
           | {:tool_result, ToolResult.t()}
           | {:tool_ui,

--- a/lib/ex_athena/web/components/layouts.ex
+++ b/lib/ex_athena/web/components/layouts.ex
@@ -158,6 +158,67 @@ defmodule ExAthena.Web.Layouts do
                   this.pushEvent("modal_path_change", {path: value})
                 })
               }
+            },
+
+            // Resizable split-pane divider inside .chat-main. Mouse-drag on
+            // .chat-divider updates --left-w / --right-w CSS variables on
+            // the .chat-main element (this.el). Ratio persists in
+            // localStorage. Clamped 20%–80%.
+            SplitResize: {
+              mounted() {
+                const STORAGE_KEY = "ex_athena.split_ratio"
+                const MIN = 0.20, MAX = 0.80
+                const apply = (ratio) => {
+                  const r = Math.max(MIN, Math.min(MAX, ratio))
+                  this.el.style.setProperty("--left-w", `${r}fr`)
+                  this.el.style.setProperty("--right-w", `${1 - r}fr`)
+                  return r
+                }
+
+                const stored = parseFloat(localStorage.getItem(STORAGE_KEY))
+                if (!isNaN(stored)) apply(stored)
+
+                const divider = this.el.querySelector("#chat-divider")
+                if (!divider) return
+
+                divider.addEventListener("mousedown", (e) => {
+                  e.preventDefault()
+                  divider.classList.add("dragging")
+                  document.body.style.cursor = "col-resize"
+                  document.body.style.userSelect = "none"
+
+                  const onMove = (ev) => {
+                    const rect = this.el.getBoundingClientRect()
+                    const ratio = (ev.clientX - rect.left) / rect.width
+                    apply(ratio)
+                  }
+
+                  const onUp = () => {
+                    divider.classList.remove("dragging")
+                    document.body.style.cursor = ""
+                    document.body.style.userSelect = ""
+                    const left = parseFloat(getComputedStyle(this.el).getPropertyValue("--left-w"))
+                    if (!isNaN(left)) localStorage.setItem(STORAGE_KEY, String(left))
+                    document.removeEventListener("mousemove", onMove)
+                    document.removeEventListener("mouseup", onUp)
+                  }
+
+                  document.addEventListener("mousemove", onMove)
+                  document.addEventListener("mouseup", onUp)
+                })
+
+                // Left pane can request the right pane to scroll to a tool
+                // entry by tool_call_id (e.g. clicking a one-liner).
+                this.handleEvent("focus-detail", ({tool_call_id}) => {
+                  const node = this.el.querySelector(
+                    `.detail-entry[data-tool-call-id="${tool_call_id}"]`
+                  )
+                  if (!node) return
+                  node.scrollIntoView({behavior: "smooth", block: "center"})
+                  node.classList.add("detail-entry--focused")
+                  setTimeout(() => node.classList.remove("detail-entry--focused"), 1200)
+                })
+              }
             }
           }
 

--- a/lib/ex_athena/web/live/chat_live.ex
+++ b/lib/ex_athena/web/live/chat_live.ex
@@ -64,6 +64,14 @@ defmodule ExAthena.Web.Live.ChatLive do
         # Stored tool UI payloads (diff/process/file) keyed by tool_call_id
         tool_uis: %{},
         expanded_uis: MapSet.new(),
+        # Right-pane details stream: a chronological, append-only log of every
+        # event in the session. Stored in REVERSE order (head = newest) for
+        # O(1) prepends and O(1) "extend the last entry" merging during
+        # streaming. `Enum.reverse/1` once at render time.
+        details_stream: [],
+        # The assistant message id that streaming events are currently
+        # attributed to. Set in start_agent_run; cleared in :athena_done.
+        pending_assistant_msg_id: nil,
         # Loading / status / errors
         page_loading: !connected?(socket),
         status: nil,
@@ -141,6 +149,8 @@ defmodule ExAthena.Web.Live.ChatLive do
          ex_messages: [],
          tool_uis: %{},
          expanded_uis: MapSet.new(),
+         details_stream: [],
+         pending_assistant_msg_id: nil,
          status: nil,
          error: nil,
          show_modal: false,
@@ -168,6 +178,8 @@ defmodule ExAthena.Web.Live.ChatLive do
          ex_messages: [],
          tool_uis: %{},
          expanded_uis: MapSet.new(),
+         details_stream: [],
+         pending_assistant_msg_id: nil,
          status: nil,
          error: nil,
          sessions: sessions,
@@ -194,6 +206,8 @@ defmodule ExAthena.Web.Live.ChatLive do
        ex_messages: [],
        tool_uis: %{},
        expanded_uis: MapSet.new(),
+       details_stream: [],
+       pending_assistant_msg_id: nil,
        status: nil,
        error: nil,
        stream_text: "",
@@ -247,6 +261,8 @@ defmodule ExAthena.Web.Live.ChatLive do
        ex_messages: [],
        tool_uis: %{},
        expanded_uis: MapSet.new(),
+       details_stream: [],
+       pending_assistant_msg_id: nil,
        status: nil,
        error: nil
      )}
@@ -257,6 +273,14 @@ defmodule ExAthena.Web.Live.ChatLive do
       {:ok, data} ->
         cwd = Map.get(data, :cwd, socket.assigns.cwd)
         if cwd, do: Sessions.touch_recent(cwd)
+
+        tool_uis = Map.get(data, :tool_uis, %{})
+
+        details_stream =
+          case Map.get(data, :details_stream) do
+            nil -> hydrate_details_stream(data.display_messages, tool_uis)
+            existing -> existing
+          end
 
         {:noreply,
          assign(socket,
@@ -269,8 +293,10 @@ defmodule ExAthena.Web.Live.ChatLive do
            mode: data.mode,
            messages: data.display_messages,
            ex_messages: data.ex_messages,
-           tool_uis: Map.get(data, :tool_uis, %{}),
+           tool_uis: tool_uis,
            expanded_uis: MapSet.new(),
+           details_stream: details_stream,
+           pending_assistant_msg_id: nil,
            status: nil,
            error: nil,
            show_sessions: false
@@ -307,6 +333,7 @@ defmodule ExAthena.Web.Live.ChatLive do
 
         new_id = unique_id()
         title = derive_title(forked_messages)
+        details_stream = hydrate_details_stream(forked_messages, socket.assigns.tool_uis)
 
         {:noreply,
          assign(socket,
@@ -315,6 +342,8 @@ defmodule ExAthena.Web.Live.ChatLive do
            session_created_at: DateTime.utc_now(),
            messages: forked_messages,
            ex_messages: ex_messages,
+           details_stream: details_stream,
+           pending_assistant_msg_id: nil,
            status: nil,
            error: nil,
            stream_text: "",
@@ -337,6 +366,10 @@ defmodule ExAthena.Web.Live.ChatLive do
     {:noreply, assign(socket, expanded_uis: expanded)}
   end
 
+  def handle_event("focus_detail", %{"id" => tool_call_id}, socket) do
+    {:noreply, push_event(socket, "focus-detail", %{tool_call_id: tool_call_id})}
+  end
+
   # ---------------------------------------------------------------------------
   # Internal messages
   # ---------------------------------------------------------------------------
@@ -357,40 +390,119 @@ defmodule ExAthena.Web.Live.ChatLive do
   end
 
   def handle_info({:athena, {:content, text}}, socket) do
-    {:noreply, update(socket, :stream_text, &(&1 <> text))}
+    msg_id = socket.assigns.pending_assistant_msg_id
+
+    {:noreply,
+     socket
+     |> update(:stream_text, &(&1 <> text))
+     |> update(:details_stream, &extend_or_prepend_text(&1, :assistant_text, msg_id, text))}
+  end
+
+  def handle_info({:athena, {:thinking, text}}, socket) do
+    msg_id = socket.assigns.pending_assistant_msg_id
+
+    {:noreply,
+     update(socket, :details_stream, &extend_or_prepend_text(&1, :thinking, msg_id, text))}
   end
 
   def handle_info({:athena, {:tool_call, tc}}, socket) do
     event = %{type: :call, id: tc.id, name: tc.name, arguments: tc.arguments}
     action = action_label(tc.name, tc.arguments)
+    msg_id = socket.assigns.pending_assistant_msg_id
+
+    detail =
+      new_detail(:tool_call, msg_id, %{
+        tool_call_id: tc.id,
+        name: tc.name,
+        arguments: tc.arguments
+      })
 
     {:noreply,
      socket
      |> update(:stream_events, &(&1 ++ [event]))
+     |> update(:details_stream, &[detail | &1])
      |> assign(current_action: action)}
   end
 
   def handle_info({:athena, {:tool_result, tr}}, socket) do
+    content = to_string(tr.content)
+    is_error = tr.is_error || false
+
     event = %{
       type: :result,
       tool_call_id: tr.tool_call_id,
-      content: to_string(tr.content),
-      is_error: tr.is_error || false
+      content: content,
+      is_error: is_error
     }
+
+    msg_id = socket.assigns.pending_assistant_msg_id
+
+    detail =
+      new_detail(:tool_result, msg_id, %{
+        tool_call_id: tr.tool_call_id,
+        content: content,
+        is_error: is_error
+      })
 
     {:noreply,
      socket
      |> update(:stream_events, &(&1 ++ [event]))
+     |> update(:details_stream, &[detail | &1])
      |> assign(current_action: nil)}
   end
 
-  def handle_info({:athena, {:tool_ui, %{tool_call_id: id, kind: kind, payload: payload}}}, socket) do
+  def handle_info(
+        {:athena, {:tool_ui, %{tool_call_id: id, kind: kind, payload: payload}}},
+        socket
+      ) do
     ui_entry = build_ui_entry(kind, payload)
-    {:noreply, update(socket, :stream_tool_ui, &Map.put(&1, id, ui_entry))}
+    msg_id = socket.assigns.pending_assistant_msg_id
+    detail = new_detail(:tool_ui, msg_id, %{tool_call_id: id, ui: ui_entry})
+
+    {:noreply,
+     socket
+     |> update(:stream_tool_ui, &Map.put(&1, id, ui_entry))
+     |> update(:details_stream, &[detail | &1])}
+  end
+
+  def handle_info({:athena, {:iteration, n}}, socket) do
+    detail = new_detail(:iteration, socket.assigns.pending_assistant_msg_id, %{n: n})
+    {:noreply, update(socket, :details_stream, &[detail | &1])}
+  end
+
+  def handle_info({:athena, {:compaction, data}}, socket) do
+    detail = new_detail(:compaction, socket.assigns.pending_assistant_msg_id, data)
+    {:noreply, update(socket, :details_stream, &[detail | &1])}
+  end
+
+  def handle_info({:athena, {:subagent_spawn, data}}, socket) do
+    detail = new_detail(:subagent_spawn, socket.assigns.pending_assistant_msg_id, data)
+    {:noreply, update(socket, :details_stream, &[detail | &1])}
+  end
+
+  def handle_info({:athena, {:subagent_result, data}}, socket) do
+    detail = new_detail(:subagent_result, socket.assigns.pending_assistant_msg_id, data)
+    {:noreply, update(socket, :details_stream, &[detail | &1])}
+  end
+
+  def handle_info({:athena, {:structured_retry, data}}, socket) do
+    detail = new_detail(:structured_retry, socket.assigns.pending_assistant_msg_id, data)
+    {:noreply, update(socket, :details_stream, &[detail | &1])}
+  end
+
+  def handle_info({:athena, {:usage, usage}}, socket) do
+    detail = new_detail(:usage, socket.assigns.pending_assistant_msg_id, %{usage: usage})
+    {:noreply, update(socket, :details_stream, &[detail | &1])}
   end
 
   def handle_info({:athena, {:error, reason}}, socket) do
-    {:noreply, assign(socket, error: inspect(reason))}
+    detail =
+      new_detail(:error, socket.assigns.pending_assistant_msg_id, %{reason: inspect(reason)})
+
+    {:noreply,
+     socket
+     |> assign(error: inspect(reason))
+     |> update(:details_stream, &[detail | &1])}
   end
 
   def handle_info({:athena, _other}, socket), do: {:noreply, socket}
@@ -413,8 +525,10 @@ defmodule ExAthena.Web.Live.ChatLive do
 
     new_tool_uis = Map.merge(socket.assigns.tool_uis, socket.assigns.stream_tool_ui)
 
+    assistant_msg_id = socket.assigns.pending_assistant_msg_id || unique_id()
+
     assistant_msg = %{
-      id: unique_id(),
+      id: assistant_msg_id,
       role: :assistant,
       text: socket.assigns.stream_text,
       tool_events: socket.assigns.stream_events,
@@ -435,6 +549,7 @@ defmodule ExAthena.Web.Live.ChatLive do
         stream_events: [],
         stream_tool_ui: %{},
         current_action: nil,
+        pending_assistant_msg_id: nil,
         status: status,
         error: nil,
         session_title: title
@@ -650,7 +765,7 @@ defmodule ExAthena.Web.Live.ChatLive do
       </aside>
 
       <%!-- Main chat --%>
-      <main class="chat-main">
+      <main class="chat-main" id="chat-main" phx-hook="SplitResize">
         <div class="messages" id="messages" phx-hook="ScrollToBottom">
           <%= if @messages == [] and not @streaming do %>
             <div class="empty-state">
@@ -699,6 +814,12 @@ defmodule ExAthena.Web.Live.ChatLive do
           <%= if @error do %>
             <div class="msg-error">⚠ {@error}</div>
           <% end %>
+        </div>
+
+        <div class="chat-divider" id="chat-divider" aria-label="Resize panes" role="separator"></div>
+
+        <div class="details-pane" id="details-pane" phx-hook="ScrollToBottom">
+          <.details_pane stream={@details_stream} max_diff_lines={@max_diff_lines} />
         </div>
 
         <div class="input-bar">
@@ -796,33 +917,32 @@ defmodule ExAthena.Web.Live.ChatLive do
 
   defp tool_events(assigns) do
     calls = Enum.filter(assigns.events, &(&1.type == :call))
-    results_by_id = assigns.events |> Enum.filter(&(&1.type == :result)) |> Map.new(&{&1.tool_call_id, &1})
+
+    results_by_id =
+      assigns.events |> Enum.filter(&(&1.type == :result)) |> Map.new(&{&1.tool_call_id, &1})
+
     assigns = assign(assigns, calls: calls, results_by_id: results_by_id)
 
     ~H"""
-    <div class="tool-events">
-      <div :for={call <- @calls} class="tool-call">
-        <div class="tool-call-header">
-          <span class="tool-arrow">→</span>
-          <span class="tool-name">{call.name}</span>
-          <span class="tool-args">{preview_args(call.arguments)}</span>
-        </div>
-
+    <div class="tool-events tool-events--compact">
+      <button
+        :for={call <- @calls}
+        type="button"
+        class="tool-one-liner"
+        phx-click="focus_detail"
+        phx-value-id={call.id}
+        title="Show details on the right"
+      >
+        <span class="tool-arrow">→</span>
+        <span class="tool-name">{call.name}</span>
+        <span class="tool-args">{preview_args(call.arguments)}</span>
         <%= if result = Map.get(@results_by_id, call.id) do %>
-          <div class={"tool-result#{if result.is_error, do: " tool-result--error", else: ""}"}>
+          <span class={"tool-result-inline#{if result.is_error, do: " tool-result-inline--error", else: ""}"}>
             <span class="tool-arrow">{if result.is_error, do: "✗", else: "←"}</span>
             <span class="tool-result-content">{summarize(result.content)}</span>
-            <%= if Map.has_key?(@tool_uis, call.id) do %>
-              <button class="btn-view-ui" phx-click="toggle_ui" phx-value-id={call.id}>
-                {if MapSet.member?(@expanded_uis, call.id), do: "▲ hide", else: "▼ view"}
-              </button>
-            <% end %>
-          </div>
-          <%= if MapSet.member?(@expanded_uis, call.id) and Map.has_key?(@tool_uis, call.id) do %>
-            <.tool_ui_panel ui={Map.get(@tool_uis, call.id)} />
-          <% end %>
+          </span>
         <% end %>
-      </div>
+      </button>
     </div>
     """
   end
@@ -872,6 +992,209 @@ defmodule ExAthena.Web.Live.ChatLive do
   defp tool_ui_panel(assigns), do: ~H""
 
   # ---------------------------------------------------------------------------
+  # Right-pane: details_stream renderer
+  # ---------------------------------------------------------------------------
+
+  defp details_pane(%{stream: []} = assigns) do
+    ~H"""
+    <div class="details-empty">
+      <div class="details-empty-title">Activity</div>
+      <div class="details-empty-sub">Tool calls, results, and thinking will stream here.</div>
+    </div>
+    """
+  end
+
+  defp details_pane(assigns) do
+    assigns = assign(assigns, :entries, Enum.reverse(assigns.stream))
+
+    ~H"""
+    <div class="details-list" id="details-list">
+      <.detail_entry :for={e <- @entries} entry={e} />
+    </div>
+    """
+  end
+
+  defp detail_entry(%{entry: %{type: :user_text} = e} = assigns) do
+    assigns = assign(assigns, :e, e)
+
+    ~H"""
+    <div class="detail-entry detail-entry--user" id={"detail-#{@e.id}"}>
+      <div class="detail-label">you</div>
+      <div class="detail-text">{@e.payload.text}</div>
+    </div>
+    """
+  end
+
+  defp detail_entry(%{entry: %{type: :assistant_text} = e} = assigns) do
+    assigns = assign(assigns, :e, e)
+
+    ~H"""
+    <div class="detail-entry detail-entry--assistant" id={"detail-#{@e.id}"}>
+      <div class="detail-label">assistant</div>
+      <div class="detail-text" style="white-space: pre-wrap">{@e.payload.text}</div>
+    </div>
+    """
+  end
+
+  defp detail_entry(%{entry: %{type: :thinking} = e} = assigns) do
+    assigns = assign(assigns, :e, e)
+
+    ~H"""
+    <div class="detail-entry detail-entry--thinking" id={"detail-#{@e.id}"}>
+      <div class="detail-label">thinking</div>
+      <div class="detail-text" style="white-space: pre-wrap">{@e.payload.text}</div>
+    </div>
+    """
+  end
+
+  defp detail_entry(%{entry: %{type: :tool_call} = e} = assigns) do
+    assigns =
+      assign(assigns,
+        e: e,
+        args_pretty: format_args(e.payload.arguments)
+      )
+
+    ~H"""
+    <div
+      class="detail-entry detail-entry--tool-call"
+      id={"detail-#{@e.id}"}
+      data-tool-call-id={@e.payload.tool_call_id}
+    >
+      <div class="detail-label">
+        <span class="tool-arrow">→</span> {@e.payload.name}
+      </div>
+      <pre class="detail-pre">{@args_pretty}</pre>
+    </div>
+    """
+  end
+
+  defp detail_entry(%{entry: %{type: :tool_result} = e} = assigns) do
+    assigns = assign(assigns, :e, e)
+
+    ~H"""
+    <div
+      class={"detail-entry detail-entry--tool-result#{if @e.payload.is_error, do: " detail-entry--error", else: ""}"}
+      id={"detail-#{@e.id}"}
+      data-tool-call-id={@e.payload.tool_call_id}
+    >
+      <div class="detail-label">
+        <span class="tool-arrow">{if @e.payload.is_error, do: "✗", else: "←"}</span>
+        {if @e.payload.is_error, do: "error", else: "result"}
+      </div>
+      <pre class="detail-pre">{@e.payload.content}</pre>
+    </div>
+    """
+  end
+
+  defp detail_entry(%{entry: %{type: :tool_ui} = e} = assigns) do
+    assigns = assign(assigns, :e, e)
+
+    ~H"""
+    <div
+      class="detail-entry detail-entry--tool-ui"
+      id={"detail-#{@e.id}"}
+      data-tool-call-id={@e.payload.tool_call_id}
+    >
+      <.tool_ui_panel ui={@e.payload.ui} />
+    </div>
+    """
+  end
+
+  defp detail_entry(%{entry: %{type: :iteration} = e} = assigns) do
+    assigns = assign(assigns, :e, e)
+
+    ~H"""
+    <div class="detail-entry detail-entry--iteration" id={"detail-#{@e.id}"}>
+      <span class="detail-divider-line"></span>
+      <span class="detail-divider-label">iteration {@e.payload.n}</span>
+      <span class="detail-divider-line"></span>
+    </div>
+    """
+  end
+
+  defp detail_entry(%{entry: %{type: :compaction} = e} = assigns) do
+    assigns = assign(assigns, :e, e)
+
+    ~H"""
+    <div class="detail-entry detail-entry--meta" id={"detail-#{@e.id}"}>
+      <div class="detail-label">compaction</div>
+      <div class="detail-text">
+        {Map.get(@e.payload, :before)} → {Map.get(@e.payload, :after)} tokens
+        <%= if reason = Map.get(@e.payload, :reason) do %>
+          · {inspect(reason)}
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+
+  defp detail_entry(%{entry: %{type: :subagent_spawn} = e} = assigns) do
+    assigns = assign(assigns, :e, e)
+
+    ~H"""
+    <div class="detail-entry detail-entry--subagent" id={"detail-#{@e.id}"}>
+      <div class="detail-label">subagent spawn · {inspect(Map.get(@e.payload, :id))}</div>
+      <pre class="detail-pre">{Map.get(@e.payload, :prompt, "")}</pre>
+    </div>
+    """
+  end
+
+  defp detail_entry(%{entry: %{type: :subagent_result} = e} = assigns) do
+    assigns = assign(assigns, :e, e)
+
+    ~H"""
+    <div class="detail-entry detail-entry--subagent" id={"detail-#{@e.id}"}>
+      <div class="detail-label">subagent result · {inspect(Map.get(@e.payload, :id))}</div>
+      <pre class="detail-pre">{Map.get(@e.payload, :text, "")}</pre>
+    </div>
+    """
+  end
+
+  defp detail_entry(%{entry: %{type: :structured_retry} = e} = assigns) do
+    assigns = assign(assigns, :e, e)
+
+    ~H"""
+    <div class="detail-entry detail-entry--meta" id={"detail-#{@e.id}"}>
+      <div class="detail-label">structured-retry attempt {Map.get(@e.payload, :attempt)}</div>
+      <pre class="detail-pre">{inspect(Map.get(@e.payload, :error))}</pre>
+    </div>
+    """
+  end
+
+  defp detail_entry(%{entry: %{type: :usage} = e} = assigns) do
+    assigns = assign(assigns, :e, e)
+
+    ~H"""
+    <div class="detail-entry detail-entry--meta" id={"detail-#{@e.id}"}>
+      <div class="detail-label">usage</div>
+      <pre class="detail-pre">{inspect(Map.get(@e.payload, :usage))}</pre>
+    </div>
+    """
+  end
+
+  defp detail_entry(%{entry: %{type: :error} = e} = assigns) do
+    assigns = assign(assigns, :e, e)
+
+    ~H"""
+    <div class="detail-entry detail-entry--error" id={"detail-#{@e.id}"}>
+      <div class="detail-label">⚠ error</div>
+      <div class="detail-text">{Map.get(@e.payload, :reason)}</div>
+    </div>
+    """
+  end
+
+  defp detail_entry(assigns), do: ~H""
+
+  defp format_args(args) when is_map(args) do
+    case Jason.encode(args, pretty: true) do
+      {:ok, json} -> json
+      _ -> inspect(args, pretty: true, limit: :infinity)
+    end
+  end
+
+  defp format_args(other), do: inspect(other, pretty: true)
+
+  # ---------------------------------------------------------------------------
   # Private helpers
   # ---------------------------------------------------------------------------
 
@@ -882,6 +1205,7 @@ defmodule ExAthena.Web.Live.ChatLive do
     mode = socket.assigns.mode
 
     user_msg = %{id: unique_id(), role: :user, text: text, tool_events: [], status: nil}
+    assistant_msg_id = unique_id()
     new_ex_msg = Messages.user(text)
     ex_messages = socket.assigns.ex_messages ++ [new_ex_msg]
 
@@ -908,6 +1232,8 @@ defmodule ExAthena.Web.Live.ChatLive do
       end
     end)
 
+    user_detail = new_detail(:user_text, user_msg.id, %{text: text})
+
     {:noreply,
      assign(socket,
        messages: socket.assigns.messages ++ [user_msg],
@@ -917,6 +1243,8 @@ defmodule ExAthena.Web.Live.ChatLive do
        stream_events: [],
        stream_tool_ui: %{},
        current_action: nil,
+       pending_assistant_msg_id: assistant_msg_id,
+       details_stream: [user_detail | socket.assigns.details_stream],
        error: nil
      )}
   end
@@ -935,9 +1263,105 @@ defmodule ExAthena.Web.Live.ChatLive do
       updated_at: DateTime.utc_now(),
       display_messages: a.messages,
       ex_messages: a.ex_messages,
-      tool_uis: a.tool_uis
+      tool_uis: a.tool_uis,
+      details_stream: a.details_stream
     })
   end
+
+  # ---------------------------------------------------------------------------
+  # Details-stream helpers
+  # ---------------------------------------------------------------------------
+
+  defp new_detail(type, message_id, payload) do
+    %{
+      id: unique_id(),
+      type: type,
+      message_id: message_id,
+      payload: payload
+    }
+  end
+
+  # Stream is stored newest-first. If the head matches the same type and
+  # message_id (e.g. successive :content deltas during one turn), extend the
+  # existing entry's text instead of creating a new one.
+  defp extend_or_prepend_text(stream, _type, _msg_id, ""), do: stream
+
+  defp extend_or_prepend_text(
+         [%{type: t, message_id: m, payload: %{text: existing} = pl} = head | rest],
+         t,
+         m,
+         text
+       ) do
+    [%{head | payload: %{pl | text: existing <> text}} | rest]
+  end
+
+  defp extend_or_prepend_text(stream, type, msg_id, text) do
+    [new_detail(type, msg_id, %{text: text}) | stream]
+  end
+
+  # Rebuild details_stream from legacy persisted state (display messages +
+  # tool_uis). Used when loading a session that pre-dates details_stream
+  # persistence. Returns newest-first.
+  defp hydrate_details_stream(messages, tool_uis) when is_list(messages) do
+    messages
+    |> Enum.flat_map(&message_to_details(&1, tool_uis))
+    |> Enum.reverse()
+  end
+
+  defp hydrate_details_stream(_, _), do: []
+
+  defp message_to_details(%{role: :user, id: id, text: text}, _tool_uis) do
+    [new_detail(:user_text, id, %{text: text})]
+  end
+
+  defp message_to_details(%{role: :assistant, id: id, text: text, tool_events: events}, tool_uis) do
+    calls = Enum.filter(events, &(&1.type == :call))
+
+    results_by_id =
+      events |> Enum.filter(&(&1.type == :result)) |> Map.new(&{&1.tool_call_id, &1})
+
+    tool_details =
+      Enum.flat_map(calls, fn call ->
+        call_detail =
+          new_detail(:tool_call, id, %{
+            tool_call_id: call.id,
+            name: call.name,
+            arguments: call.arguments
+          })
+
+        result_detail =
+          case Map.get(results_by_id, call.id) do
+            nil ->
+              []
+
+            r ->
+              [
+                new_detail(:tool_result, id, %{
+                  tool_call_id: call.id,
+                  content: r.content,
+                  is_error: r.is_error
+                })
+              ]
+          end
+
+        ui_detail =
+          case Map.get(tool_uis, call.id) do
+            nil -> []
+            ui -> [new_detail(:tool_ui, id, %{tool_call_id: call.id, ui: ui})]
+          end
+
+        [call_detail] ++ result_detail ++ ui_detail
+      end)
+
+    text_detail =
+      if text && text != "",
+        do: [new_detail(:assistant_text, id, %{text: text})],
+        else: []
+
+    tool_details ++ text_detail
+  end
+
+  defp message_to_details(_, _), do: []
 
   defp build_ui_entry(:diff, %{path: path, before: before, after: after_text} = _payload) do
     before_lines = String.split(before, "\n")
@@ -1044,6 +1468,7 @@ defmodule ExAthena.Web.Live.ChatLive do
   defp fetch_models("llamacpp") do
     base_url = Application.get_env(:ex_athena, :llamacpp, [])[:base_url]
     opts = if base_url, do: [base_url: base_url], else: []
+
     case LlamaCpp.list_models(opts) do
       {:ok, models} -> models
       _ -> []
@@ -1053,6 +1478,7 @@ defmodule ExAthena.Web.Live.ChatLive do
   defp fetch_models("ollama") do
     base_url = Application.get_env(:ex_athena, :ollama, [])[:base_url]
     opts = if base_url, do: [base_url: base_url], else: []
+
     case Ollama.list_models(opts) do
       {:ok, models} -> models
       _ -> []
@@ -1145,8 +1571,12 @@ defmodule ExAthena.Web.Live.ChatLive do
         |> Enum.filter(&File.dir?(Path.join(dir, &1)))
         |> Enum.sort()
         |> case do
-          [] -> path
-          [single] -> Path.join(dir, single) <> "/"
+          [] ->
+            path
+
+          [single] ->
+            Path.join(dir, single) <> "/"
+
           many ->
             cp = common_prefix(many)
             filled = if cp == "" or cp == prefix, do: hd(many), else: cp

--- a/priv/web/static/app.css
+++ b/priv/web/static/app.css
@@ -202,10 +202,14 @@ html, body { height: 100%; background: var(--bg); color: var(--text); font-famil
 
 /* ── Chat main ────────────────────────────────────────────────────────────── */
 
+/* Two-pane layout: messages | divider | details. Input bar spans all three.
+   Column widths are driven by CSS custom properties set by the SplitResize
+   hook (clamped 20%–80%); defaults split the available space 1:1. */
 .chat-main {
   flex: 1;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-rows: 1fr auto;
+  grid-template-columns: var(--left-w, 1fr) 6px var(--right-w, 1fr);
   overflow: hidden;
   min-width: 0;
 }
@@ -213,13 +217,15 @@ html, body { height: 100%; background: var(--bg); color: var(--text); font-famil
 /* ── Messages ─────────────────────────────────────────────────────────────── */
 
 .messages {
-  flex: 1;
+  grid-column: 1;
+  grid-row: 1;
   overflow-y: auto;
   padding: 24px;
   display: flex;
   flex-direction: column;
   gap: 0;
   scroll-behavior: smooth;
+  min-width: 0;
 }
 
 /* Empty state */
@@ -379,6 +385,8 @@ html, body { height: 100%; background: var(--bg); color: var(--text); font-famil
 /* ── Input bar ────────────────────────────────────────────────────────────── */
 
 .input-bar {
+  grid-column: 1 / span 3;
+  grid-row: 2;
   border-top: 1px solid var(--border);
   padding: 16px 24px;
   background: var(--bg);
@@ -1134,3 +1142,199 @@ html, body { height: 100%; background: var(--bg); color: var(--text); font-famil
   font-family: var(--font-mono);
   margin-top: 8px;
 }
+
+/* ── Split-pane divider ───────────────────────────────────────────────────── */
+
+.chat-divider {
+  grid-column: 2;
+  grid-row: 1;
+  background: var(--border);
+  cursor: col-resize;
+  position: relative;
+  transition: background 0.15s;
+}
+
+.chat-divider:hover,
+.chat-divider.dragging { background: var(--accent); }
+
+.chat-divider::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -3px;
+  right: -3px;
+}
+
+/* ── Details pane ─────────────────────────────────────────────────────────── */
+
+.details-pane {
+  grid-column: 3;
+  grid-row: 1;
+  overflow-y: auto;
+  background: var(--bg);
+  scroll-behavior: smooth;
+  min-width: 0;
+}
+
+.details-empty {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 24px;
+  color: var(--muted);
+  text-align: center;
+  user-select: none;
+}
+
+.details-empty-title { font-family: var(--font-mono); font-size: 13px; color: var(--text); }
+.details-empty-sub   { font-family: var(--font-mono); font-size: 11px; }
+
+.details-list {
+  display: flex;
+  flex-direction: column;
+  padding: 16px 20px;
+  gap: 12px;
+}
+
+.detail-entry {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.detail-entry:last-child { border-bottom: none; }
+
+.detail-label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 10px;
+  color: var(--muted);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.detail-text {
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  line-height: 1.6;
+  word-wrap: break-word;
+}
+
+.detail-pre {
+  background: var(--sidebar-bg);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  padding: 8px 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--text);
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.detail-entry--user .detail-label { color: var(--user-accent); }
+
+.detail-entry--assistant .detail-label { color: var(--accent); }
+
+.detail-entry--thinking .detail-label { color: #c084fc; }
+.detail-entry--thinking .detail-text { color: var(--muted); font-style: italic; }
+
+.detail-entry--tool-call .detail-label,
+.detail-entry--tool-result .detail-label { color: var(--accent); }
+
+.detail-entry--error .detail-label,
+.detail-entry--error .detail-text { color: var(--error-text); }
+
+.detail-entry--iteration {
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
+  border-bottom: none;
+  padding: 14px 0 4px;
+}
+
+.detail-divider-line {
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+
+.detail-divider-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.detail-entry--meta .detail-label,
+.detail-entry--subagent .detail-label { color: var(--muted); }
+
+.detail-entry--focused {
+  background: var(--accent-dim);
+  outline: 1px solid var(--accent);
+}
+
+/* ── Compact tool-events (left pane one-liners) ───────────────────────────── */
+
+.tool-events--compact { gap: 4px; }
+
+.tool-one-liner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  background: var(--tool-bg);
+  border: 1px solid var(--tool-border);
+  border-radius: var(--radius);
+  padding: 6px 10px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-align: left;
+  color: var(--text);
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+  overflow: hidden;
+}
+
+.tool-one-liner:hover {
+  border-color: var(--accent);
+  background: rgba(52, 211, 153, 0.06);
+}
+
+.tool-one-liner .tool-args,
+.tool-one-liner .tool-result-content {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.tool-result-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--muted);
+  margin-left: auto;
+  padding-left: 12px;
+  border-left: 1px solid var(--tool-border);
+  min-width: 0;
+  overflow: hidden;
+}
+
+.tool-result-inline--error { color: var(--error-text); }
+.tool-result-inline--error .tool-arrow { color: var(--error-text); }

--- a/test/ex_athena/chat/tui/state_test.exs
+++ b/test/ex_athena/chat/tui/state_test.exs
@@ -333,4 +333,78 @@ defmodule ExAthena.Chat.Tui.StateTest do
       assert state.events == []
     end
   end
+
+  describe "details pane" do
+    test ":tool_call appends a header + full pretty-printed args to details" do
+      tc = %ToolCall{id: "1", name: "Read", arguments: %{"path" => "lib/foo.ex"}}
+
+      state =
+        Session.new()
+        |> State.new()
+        |> State.append_loop_event({:tool_call, tc})
+
+      assert [{:detail_header, header} | rows] = state.details
+      assert header =~ "Read"
+      # The pretty-printed JSON spans multiple rows; each row is one entry.
+      assert Enum.any?(rows, fn {kind, line} -> kind == :tool_call and line =~ "path" end)
+    end
+
+    test ":tool_result appends the FULL content (not summarized) to details" do
+      tr = %ToolResult{
+        tool_call_id: "1",
+        content: "line one\nline two\nline three",
+        is_error: false
+      }
+
+      state =
+        Session.new()
+        |> State.new()
+        |> State.append_loop_event({:tool_result, tr})
+
+      texts = for {_, text} <- state.details, do: text
+      assert "line one" in texts
+      assert "line two" in texts
+      assert "line three" in texts
+    end
+
+    test ":iteration adds a header row to details but no row to events" do
+      state =
+        Session.new()
+        |> State.new()
+        |> State.append_loop_event({:iteration, 7})
+
+      assert state.events == []
+      assert [{:detail_header, "iteration 7"}] = state.details
+    end
+
+    test ":thinking deltas accumulate and flush into a thinking row in details" do
+      state =
+        Session.new()
+        |> State.new()
+        |> State.append_loop_event({:thinking, "let me "})
+        |> State.append_loop_event({:thinking, "think…"})
+
+      # Until flush_stream/1, the buffer holds the text.
+      assert state.details_thinking_buffer == "let me think…"
+      assert state.details == []
+
+      state = State.flush_stream(state)
+      assert state.details_thinking_buffer == ""
+      assert [{:thinking, "let me think…"}] = state.details
+    end
+
+    test "clear_session/1 also resets details state" do
+      state =
+        Session.new()
+        |> State.new()
+        |> State.append_loop_event({:iteration, 1})
+        |> State.append_loop_event({:thinking, "hmm"})
+        |> State.clear_session()
+
+      assert state.details == []
+      assert state.details_stream_buffer == ""
+      assert state.details_thinking_buffer == ""
+      assert state.details_scroll_offset == 0
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- **TUI (`mix athena.chat`)**: body now splits 50/50 — existing one-line event feed on the left, new bordered **details** pane on the right showing full tool args, full tool results, tool UI payloads (diff/process/file), thinking deltas, iteration headers, compactions, sub-agent activity, errors, and usage.
- **Web LiveView (`/`)**: CSS-grid two-pane layout — left = conversation with tool usage collapsed to clickable one-liners; right = chronological details stream across the whole session, with a **draggable divider** (ratio persists in localStorage, clamped 20–80%). Clicking a one-liner scrolls/flashes the matching entry on the right.
- New `{:thinking, text}` event in `ExAthena.Loop.Events` — UI is ready for provider-emitted reasoning content (provider extraction is a follow-up).
- `/help` fix: it was sending the entire help text as a single `:info` row, but rows render at fixed height 1, so only the first line was visible. Now splits into per-line `:info` events and the text covers slash commands + keyboard shortcuts + CLI flags.
- Sessions persist `details_stream`; legacy sessions hydrate by walking `display_messages` + `tool_uis`.

## Implementation details
- `Tui.State`: new `details`, `details_scroll_offset`, `details_stream_buffer`, `details_thinking_buffer`. `append_loop_event/2` fans out to both panes via `append_detail_header` / `append_detail_lines`. `flush_stream/1` materializes both buffers.
- `Tui.View`: second `Layout.split` on the body rect; right pane wrapped in a rounded `Block` titled "details".
- `ChatLive`: `details_stream` socket assign (newest-first, O(1) prepends; reversed once at render). New `handle_info` clauses for previously-dropped events. `details_pane/1` component reuses `tool_ui_panel/1` and `MarkdownRender`.
- `SplitResize` JS hook in `layouts.ex`: drag-to-resize + `focus-detail` event to scroll the right pane to a tool entry.

## Test plan
- [x] `mix compile --force` clean
- [x] `mix format` clean
- [x] `mix test` — 735 tests, 1 pre-existing unrelated failure (`named_subagent_test:93` — flaky transcript assertion on main)
- [x] 5 new tests in `state_test.exs` cover tool_call full args, tool_result full content, iteration headers, thinking flush, and `clear_session` reset
- [ ] Manual: `mix athena.chat` shows the bordered details pane on the right with full tool output
- [ ] Manual: `mix phx.server` → `/` shows split layout; divider drags and persists