### PR TITLE
feat(tui): stream text + thinking in real time

### DIFF
--- a/lib/ex_athena/chat/tui.ex
+++ b/lib/ex_athena/chat/tui.ex
@@ -249,6 +249,7 @@ defmodule ExAthena.Chat.Tui do
       state
       |> State.append_event({:user, text})
       |> State.set_loading(true)
+      |> State.reset_stream_state()
       |> update_in_session(&Session.append_user(&1, text))
 
     task_pid = Runner.start(state.session, self())

--- a/lib/ex_athena/chat/tui/state.ex
+++ b/lib/ex_athena/chat/tui/state.ex
@@ -14,6 +14,7 @@ defmodule ExAthena.Chat.Tui.State do
   alias ExAthena.Chat.Session
   alias ExAthena.Messages.{ToolCall, ToolResult}
   alias ExAthena.Result
+  alias ExAthena.Streaming.Event, as: StreamEvent
 
   @preview_chars 200
   @default_footer "Enter: send  Ctrl+C: quit  /help"
@@ -51,6 +52,16 @@ defmodule ExAthena.Chat.Tui.State do
             details_thinking_buffer: "",
             thinking_open?: false,
             show_details: true,
+            # Streaming-tag parser state. Tracks whether we're currently
+            # inside a `<think>` block and holds the longest suffix of the
+            # latest delta that could be the start of an open/close tag
+            # (so partial tags spanning deltas still parse correctly).
+            stream_parser: %{mode: :outside, pending: "", close_tag: nil},
+            # True once any per-token streaming delta has arrived this turn.
+            # When true we suppress the redundant end-of-turn
+            # `{:content,...}` / `{:thinking,...}` loop events that the
+            # mode emits with the full accumulated text.
+            streamed_this_turn?: false,
             footer: @default_footer,
             prior_log_level: :info,
             run_task: nil
@@ -69,6 +80,8 @@ defmodule ExAthena.Chat.Tui.State do
           details_thinking_buffer: String.t(),
           thinking_open?: boolean(),
           show_details: boolean(),
+          stream_parser: %{mode: atom(), pending: String.t(), close_tag: String.t() | nil},
+          streamed_this_turn?: boolean(),
           footer: String.t(),
           prior_log_level: atom(),
           run_task: pid() | nil
