### PR TITLE
feat(tui): wrap text, /details toggle, extract <think> blocks

### DIFF
--- a/lib/ex_athena/chat/commands.ex
+++ b/lib/ex_athena/chat/commands.ex
@@ -29,6 +29,7 @@ defmodule ExAthena.Chat.Commands do
     "tools" => :tools,
     "clear" => :clear,
     "expand" => :expand,
+    "details" => :details,
     "help" => :help,
     "?" => :help
   }
@@ -72,6 +73,8 @@ defmodule ExAthena.Chat.Commands do
       /clear             wipe the conversation history (new session)
       /expand [N]        show the Nth-most-recent tool result in full
                          (default 1 = most recent)
+      /details [on|off]  show or hide the right "details" pane
+                         (no args = toggle)
       /help, /?          show this help
       /exit, /quit, /q   leave the chat
 

--- a/lib/ex_athena/chat/tui.ex
+++ b/lib/ex_athena/chat/tui.ex
@@ -324,6 +324,22 @@ defmodule ExAthena.Chat.Tui do
     |> noreply()
   end
 
+  defp dispatch_command(:details, args, state) do
+    new_value =
+      case Enum.map(args, &String.downcase/1) do
+        ["on"] -> true
+        ["off"] -> false
+        _ -> not state.show_details
+      end
+
+    label = if new_value, do: "on", else: "off"
+
+    state
+    |> Map.put(:show_details, new_value)
+    |> State.append_event({:info, "Details pane → " <> label})
+    |> noreply()
+  end
+
   defp dispatch_command(:expand, args, state) do
     results = Session.tool_results(state.session)
     total = length(results)

--- a/lib/ex_athena/chat/tui/state.ex
+++ b/lib/ex_athena/chat/tui/state.ex
@@ -49,6 +49,8 @@ defmodule ExAthena.Chat.Tui.State do
             details_scroll_offset: 0,
             details_stream_buffer: "",
             details_thinking_buffer: "",
+            thinking_open?: false,
+            show_details: true,
             footer: @default_footer,
             prior_log_level: :info,
             run_task: nil
@@ -65,6 +67,8 @@ defmodule ExAthena.Chat.Tui.State do
           details_scroll_offset: non_neg_integer(),
           details_stream_buffer: String.t(),
           details_thinking_buffer: String.t(),
+          thinking_open?: boolean(),
+          show_details: boolean(),
           footer: String.t(),
           prior_log_level: atom(),
           run_task: pid() | nil
