### PR TITLE
feat(provider): plumb thinking/reasoning through req_llm to loop events

### DIFF
--- a/lib/ex_athena/modes/plan_and_solve.ex
+++ b/lib/ex_athena/modes/plan_and_solve.ex
@@ -64,6 +64,10 @@ defmodule ExAthena.Modes.PlanAndSolve do
 
     case state.provider_mod.query(request, state.provider_opts) do
       {:ok, response} ->
+        if is_binary(response.thinking) and response.thinking != "" do
+          ExAthena.Loop.Events.emit(state.on_event, {:thinking, response.thinking})
+        end
+
         ExAthena.Loop.Events.emit(state.on_event, {:content, response.text || ""})
 
         state = fold_usage(state, response)

--- a/lib/ex_athena/modes/react.ex
+++ b/lib/ex_athena/modes/react.ex
@@ -88,6 +88,7 @@ defmodule ExAthena.Modes.ReAct do
              ) do
           {:ok, []} ->
             # Terminal: model returned plain text with no tool calls.
+            maybe_emit_thinking(state.on_event, response)
             Events.emit(state.on_event, {:content, response.text || ""})
 
             state =
@@ -100,6 +101,7 @@ defmodule ExAthena.Modes.ReAct do
             {:halt, state}
 
           {:ok, tool_calls} ->
+            maybe_emit_thinking(state.on_event, response)
             Events.emit(state.on_event, {:content, response.text || ""})
 
             assistant_msg = Messages.assistant(response.text, tool_calls)
@@ -433,6 +435,16 @@ defmodule ExAthena.Modes.ReAct do
         end
     end
   end
+
+  # Emit a {:thinking, text} loop event when the provider surfaced any
+  # reasoning content. Skipped silently when the response has no thinking
+  # (most providers, simple models, or when thinking was disabled).
+  defp maybe_emit_thinking(on_event, %{thinking: text})
+       when is_binary(text) and text != "" do
+    Events.emit(on_event, {:thinking, text})
+  end
+
+  defp maybe_emit_thinking(_on_event, _response), do: :ok
 
   defp extract_cost(nil), do: nil
 

--- a/lib/ex_athena/modes/reflexion.ex
+++ b/lib/ex_athena/modes/reflexion.ex
@@ -120,6 +120,10 @@ defmodule ExAthena.Modes.Reflexion do
               Messages.assistant(critique)
             ]
 
+        if is_binary(response.thinking) and response.thinking != "" do
+          ExAthena.Loop.Events.emit(state.on_event, {:thinking, response.thinking})
+        end
+
         ExAthena.Loop.Events.emit(state.on_event, {:content, critique})
 
         {:ok, %{state | messages: new_messages, budget: new_budget}}

--- a/lib/ex_athena/providers/req_llm.ex
+++ b/lib/ex_athena/providers/req_llm.ex
@@ -346,8 +346,16 @@ defmodule ExAthena.Providers.ReqLLM do
   # ── Response mapping ──────────────────────────────────────────────
 
   defp to_response(%ReqLLM.Response{} = resp, %Request{} = request) do