@@ -94,6 +107,51 @@ defmodule ExAthena.Chat.Tui.State do
   left pane and a full-detail block in the right pane.
   """
   @spec append_loop_event(t(), term()) :: t()
+  # Per-token streaming text delta (arrives via the provider during
+  # inference, before the loop emits its final {:content, ...} event).
+  # Run it through the inline <think>...</think> parser so thinking is
+  # routed to the right pane in real time.
+  def append_loop_event(%__MODULE__{} = state, %StreamEvent{type: :text_delta, data: text})
+      when is_binary(text) do
+    {new_parser, content_chunk, thinking_chunk} = parse_stream_chunk(state.stream_parser, text)
+
+    %{
+      state
+      | stream_parser: new_parser,
+        streamed_this_turn?: true,
+        stream_buffer: state.stream_buffer <> content_chunk,
+        details_stream_buffer: state.details_stream_buffer <> content_chunk,
+        details_thinking_buffer: state.details_thinking_buffer <> thinking_chunk
+    }
+  end
+
+  # Per-token native thinking delta (Claude `<thinking>` blocks via
+  # req_llm). Routes straight to the thinking buffer.
+  def append_loop_event(%__MODULE__{} = state, %StreamEvent{type: :thinking_delta, data: text})
+      when is_binary(text) do
+    %{
+      state
+      | streamed_this_turn?: true,
+        details_thinking_buffer: state.details_thinking_buffer <> text
+    }
+  end
+
+  # Ignore other Streaming.Event kinds (start, tool_call_*, usage, stop,
+  # error). The agent loop translates the relevant ones into loop event
+  # tuples that we handle below.
+  def append_loop_event(%__MODULE__{} = state, %StreamEvent{}), do: state
+
+  # When per-token streaming already populated the buffers this turn,
+  # the mode's end-of-turn {:content, full_text} would duplicate it.
+  # Drop it (the streamed content is the source of truth).
+  def append_loop_event(%__MODULE__{streamed_this_turn?: true} = state, {:content, _text}) do
+    state
+  end
+
+  def append_loop_event(%__MODULE__{streamed_this_turn?: true} = state, {:thinking, _text}) do
+    state
+  end
+
   def append_loop_event(%__MODULE__{} = state, {:content, text}) when is_binary(text) do
     {thinking, content} = split_thinking_blocks(text)
 
@@ -276,7 +334,9 @@ defmodule ExAthena.Chat.Tui.State do
         details: [],
         details_scroll_offset: 0,
         details_stream_buffer: "",
-        details_thinking_buffer: ""
+        details_thinking_buffer: "",
+        stream_parser: %{mode: :outside, pending: "", close_tag: nil},
+        streamed_this_turn?: false
     }
   end
 
@@ -307,14 +367,104 @@ defmodule ExAthena.Chat.Tui.State do
   def current_popup_selection(%__MODULE__{popup: {_, [], _}}), do: nil
   def current_popup_selection(%__MODULE__{popup: {_, items, idx}}), do: Enum.at(items, idx)
 
-  # ─ Thinking-tag extraction ───────────────────────────────────────────────
+  # ─ Streaming-tag parser ──────────────────────────────────────────────────
 
-  # Many open-weights reasoning models (qwen3, deepseek-r1, …) prepend
-  # `<think>…</think>` blocks to their answer. The provider stream doesn't
-  # split them out, so the agent loop emits everything as `{:content, text}`.
-  # Here we extract those blocks into `thinking` and return the rest as
-  # the visible content. Matches `<think>` AND `<thinking>` to cover the
-  # common variants; `s` flag so `.` spans newlines.
+  @open_re ~r/<think(?:ing)?>/
+  @open_candidates ["<think>", "<thinking>"]
+
+  @doc """
+  Reset the streaming parser state at the start of a new turn.
+  Called by `Tui.dispatch_message/2` before issuing the next request.
+  """
+  @spec reset_stream_state(t()) :: t()
+  def reset_stream_state(%__MODULE__{} = state) do
+    %{
+      state
+      | stream_parser: %{mode: :outside, pending: "", close_tag: nil},
+        streamed_this_turn?: false
+    }
+  end
+
+  # Run a streaming text delta through the inline-think state machine.
+  # Returns `{new_parser, content_chunk, thinking_chunk}`. The parser
+  # holds a `pending` string — the longest suffix of the previous delta
+  # that could be the start of a candidate tag — so tags split across
+  # deltas (`"…<thi"` + `"nk>foo</think>"`) still parse correctly.
+  @doc false
+  def parse_stream_chunk(parser, chunk) when is_binary(chunk) do
+    do_parse_stream(parser, chunk, "", "")
+  end
+
+  defp do_parse_stream(parser, "", content_acc, thinking_acc),
+    do: {parser, content_acc, thinking_acc}
+
+  defp do_parse_stream(%{mode: :outside, pending: pending}, chunk, content_acc, thinking_acc) do
+    text = pending <> chunk
+
+    case Regex.split(@open_re, text, parts: 2, include_captures: true) do
+      [before, tag, rest] ->
+        close_tag = if tag == "<think>", do: "</think>", else: "</thinking>"
+        next = %{mode: :inside, pending: "", close_tag: close_tag}
+        do_parse_stream(next, rest, content_acc <> before, thinking_acc)
+
+      [single] ->
+        {pending_tail, emit} = split_pending_tail(single, @open_candidates)
+        next = %{mode: :outside, pending: pending_tail, close_tag: nil}
+        {next, content_acc <> emit, thinking_acc}
+    end
+  end
+
+  defp do_parse_stream(
+         %{mode: :inside, pending: pending, close_tag: close_tag},
+         chunk,
+         content_acc,
+         thinking_acc
+       ) do
+    text = pending <> chunk
+
+    case String.split(text, close_tag, parts: 2) do
+      [before, rest] ->
+        next = %{mode: :outside, pending: "", close_tag: nil}
+        do_parse_stream(next, rest, content_acc, thinking_acc <> before)
+
+      [single] ->
+        {pending_tail, emit} = split_pending_tail(single, [close_tag])
+        next = %{mode: :inside, pending: pending_tail, close_tag: close_tag}
+        {next, content_acc, thinking_acc <> emit}
+    end
+  end
+
+  # Split `text` into `{pending_tail, emit}` where `pending_tail` is the
+  # longest suffix of `text` that is a STRICT prefix of any candidate
+  # tag (e.g. "<thi" when the candidate is "<think>"). Everything before
+  # the partial is safe to emit; the partial is held until the next
+  # delta arrives.
+  defp split_pending_tail(text, candidates) do
+    text_len = byte_size(text)
+    max_n = candidates |> Enum.map(&byte_size/1) |> Enum.max() |> Kernel.-(1) |> min(text_len)
+
+    pending =
+      Enum.reduce_while(max_n..1//-1, "", fn n, _ ->
+        suffix = binary_part(text, text_len - n, n)
+
+        if Enum.any?(candidates, &String.starts_with?(&1, suffix)),
+          do: {:halt, suffix},
+          else: {:cont, ""}
+      end)
+
+    if pending == "" do
+      {"", text}
+    else
+      {pending, binary_part(text, 0, text_len - byte_size(pending))}
+    end
+  end
+
+  # ─ Thinking-tag extraction (one-shot, end-of-turn) ───────────────────────
+
+  # Used by the existing {:content, text} handler when streaming wasn't
+  # available (provider supports only query/2, not stream/3). Matches
+  # `<think>` AND `<thinking>` to cover the common variants; `s` flag so
+  # `.` spans newlines.
   @think_re ~r/<think(?:ing)?>(.*?)<\/think(?:ing)?>/s
 
   @doc false

--- a/test/ex_athena/chat/tui/state_test.exs
+++ b/test/ex_athena/chat/tui/state_test.exs
@@ -334,6 +334,121 @@ defmodule ExAthena.Chat.Tui.StateTest do
     end
   end
 
+  describe "parse_stream_chunk/2 — streaming <think> parser" do
+    @start %{mode: :outside, pending: "", close_tag: nil}
+
+    test "passes plain text through unchanged" do
+      assert {%{mode: :outside, pending: "", close_tag: nil}, "Hello world", ""} =
+               State.parse_stream_chunk(@start, "Hello world")
+    end
+
+    test "splits a complete <think>...</think> block in one chunk" do
+      assert {parser, "Answer", "reasoning"} =
+               State.parse_stream_chunk(@start, "<think>reasoning</think>Answer")
+
+      assert parser.mode == :outside
+    end
+
+    test "handles a tag split across two deltas" do
+      {p1, c1, t1} = State.parse_stream_chunk(@start, "Hello <thi")
+      assert c1 == "Hello "
+      assert t1 == ""
+      # Partial open tag held in pending
+      assert p1.pending == "<thi"
+      assert p1.mode == :outside
+
+      {p2, c2, t2} = State.parse_stream_chunk(p1, "nk>let me think</think>foo")
+      # The full block resolves across the boundary
+      assert c2 == "foo"
+      assert t2 == "let me think"
+      assert p2.mode == :outside
+      assert p2.pending == ""
+    end
+
+    test "handles a close tag split across deltas" do
+      {p1, c1, t1} = State.parse_stream_chunk(@start, "<think>thinking part 1")
+      assert c1 == ""
+      assert t1 == "thinking part 1"
+      assert p1.mode == :inside
+
+      {p2, c2, t2} = State.parse_stream_chunk(p1, " part 2</thi")
+      assert c2 == ""
+      assert t2 == " part 2"
+      assert p2.mode == :inside
+      assert p2.pending == "</thi"
+
+      {p3, c3, t3} = State.parse_stream_chunk(p2, "nk>answer")
+      assert c3 == "answer"
+      assert t3 == ""
+      assert p3.mode == :outside
+    end
+
+    test "supports <thinking>...</thinking> as well" do
+      assert {_, "ok", "deep"} =
+               State.parse_stream_chunk(@start, "<thinking>deep</thinking>ok")
+    end
+
+    test "handles multiple blocks in one chunk" do
+      {_p, content, thinking} =
+        State.parse_stream_chunk(@start, "<think>a</think>b<think>c</think>d")
+
+      assert content == "bd"
+      assert thinking == "ac"
+    end
+  end
+
+  describe "append_loop_event/2 — streaming events" do
+    test ":text_delta routes content to stream_buffer and <think> body to thinking buffer" do
+      state =
+        Session.new()
+        |> State.new()
+        |> State.append_loop_event(%ExAthena.Streaming.Event{
+          type: :text_delta,
+          data: "<think>plan</think>Hello"
+        })
+
+      assert state.stream_buffer == "Hello"
+      assert state.details_stream_buffer == "Hello"
+      assert state.details_thinking_buffer == "plan"
+      assert state.streamed_this_turn? == true
+    end
+
+    test ":thinking_delta routes directly to thinking buffer" do
+      state =
+        Session.new()
+        |> State.new()
+        |> State.append_loop_event(%ExAthena.Streaming.Event{type: :thinking_delta, data: "abc"})
+
+      assert state.details_thinking_buffer == "abc"
+      assert state.streamed_this_turn? == true
+    end
+
+    test "end-of-turn {:content, text} is suppressed when streaming already happened" do
+      state =
+        Session.new()
+        |> State.new()
+        |> State.append_loop_event(%ExAthena.Streaming.Event{type: :text_delta, data: "Hi"})
+        |> State.append_loop_event({:content, "Hi"})
+
+      # Buffer wasn't doubled.
+      assert state.stream_buffer == "Hi"
+    end
+
+    test "reset_stream_state/1 clears the parser + dedup flag" do
+      state =
+        Session.new()
+        |> State.new()
+        |> State.append_loop_event(%ExAthena.Streaming.Event{type: :text_delta, data: "<thi"})
+
+      assert state.stream_parser.pending == "<thi"
+      assert state.streamed_this_turn? == true
+
+      state = State.reset_stream_state(state)
+      assert state.stream_parser.pending == ""
+      assert state.streamed_this_turn? == false
+    end
+  end
+
   describe "split_thinking_blocks/1" do
     test "extracts a single <think>…</think> block" do
       assert {"my reasoning", "the answer"} =


### PR DESCRIPTION
## Why

The TUI was ignoring per-token `Streaming.Event{:text_delta}` / `Streaming.Event{:thinking_delta}` chunks and only updating from the mode's end-of-turn `{:content,...}` and `{:thinking,...}` loop events. So both messages and the thinking pane only filled in **after the model finished** — no live typing effect.

## Summary

- `Tui.State.append_loop_event/2` now handles `%Streaming.Event{type: :text_delta}` — runs the delta through an inline `<think>...</think>` parser. Routes content to `stream_buffer` + `details_stream_buffer`, thinking to `details_thinking_buffer`.
- The parser tracks `mode / pending / close_tag` so tags spanning deltas (`"…<thi"` + `"nk>foo</think>"`) still resolve correctly. `<think>` AND `<thinking>` variants supported.
- Native thinking deltas (`%Streaming.Event{type: :thinking_delta}` from Claude via req_llm) route straight to `details_thinking_buffer`.
- A `streamed_this_turn?` flag suppresses the redundant end-of-turn `{:content,...}` / `{:thinking,...}` loop events so streamed text isn't duplicated.
- Parser + dedup flag reset in `Tui.dispatch_message/2` (next user turn) and `clear_session/1`.
- The 60ms tick (`flush_stream/1`) already materializes the buffers into rows, so streaming appears live in both panes with no extra plumbing.

The existing `@think_re` end-of-turn regex (added in #63) still handles the `query/2` non-stream provider path as a fallback.

## Test plan
- [x] `mix compile --force` clean
- [x] `mix format` clean
- [x] `mix test` — 753 tests (13 new), same 1 pre-existing flake as main
- [x] New tests cover: tag in one chunk, open tag split across deltas, close tag split across deltas, `<thinking>` variant, multiple blocks per chunk, `:text_delta` / `:thinking_delta` handlers, end-of-turn dedup, `reset_stream_state/1`.
- [ ] Manual: `mix athena.chat`, ask qwen3.5 a question — confirm assistant text types out live on the left and italic magenta thinking types out live on the right.