@@ -91,10 +95,13 @@ defmodule ExAthena.Chat.Tui.State do
   """
   @spec append_loop_event(t(), term()) :: t()
   def append_loop_event(%__MODULE__{} = state, {:content, text}) when is_binary(text) do
+    {thinking, content} = split_thinking_blocks(text)
+
     %{
       state
-      | stream_buffer: state.stream_buffer <> text,
-        details_stream_buffer: state.details_stream_buffer <> text
+      | stream_buffer: state.stream_buffer <> content,
+        details_stream_buffer: state.details_stream_buffer <> content,
+        details_thinking_buffer: state.details_thinking_buffer <> thinking
     }
   end
 
@@ -299,6 +306,29 @@ defmodule ExAthena.Chat.Tui.State do
   def current_popup_selection(%__MODULE__{popup: nil}), do: nil
   def current_popup_selection(%__MODULE__{popup: {_, [], _}}), do: nil
   def current_popup_selection(%__MODULE__{popup: {_, items, idx}}), do: Enum.at(items, idx)
+
+  # ─ Thinking-tag extraction ───────────────────────────────────────────────
+
+  # Many open-weights reasoning models (qwen3, deepseek-r1, …) prepend
+  # `<think>…</think>` blocks to their answer. The provider stream doesn't
+  # split them out, so the agent loop emits everything as `{:content, text}`.
+  # Here we extract those blocks into `thinking` and return the rest as
+  # the visible content. Matches `<think>` AND `<thinking>` to cover the
+  # common variants; `s` flag so `.` spans newlines.
+  @think_re ~r/<think(?:ing)?>(.*?)<\/think(?:ing)?>/s
+
+  @doc false
+  def split_thinking_blocks(text) when is_binary(text) do
+    case Regex.scan(@think_re, text, capture: :all_but_first) do
+      [] ->
+        {"", text}
+
+      matches ->
+        thinking = matches |> List.flatten() |> Enum.join("\n")
+        content = Regex.replace(@think_re, text, "") |> String.trim()
+        {thinking, content}
+    end
+  end
 
   # ─ Details-pane helpers ──────────────────────────────────────────────────
 

--- a/lib/ex_athena/chat/tui/view.ex
+++ b/lib/ex_athena/chat/tui/view.ex
@@ -51,24 +51,36 @@ defmodule ExAthena.Chat.Tui.View do
         {:length, @footer_height}
       ])
 
-    [messages_rect, details_rect] =
-      Layout.split(body_rect, :horizontal, [
-        {:percentage, 50},
-        {:percentage, 50}
-      ])
+    {messages_rect, details_rect} = split_body(body_rect, state)
 
-    widgets = [
-      {header(state), header_rect},
-      {messages(state), messages_rect},
-      {details(state), details_rect},
-      {input(state), input_rect},
-      {footer(state), footer_rect}
-    ]
+    widgets =
+      [
+        {header(state), header_rect},
+        {messages(state, messages_rect.width), messages_rect},
+        {input(state), input_rect},
+        {footer(state), footer_rect}
+      ] ++ details_widget(state, details_rect)
 
     case popup(state, messages_rect) do
       nil -> widgets
       popup_tuple -> widgets ++ [popup_tuple]
     end
+  end
+
+  defp split_body(body_rect, %State{show_details: false}), do: {body_rect, nil}
+
+  defp split_body(body_rect, _state) do
+    [m, d] = Layout.split(body_rect, :horizontal, [{:percentage, 50}, {:percentage, 50}])
+    {m, d}
+  end
+
+  defp details_widget(_state, nil), do: []
+
+  defp details_widget(state, details_rect) do
+    # The details Block draws a left + right border, so the interior width
+    # is two cells narrower. We use the interior width for wrap calculation.
+    inner = max(details_rect.width - 2, 1)
+    [{details(state, inner), details_rect}]
   end
 
   @doc "Build the header status string from a session."
@@ -97,15 +109,18 @@ defmodule ExAthena.Chat.Tui.View do
     }
   end
 
-  defp messages(%State{
-         events: events,
-         loading?: loading?,
-         scroll_offset: scroll,
-         session: session
-       }) do
+  defp messages(
+         %State{
+           events: events,
+           loading?: loading?,
+           scroll_offset: scroll,
+           session: session
+         },
+         width
+       ) do
     items =
       events
-      |> Enum.map(&row_widget(&1, session.model))
+      |> Enum.map(&row_widget(&1, session.model, width))
       |> append_throbber(loading?)
 
     %WidgetList{items: items, scroll_offset: scroll}
@@ -118,93 +133,124 @@ defmodule ExAthena.Chat.Tui.View do
     border_style: %Style{fg: :dark_gray}
   }
 
-  defp details(%State{details: details, details_scroll_offset: scroll}) do
-    items = Enum.map(details, &detail_row_widget/1)
+  defp details(%State{details: details, details_scroll_offset: scroll}, width) do
+    items = Enum.map(details, &detail_row_widget(&1, width))
     %WidgetList{items: items, scroll_offset: scroll, block: @details_block}
   end
 
-  defp detail_row_widget({:detail_header, text}) do
+  # Estimate the number of rows a string occupies once it's wrapped at
+  # `width` columns. Counts each explicit `\n` as a line break and uses
+  # `String.length/1` to approximate display columns (good enough for
+  # ASCII / European text; emoji and CJK may be off by one). The Paragraph
+  # widget does the actual wrapping; this just sizes the row in the
+  # surrounding WidgetList so wrapped content isn't clipped.
+  defp wrapped_height(text, width) when is_binary(text) and is_integer(width) and width > 0 do
+    text
+    |> String.split("\n")
+    |> Enum.map(fn line ->
+      case String.length(line) do
+        0 -> 1
+        n -> div(n - 1, width) + 1
+      end
+    end)
+    |> Enum.sum()
+    |> max(1)
+  end
+
+  defp wrapped_height(_text, _width), do: 1
+
+  defp detail_row_widget({:detail_header, text}, width) do
     {%Paragraph{
        text: text,
-       style: %Style{fg: :light_yellow, modifiers: [:bold]}
-     }, 1}
+       style: %Style{fg: :light_yellow, modifiers: [:bold]},
+       wrap: true
+     }, wrapped_height(text, width)}
   end
 
-  defp detail_row_widget({:thinking, text}) do
+  defp detail_row_widget({:thinking, text}, width) do
     {%Paragraph{
        text: text,
-       style: %Style{fg: :magenta, modifiers: [:italic]}
-     }, 1}
+       style: %Style{fg: :magenta, modifiers: [:italic]},
+       wrap: true
+     }, wrapped_height(text, width)}
   end
 
-  defp detail_row_widget({:assistant, text}) do
-    {%Paragraph{text: text, style: %Style{fg: :white}}, 1}
+  defp detail_row_widget({:assistant, text}, width) do
+    {%Paragraph{text: text, style: %Style{fg: :white}, wrap: true}, wrapped_height(text, width)}
   end
 
-  defp detail_row_widget({:tool_call, text}) do
-    {%Paragraph{text: text, style: %Style{fg: :cyan}}, 1}
+  defp detail_row_widget({:tool_call, text}, width) do
+    {%Paragraph{text: text, style: %Style{fg: :cyan}, wrap: true}, wrapped_height(text, width)}
   end
 
-  defp detail_row_widget({:tool_result, text}) do
-    {%Paragraph{text: text, style: %Style{fg: :dark_gray}}, 1}
+  defp detail_row_widget({:tool_result, text}, width) do
+    {%Paragraph{text: text, style: %Style{fg: :dark_gray}, wrap: true},
+     wrapped_height(text, width)}
   end
 
-  defp detail_row_widget({:tool_result_error, text}) do
-    {%Paragraph{text: text, style: %Style{fg: :red}}, 1}
+  defp detail_row_widget({:tool_result_error, text}, width) do
+    {%Paragraph{text: text, style: %Style{fg: :red}, wrap: true}, wrapped_height(text, width)}
   end
 
-  defp detail_row_widget({:error, text}) do
-    {%Paragraph{text: text, style: %Style{fg: :red, modifiers: [:bold]}}, 1}
+  defp detail_row_widget({:error, text}, width) do
+    {%Paragraph{text: text, style: %Style{fg: :red, modifiers: [:bold]}, wrap: true},
+     wrapped_height(text, width)}
   end
 
-  defp detail_row_widget({:info, text}) do
-    {%Paragraph{text: text, style: %Style{fg: :dark_gray}}, 1}
+  defp detail_row_widget({:info, text}, width) do
+    {%Paragraph{text: text, style: %Style{fg: :dark_gray}, wrap: true},
+     wrapped_height(text, width)}
   end
 
-  defp detail_row_widget({_kind, text}) do
-    {%Paragraph{text: text, style: %Style{fg: :dark_gray}}, 1}
+  defp detail_row_widget({_kind, text}, width) do
+    {%Paragraph{text: text, style: %Style{fg: :dark_gray}, wrap: true},
+     wrapped_height(text, width)}
   end
 
-  defp row_widget({:user, text}, _model) do
-    {%Paragraph{
-       text: "me ▸ " <> text,
-       style: %Style{fg: :green, modifiers: [:bold]}
-     }, 1}
+  defp row_widget({:user, text}, _model, width) do
+    full = "me ▸ " <> text
+
+    {%Paragraph{text: full, style: %Style{fg: :green, modifiers: [:bold]}, wrap: true},
+     wrapped_height(full, width)}
   end
 
-  defp row_widget({:assistant, text}, model) do
-    {%Paragraph{
-       text: model <> " ▸ " <> text,
-       style: %Style{fg: :cyan, modifiers: [:bold]}
-     }, 1}
+  defp row_widget({:assistant, text}, model, width) do
+    full = model <> " ▸ " <> text
+
+    {%Paragraph{text: full, style: %Style{fg: :cyan, modifiers: [:bold]}, wrap: true},
+     wrapped_height(full, width)}
   end
 
-  defp row_widget({:tool_call, text}, _model) do
-    {%Paragraph{text: text, style: %Style{fg: :cyan}}, 1}
+  defp row_widget({:tool_call, text}, _model, width) do
+    {%Paragraph{text: text, style: %Style{fg: :cyan}, wrap: true}, wrapped_height(text, width)}
   end
 
-  defp row_widget({:tool_result, text}, _model) do
-    {%Paragraph{text: text, style: %Style{fg: :dark_gray}}, 1}
+  defp row_widget({:tool_result, text}, _model, width) do
+    {%Paragraph{text: text, style: %Style{fg: :dark_gray}, wrap: true},
+     wrapped_height(text, width)}
   end
 
-  defp row_widget({:tool_result_error, text}, _model) do
-    {%Paragraph{text: text, style: %Style{fg: :red}}, 1}
+  defp row_widget({:tool_result_error, text}, _model, width) do
+    {%Paragraph{text: text, style: %Style{fg: :red}, wrap: true}, wrapped_height(text, width)}
   end
 
-  defp row_widget({:warning, text}, _model) do
-    {%Paragraph{text: text, style: %Style{fg: :yellow}}, 1}
+  defp row_widget({:warning, text}, _model, width) do
+    {%Paragraph{text: text, style: %Style{fg: :yellow}, wrap: true}, wrapped_height(text, width)}
   end
 
-  defp row_widget({:error, text}, _model) do
-    {%Paragraph{text: text, style: %Style{fg: :red, modifiers: [:bold]}}, 1}
+  defp row_widget({:error, text}, _model, width) do
+    {%Paragraph{text: text, style: %Style{fg: :red, modifiers: [:bold]}, wrap: true},
+     wrapped_height(text, width)}
   end
 
-  defp row_widget({:info, text}, _model) do
-    {%Paragraph{text: text, style: %Style{fg: :dark_gray}}, 1}
+  defp row_widget({:info, text}, _model, width) do
+    {%Paragraph{text: text, style: %Style{fg: :dark_gray}, wrap: true},
+     wrapped_height(text, width)}
   end
 
-  defp row_widget({:status, text}, _model) do
-    {%Paragraph{text: text, style: %Style{fg: :dark_gray}}, 1}
+  defp row_widget({:status, text}, _model, width) do
+    {%Paragraph{text: text, style: %Style{fg: :dark_gray}, wrap: true},
+     wrapped_height(text, width)}
   end
 
   defp append_throbber(items, false), do: items

--- a/test/ex_athena/chat/commands_test.exs
+++ b/test/ex_athena/chat/commands_test.exs
@@ -82,9 +82,20 @@ defmodule ExAthena.Chat.CommandsTest do
     test "lists every slash command with a one-line description" do
       text = Commands.help_text()
 
-      for verb <- ~w(/model /mode /tools /clear /expand /help /exit) do
+      for verb <- ~w(/model /mode /tools /clear /expand /details /help /exit) do
         assert text =~ verb, "expected help text to mention #{verb}"
       end
+    end
+  end
+
+  describe "parse/1 /details" do
+    test "parses /details with no args" do
+      assert Commands.parse("/details") == {:command, :details, []}
+    end
+
+    test "parses /details on and /details off" do
+      assert Commands.parse("/details on") == {:command, :details, ["on"]}
+      assert Commands.parse("/details off") == {:command, :details, ["off"]}
     end
   end
 end

--- a/test/ex_athena/chat/tui/state_test.exs
+++ b/test/ex_athena/chat/tui/state_test.exs
@@ -334,6 +334,45 @@ defmodule ExAthena.Chat.Tui.StateTest do
     end
   end
 
+  describe "split_thinking_blocks/1" do
+    test "extracts a single <think>…</think> block" do
+      assert {"my reasoning", "the answer"} =
+               State.split_thinking_blocks("<think>my reasoning</think>the answer")
+    end
+
+    test "joins multiple blocks with newlines" do
+      assert {"a\nb", "rest"} =
+               State.split_thinking_blocks("<think>a</think> <think>b</think> rest")
+    end
+
+    test "supports <thinking> as well as <think>" do
+      assert {"reasoning", "answer"} =
+               State.split_thinking_blocks("<thinking>reasoning</thinking>answer")
+    end
+
+    test "spans newlines inside the block" do
+      input = "<think>line 1\nline 2</think>final"
+      assert {"line 1\nline 2", "final"} = State.split_thinking_blocks(input)
+    end
+
+    test "is a passthrough when no tags are present" do
+      assert {"", "plain answer"} = State.split_thinking_blocks("plain answer")
+    end
+  end
+
+  describe ":content with <think> tags" do
+    test "routes inside-tag content to thinking buffer and the rest to stream buffer" do
+      state =
+        Session.new()
+        |> State.new()
+        |> State.append_loop_event({:content, "<think>plan it</think>Hello there"})
+
+      assert state.details_thinking_buffer == "plan it"
+      assert state.stream_buffer == "Hello there"
+      assert state.details_stream_buffer == "Hello there"
+    end
+  end
+
   describe "details pane" do
     test ":tool_call appends a header + full pretty-printed args to details" do
       tc = %ToolCall{id: "1", name: "Read", arguments: %{"path" => "lib/foo.ex"}}


### PR DESCRIPTION
Follow-ups to #62 driven by the screenshot feedback:

## Summary
- **Text wrapping**: long messages were truncated at the pane edge because every event was rendered as a height-1 `Paragraph` with `wrap: false`. Now every Paragraph wraps and the row height is computed from the pane width via a `wrapped_height/2` helper. Applies to both panes.
- **`/details` slash command**: toggles the right pane. Bare `/details` toggles; `/details on` and `/details off` set it explicitly. When off, the messages pane uses the full body width.
- **Thinking extraction**: parses `<think>…</think>` (and `<thinking>…</thinking>`) blocks out of `{:content, text}` and routes them to the right pane as italic magenta thinking entries. Works with qwen3, deepseek-r1, and any model that emits these tags in its response — no provider changes needed.

## Files
- `lib/ex_athena/chat/tui/view.ex` — width-aware row widgets + `split_body/2`.
- `lib/ex_athena/chat/tui/state.ex` — `show_details`, `split_thinking_blocks/1`, content-event rewrite.
- `lib/ex_athena/chat/commands.ex` — new `:details` verb, updated `/help`.
- `lib/ex_athena/chat/tui.ex` — `dispatch_command(:details, …)`.
- Tests added for `split_thinking_blocks/1`, `:content` with `<think>` tags, and `/details` parsing.

## Test plan
- [x] `mix compile --force` clean
- [x] `mix format` clean
- [x] `mix test` — 743 tests, 1 pre-existing flake (unchanged from main)
- [ ] Manual: `mix athena.chat`, send a long prompt, confirm assistant text wraps across multiple lines on the left and full text appears on the right
- [ ] Manual: `/details off` collapses to single pane; `/details on` brings it back
- [ ] Manual with a `<think>`-emitting model (e.g. qwen3): thinking shows in italic magenta in the right pane and is stripped from the visible answer