+    thinking =
+      case ReqLLM.Response.thinking(resp) do
+        nil -> nil
+        "" -> nil
+        text -> text
+      end
+
     %Response{
       text: extract_text(resp),
+      thinking: thinking,
       tool_calls: extract_tool_calls(resp),
       finish_reason: resp.finish_reason,
       model: resp.model || request.model,
@@ -410,6 +418,7 @@ defmodule ExAthena.Providers.ReqLLM do
   defp consume_stream(%ReqLLM.StreamResponse{stream: stream}, callback, request) do
     state = %{
       text: [],
+      thinking: [],
       tool_calls: [],
       # Collects OpenAI-style streaming tool-call argument fragments keyed by
       # the tool-call index. llama.cpp (and strict OpenAI clients) stream
@@ -440,6 +449,7 @@ defmodule ExAthena.Providers.ReqLLM do
     tool_calls = patch_tool_call_args(final.tool_calls, final.tool_call_args_buffer)
 
     text = final.text |> Enum.reverse() |> IO.iodata_to_binary()
+    thinking = final.thinking |> Enum.reverse() |> IO.iodata_to_binary()
 
     # Log the resolved tool calls. Warn when args are still empty after patching
     # (means neither fragments nor raw_arguments provided usable JSON).
@@ -468,6 +478,7 @@ defmodule ExAthena.Providers.ReqLLM do
 
     %Response{
       text: text,
+      thinking: if(thinking == "", do: nil, else: thinking),
       tool_calls: tool_calls,
       finish_reason: final.finish_reason || :stop,
       model: final.model,
@@ -595,6 +606,15 @@ defmodule ExAthena.Providers.ReqLLM do
 
     ExAthena.Streaming.text_delta(callback, text)
     %{acc | text: [text | acc.text]}
+  end
+
+  defp handle_chunk(%{type: :thinking, text: text}, callback, acc) when is_binary(text) do
+    Logger.debug(fn ->
+      "#{@log_prefix} ←thinking_delta #{byte_size(text)}B: #{preview(text, 80)}"
+    end)
+
+    ExAthena.Streaming.thinking_delta(callback, text)
+    %{acc | thinking: [text | acc.thinking]}
   end
 
   defp handle_chunk(%{type: :tool_call} = tc, _callback, acc) do

--- a/lib/ex_athena/response.ex
+++ b/lib/ex_athena/response.ex
@@ -12,6 +12,7 @@ defmodule ExAthena.Response do
 
   defstruct [
     :text,
+    :thinking,
     :tool_calls,
     :finish_reason,
     :usage,
@@ -28,6 +29,7 @@ defmodule ExAthena.Response do
 
   @type t :: %__MODULE__{
           text: String.t() | nil,
+          thinking: String.t() | nil,
           tool_calls: [ToolCall.t()],
           finish_reason: :stop | :length | :tool_calls | :content_filter | :error | nil,
           usage: usage() | nil,

--- a/lib/ex_athena/streaming.ex
+++ b/lib/ex_athena/streaming.ex
@@ -16,6 +16,7 @@ defmodule ExAthena.Streaming do
     @type type ::
             :start
             | :text_delta
+            | :thinking_delta
             | :tool_call_start
             | :tool_call_delta
             | :tool_call_end
@@ -33,6 +34,10 @@ defmodule ExAthena.Streaming do
   @doc "Emit a text-delta event."
   def text_delta(callback, text) when is_binary(text),
     do: emit(callback, %Event{type: :text_delta, data: text})
+
+  @doc "Emit a thinking/reasoning delta event (Claude `<thinking>` blocks, etc.)."
+  def thinking_delta(callback, text) when is_binary(text),
+    do: emit(callback, %Event{type: :thinking_delta, data: text})
 
   @doc "Emit a start-of-tool-call event with a partial ToolCall."
   def tool_call_start(callback, index, partial),


### PR DESCRIPTION
## Why

Follow-up to #62 / #63. The user reported the details pane wasn't showing thinking. Investigation revealed our provider was dropping req_llm's thinking content on the floor:

- `req_llm` exposes `:thinking` stream chunks (Claude `<thinking>` blocks) and `ReqLLM.Response.thinking/1` for non-stream responses.
- Our provider had no `handle_chunk` clause for `:thinking` — they fell through to the catch-all.
- `to_response/2` never read `ReqLLM.Response.thinking/1`.

Even when reasoning content WAS available, it never reached the modes or the TUI/web details pane.

(Note: ollama's OpenAI-compat endpoint doesn't expose reasoning content at all — this PR doesn't change that. But Claude / any thinking-capable provider that goes through req_llm now works end-to-end.)

## Summary

- `ExAthena.Response` gains a `thinking: String.t() | nil` field.
- `req_llm` provider handles `%{type: :thinking, text: text}` chunks: forwards each delta via the new `ExAthena.Streaming.thinking_delta/2` and accumulates the full text on the response struct (both stream and query paths).
- `react` / `plan_and_solve` / `reflexion` modes emit a `{:thinking, text}` loop event when `response.thinking` is non-empty, so the TUI's details pane and the web `details_stream` render it.

Models that don't emit reasoning content are unaffected.

## Test plan
- [x] `mix compile --force` clean
- [x] `mix format` clean
- [x] `mix test` — 743 tests, same 1 pre-existing flake as main
- [ ] Manual with Claude (thinking-enabled): `mix athena.chat --provider claude`, ask a complex question, confirm magenta italic thinking entries appear in the details pane