### PR TITLE
feat(tui): set working directory via --path/-p flag and /cd command

### DIFF
--- a/lib/ex_athena/chat/commands.ex
+++ b/lib/ex_athena/chat/commands.ex
@@ -30,6 +30,8 @@ defmodule ExAthena.Chat.Commands do
     "clear" => :clear,
     "expand" => :expand,
     "details" => :details,
+    "cd" => :cd,
+    "pwd" => :pwd,
     "help" => :help,
     "?" => :help
   }
@@ -75,6 +77,9 @@ defmodule ExAthena.Chat.Commands do
                          (default 1 = most recent)
       /details [on|off]  show or hide the right "details" pane
                          (no args = toggle)
+      /cd PATH           set the working directory for tools
+                         (`~` is expanded; the chat process does not chdir)
+      /pwd               print the current working directory
       /help, /?          show this help
       /exit, /quit, /q   leave the chat
 

--- a/lib/ex_athena/chat/session.ex
+++ b/lib/ex_athena/chat/session.ex
@@ -21,7 +21,8 @@ defmodule ExAthena.Chat.Session do
             messages: [],
             iteration: 0,
             usage: %{input_tokens: 0, output_tokens: 0},
-            cost_usd: 0.0
+            cost_usd: 0.0,
+            cwd: nil
 
   @type t :: %__MODULE__{
           provider: atom(),
@@ -32,7 +33,8 @@ defmodule ExAthena.Chat.Session do
           messages: [Message.t()],
           iteration: non_neg_integer(),
           usage: %{input_tokens: non_neg_integer(), output_tokens: non_neg_integer()},
-          cost_usd: float()
+          cost_usd: float(),
+          cwd: String.t() | nil
         }
 
   @spec new(keyword()) :: t()
@@ -49,8 +51,14 @@ defmodule ExAthena.Chat.Session do
       model: Keyword.get(opts, :model, configured_model),
       mode: Keyword.get(opts, :mode, :react),
       tools: Keyword.get(opts, :tools, :all),
-      permission_mode: Keyword.get(opts, :permission_mode, :default)
+      permission_mode: Keyword.get(opts, :permission_mode, :default),
+      cwd: Keyword.get(opts, :cwd)
     }
+  end
+
+  @spec set_cwd(t(), String.t() | nil) :: t()
+  def set_cwd(%__MODULE__{} = session, cwd) when is_binary(cwd) or is_nil(cwd) do
+    %{session | cwd: cwd}
   end
 
   @spec append_user(t(), String.t()) :: t()

--- a/lib/ex_athena/chat/tui.ex
+++ b/lib/ex_athena/chat/tui.ex
@@ -325,6 +325,41 @@ defmodule ExAthena.Chat.Tui do
     |> noreply()
   end
 
+  defp dispatch_command(:cd, [], state) do
+    append_and_noreply(
+      state,
+      {:warning, "Usage: /cd PATH  (use /pwd to see the current directory)"}
+    )
+  end
+
+  defp dispatch_command(:cd, [path_arg | _], state) do
+    expanded = Path.expand(path_arg)
+
+    cond do
+      not File.exists?(expanded) ->
+        append_and_noreply(state, {:warning, "Path does not exist: " <> expanded})
+
+      not File.dir?(expanded) ->
+        append_and_noreply(state, {:warning, "Not a directory: " <> expanded})
+
+      true ->
+        state
+        |> update_in_session(&Session.set_cwd(&1, expanded))
+        |> State.append_event({:info, "cwd → " <> expanded})
+        |> noreply()
+    end
+  end
+
+  defp dispatch_command(:pwd, _args, state) do
+    label =
+      case state.session.cwd do
+        nil -> "cwd: (none — using the process's own directory)"
+        path -> "cwd: " <> path
+      end
+
+    append_and_noreply(state, {:info, label})
+  end
+
   defp dispatch_command(:details, args, state) do
     new_value =
       case Enum.map(args, &String.downcase/1) do
