### PR TITLE
fix(tui): always show the effective cwd in status bar / banner / /pwd

### DIFF
--- a/lib/ex_athena/chat/tui.ex
+++ b/lib/ex_athena/chat/tui.ex
@@ -351,13 +351,19 @@ defmodule ExAthena.Chat.Tui do
   end
 
   defp dispatch_command(:pwd, _args, state) do
-    label =
+    {path, source} =
       case state.session.cwd do
-        nil -> "cwd: (none — using the process's own directory)"
-        path -> "cwd: " <> path
+        nil ->
+          case File.cwd() do
+            {:ok, p} -> {p, " (default, process cwd — use /cd or -p to override)"}
+            _ -> {"?", " (unable to read process cwd)"}
+          end
+
+        p ->
+          {p, " (set via /cd or --path)"}
       end
 
-    append_and_noreply(state, {:info, label})
+    append_and_noreply(state, {:info, "cwd: " <> path <> source})
   end
 
   defp dispatch_command(:details, args, state) do
@@ -413,18 +419,25 @@ defmodule ExAthena.Chat.Tui do
   end
 
   defp banner_events(%State{session: session} = state) do
-    state =
-      state
-      |> State.append_event({:info, "ExAthena chat  (/help for commands, /exit to quit)"})
-      |> State.append_event(
-        {:info,
-         "provider=#{session.provider}  model=#{session.model}  mode=#{inspect(session.mode)}"}
-      )
+    cwd_line =
+      case session.cwd do
+        nil ->
+          case File.cwd() do
+            {:ok, path} -> "cwd=" <> path <> "  (default — use /cd or -p to change)"
+            _ -> "cwd=(unknown)"
+          end
 
-    case session.cwd do
-      nil -> state
-      cwd -> State.append_event(state, {:info, "cwd=" <> cwd})
-    end
+        path ->
+          "cwd=" <> path
+      end
+
+    state
+    |> State.append_event({:info, "ExAthena chat  (/help for commands, /exit to quit)"})
+    |> State.append_event(
+      {:info,
+       "provider=#{session.provider}  model=#{session.model}  mode=#{inspect(session.mode)}"}
+    )
+    |> State.append_event({:info, cwd_line})
   end
 
   defp restore_logger(%State{prior_log_level: level} = state) do

--- a/lib/ex_athena/chat/tui/view.ex
+++ b/lib/ex_athena/chat/tui/view.ex
@@ -86,11 +86,7 @@ defmodule ExAthena.Chat.Tui.View do
   @doc "Build the header status string from a session."
   @spec status_line(Session.t()) :: String.t()
   def status_line(%Session{} = s) do
-    cwd_suffix =
-      case s.cwd do
-        nil -> ""
-        path -> " · cwd=" <> Path.basename(path)
-      end
+    cwd = s.cwd || effective_cwd()
 
     IO.iodata_to_binary([
       to_string(s.model),
@@ -104,8 +100,16 @@ defmodule ExAthena.Chat.Tui.View do
       Integer.to_string(Map.get(s.usage, :output_tokens, 0)),
       " tok · $",
       :erlang.float_to_binary(s.cost_usd / 1.0, decimals: 4),
-      cwd_suffix
+      " · cwd=",
+      Path.basename(cwd)
     ])
+  end
+
+  defp effective_cwd do
+    case File.cwd() do
+      {:ok, path} -> path
+      _ -> "?"
+    end
   end
 
   defp header(%State{session: session}) do


### PR DESCRIPTION
## Why

Without \`-p\`, \`session.cwd\` was \`nil\` and the status bar, banner, and \`/pwd\` all hid the cwd entirely — so users couldn't tell what directory the agent's tools were operating in. (Reported via screenshot: status bar showed everything except the cwd.)

## Fix

All three places now fall back to \`File.cwd!()\` when \`session.cwd\` is unset, and label the source:

- **Status bar (header):** always appends \` · cwd=<basename>\` — the basename so it stays short.
- **Banner (startup info row):** \`cwd=<full path>  (default — use /cd or -p to change)\` when defaulted, just the path when explicit.
- **/pwd command:** prints the full path with \`(default, process cwd — …)\` or \`(set via /cd or --path)\` suffix.

## Test plan
- [x] \`mix compile\` clean
- [x] \`mix format\` clean
- [x] \`mix test test/ex_athena/chat\` — 115 tests pass
- [ ] Manual: \`mix athena.chat\` (no flags), confirm status bar shows \`cwd=<basename>\` and \`/pwd\` reports the process cwd labeled as default
- [ ] Manual: \`mix athena.chat -p ~/some-dir\`, confirm same fields show the explicit path