@@ -378,12 +413,18 @@ defmodule ExAthena.Chat.Tui do
   end
 
   defp banner_events(%State{session: session} = state) do
-    state
-    |> State.append_event({:info, "ExAthena chat  (/help for commands, /exit to quit)"})
-    |> State.append_event(
-      {:info,
-       "provider=#{session.provider}  model=#{session.model}  mode=#{inspect(session.mode)}"}
-    )
+    state =
+      state
+      |> State.append_event({:info, "ExAthena chat  (/help for commands, /exit to quit)"})
+      |> State.append_event(
+        {:info,
+         "provider=#{session.provider}  model=#{session.model}  mode=#{inspect(session.mode)}"}
+      )
+
+    case session.cwd do
+      nil -> state
+      cwd -> State.append_event(state, {:info, "cwd=" <> cwd})
+    end
   end
 
   defp restore_logger(%State{prior_log_level: level} = state) do

--- a/lib/ex_athena/chat/tui/runner.ex
+++ b/lib/ex_athena/chat/tui/runner.ex
@@ -69,8 +69,15 @@ defmodule ExAthena.Chat.Tui.Runner do
       timeout_ms: @run_timeout_ms
     ]
 
-    apply_default_base_url(base, session.provider)
+    base
+    |> maybe_put_cwd(session.cwd)
+    |> apply_default_base_url(session.provider)
   end
+
+  defp maybe_put_cwd(opts, cwd) when is_binary(cwd) and cwd != "",
+    do: Keyword.put(opts, :cwd, cwd)
+
+  defp maybe_put_cwd(opts, _), do: opts
 
   @spec select_initial_model(String.t(), {:ok, [String.t()]} | {:error, term()}) ::
           {:ok, String.t()}

--- a/lib/ex_athena/chat/tui/view.ex
+++ b/lib/ex_athena/chat/tui/view.ex
@@ -86,6 +86,12 @@ defmodule ExAthena.Chat.Tui.View do
   @doc "Build the header status string from a session."
   @spec status_line(Session.t()) :: String.t()
   def status_line(%Session{} = s) do
+    cwd_suffix =
+      case s.cwd do
+        nil -> ""
+        path -> " · cwd=" <> Path.basename(path)
+      end
+
     IO.iodata_to_binary([
       to_string(s.model),
       " · ",
@@ -97,7 +103,8 @@ defmodule ExAthena.Chat.Tui.View do
       "/",
       Integer.to_string(Map.get(s.usage, :output_tokens, 0)),
       " tok · $",
-      :erlang.float_to_binary(s.cost_usd / 1.0, decimals: 4)
+      :erlang.float_to_binary(s.cost_usd / 1.0, decimals: 4),
+      cwd_suffix
     ])
   end
 

--- a/lib/mix/tasks/athena.chat.ex
+++ b/lib/mix/tasks/athena.chat.ex
@@ -14,12 +14,16 @@ defmodule Mix.Tasks.Athena.Chat do
       mix athena.chat --provider llamacpp
       mix athena.chat --provider ollama --model qwen2.5-coder:14b
       mix athena.chat --mode plan_and_solve
+      mix athena.chat -p ~/projects/my_app
 
   ## Flags
 
     * `--provider NAME` — `:ollama`, `:llamacpp`, `:openai`, etc. (overrides config).
     * `--model NAME`    — initial model (overrides config).
     * `--mode NAME`     — `react`, `plan_and_solve`, or `reflexion`.
+    * `--path PATH` (`-p`) — working directory for tools that touch the
+      filesystem. `~` is expanded. The chat process does NOT `cd` into
+      this path; tools just receive it as their `cwd`.
 
   ## Provider-specific requirements
 
@@ -38,13 +42,17 @@ defmodule Mix.Tasks.Athena.Chat do
     Mix.Task.run("app.start", [])
 
     {parsed, _rest, _invalid} =
-      OptionParser.parse(argv, strict: [model: :string, mode: :string, provider: :string])
+      OptionParser.parse(argv,
+        strict: [model: :string, mode: :string, provider: :string, path: :string],
+        aliases: [p: :path]
+      )
 
     opts =
       []
       |> maybe_put_provider(parsed[:provider])
       |> maybe_put(:model, parsed[:model])
       |> maybe_put_mode(parsed[:mode])
+      |> maybe_put_path(parsed[:path])
 
     Tui.start(opts)
   end
@@ -76,6 +84,19 @@ defmodule Mix.Tasks.Athena.Chat do
         "Unknown --mode #{raw}. Valid: " <> Enum.map_join(@valid_modes, ", ", &Atom.to_string/1)
       )
 
+      opts
+    end
+  end
+
+  defp maybe_put_path(opts, nil), do: opts
+
+  defp maybe_put_path(opts, raw) when is_binary(raw) do
+    expanded = Path.expand(raw)
+
+    if File.dir?(expanded) do
+      Keyword.put(opts, :cwd, expanded)
+    else
+      Mix.shell().error("--path #{raw} (expanded to #{expanded}) is not an existing directory.")
       opts
     end
   end

--- a/test/ex_athena/chat/commands_test.exs
+++ b/test/ex_athena/chat/commands_test.exs
@@ -82,9 +82,20 @@ defmodule ExAthena.Chat.CommandsTest do
     test "lists every slash command with a one-line description" do
       text = Commands.help_text()
 
-      for verb <- ~w(/model /mode /tools /clear /expand /details /help /exit) do
+      for verb <- ~w(/model /mode /tools /clear /expand /details /cd /pwd /help /exit) do
         assert text =~ verb, "expected help text to mention #{verb}"
       end
+    end
+  end
+
+  describe "parse/1 /cd and /pwd" do
+    test "parses /cd PATH" do
+      assert Commands.parse("/cd ~/test") == {:command, :cd, ["~/test"]}
+      assert Commands.parse("/cd") == {:command, :cd, []}
+    end
+
+    test "parses /pwd" do
+      assert Commands.parse("/pwd") == {:command, :pwd, []}
     end
   end
 


### PR DESCRIPTION
## Summary

Two ways to scope the agent to a project directory:

\`\`\`
mix athena.chat -p ~/test
mix athena.chat --path /Users/me/projects/foo
\`\`\`

Or mid-session:

\`\`\`
/cd ~/test       set the cwd
/pwd             print the cwd
\`\`\`

## Changes

- \`Session\` gains a \`cwd\` field + \`set_cwd/2\` setter.
- \`Mix.Tasks.Athena.Chat\` parses \`--path\` (alias \`-p\`), expands \`~\`, validates \`File.dir?\`, errors gracefully if missing.
- \`Commands\` registers \`:cd\` / \`:pwd\` verbs and lists them in \`/help\`.
- \`Tui\` dispatchers validate the path and update the session; reject nonexistent / non-directory paths with a warning row.
- \`Runner.build_run_opts\` threads \`cwd: session.cwd\` into the agent run opts (only when set) so filesystem tools resolve paths relative to it.
- \`View.status_line\` appends \`cwd=<basename>\`; banner adds a full \`cwd=<path>\` line on startup when \`--path\` was supplied.

The chat process itself does NOT \`chdir\` — only the agent loop's tools see the cwd via run opts.

## Test plan
- [x] \`mix compile --force\` clean
- [x] \`mix format\` clean
- [x] \`mix test\` — 755 tests, same 1 pre-existing flake
- [x] Parse tests for \`/cd\` and \`/pwd\` + updated \`/help\` coverage
- [ ] Manual: \`mix athena.chat -p ~/some-project\`; status bar shows \`cwd=some-project\`; ask the agent to list files and confirm it reads from that path
- [ ] Manual: from inside chat, \`/cd ~/other\` switches; \`/pwd\` reports current cwd