### PR TITLE
feat(tui): slash-command autocomplete popup

### DIFF
--- a/lib/ex_athena/chat/commands.ex
+++ b/lib/ex_athena/chat/commands.ex
@@ -62,6 +62,49 @@ defmodule ExAthena.Chat.Commands do
     end
   end
 
+  @doc """
+  Canonical slash-prefixed verbs available for autocomplete, sorted
+  alphabetically. The aliases (`?` for help, `q`/`quit` for exit, etc.)
+  are intentionally excluded.
+  """
+  @spec verbs() :: [String.t()]
+  def verbs do
+    canonical = [
+      "model",
+      "mode",
+      "tools",
+      "clear",
+      "expand",
+      "details",
+      "cd",
+      "pwd",
+      "help",
+      "exit"
+    ]
+
+    canonical |> Enum.sort() |> Enum.map(&("/" <> &1))
+  end
+
+  @doc """
+  One-line summary for each verb, keyed by the slash-prefixed name.
+  Used to enrich autocomplete suggestions.
+  """
+  @spec descriptions() :: %{String.t() => String.t()}
+  def descriptions do
+    %{
+      "/model" => "pick or set the model",
+      "/mode" => "pick or set the runner mode",
+      "/tools" => "list available tools",
+      "/clear" => "wipe the conversation",
+      "/expand" => "show full Nth tool result",
+      "/details" => "toggle the details pane",
+      "/cd" => "set the working directory",
+      "/pwd" => "print the current directory",
+      "/help" => "show full usage help",
+      "/exit" => "leave the chat"
+    }
+  end
+
   @spec help_text() :: String.t()
   def help_text do
     """

--- a/lib/ex_athena/chat/tui.ex
+++ b/lib/ex_athena/chat/tui.ex
@@ -109,6 +109,39 @@ defmodule ExAthena.Chat.Tui do
     end
   end
 
+  # ── Autocomplete navigation (only when the popup is open) ─────────────
+
+  defp handle_key(%Event.Key{code: "up"}, %State{autocomplete: %{}} = state) do
+    {:noreply, State.move_autocomplete(state, -1)}
+  end
+
+  defp handle_key(%Event.Key{code: "down"}, %State{autocomplete: %{}} = state) do
+    {:noreply, State.move_autocomplete(state, +1)}
+  end
+
+  defp handle_key(%Event.Key{code: "esc"}, %State{autocomplete: %{}} = state) do
+    {:noreply, State.close_autocomplete(state)}
+  end
+
+  # Tab accepts the highlighted suggestion: replace the textarea contents
+  # with the selected verb (plus a trailing space so the user can immediately
+  # type arguments) and close the popup. If no popup is open Tab is dropped.
+  defp handle_key(%Event.Key{code: "tab"}, %State{autocomplete: %{}} = state) do
+    case State.selected_autocomplete(state) do
+      nil ->
+        {:noreply, State.close_autocomplete(state)}
+
+      verb ->
+        if state.input_ref do
+          ExRatatui.textarea_set_value(state.input_ref, verb <> " ")
+        end
+
+        {:noreply, State.close_autocomplete(state)}
+    end
+  end
+
+  defp handle_key(%Event.Key{code: "tab"}, state), do: {:noreply, state}
+
   defp handle_key(%Event.Key{code: "enter", modifiers: mods}, state) do
     cond do
       "shift" in mods ->
@@ -121,7 +154,10 @@ defmodule ExAthena.Chat.Tui do
         {:noreply, state}
 
       true ->
-        submit_input(state)
+        # Close the autocomplete popup (if any) and submit whatever is
+        # in the textarea. Don't auto-accept the suggestion — Tab is the
+        # acceptance affordance; Enter is the submit affordance.
+        state |> State.close_autocomplete() |> submit_input()
     end
   end
 
@@ -135,6 +171,15 @@ defmodule ExAthena.Chat.Tui do
     if state.input_ref do
       ExRatatui.textarea_handle_key(state.input_ref, code, mods)
     end
+
+    # After the textarea processes the key, re-read its value and refresh
+    # the autocomplete popup — opens it on `/`, filters it as the user
+    # types more, closes it once whitespace appears.
+    state =
+      case state.input_ref do
+        nil -> state
+        ref -> State.update_autocomplete(state, ExRatatui.textarea_get_value(ref))
+      end
 
     {:noreply, state}
   end

--- a/lib/ex_athena/chat/tui/state.ex
+++ b/lib/ex_athena/chat/tui/state.ex
@@ -11,7 +11,7 @@ defmodule ExAthena.Chat.Tui.State do
   NIF into pure-data unit tests.
   """
 
-  alias ExAthena.Chat.Session
+  alias ExAthena.Chat.{Commands, Session}
   alias ExAthena.Messages.{ToolCall, ToolResult}
   alias ExAthena.Result
   alias ExAthena.Streaming.Event, as: StreamEvent
@@ -62,9 +62,17 @@ defmodule ExAthena.Chat.Tui.State do
             # `{:content,...}` / `{:thinking,...}` loop events that the
             # mode emits with the full accumulated text.
             streamed_this_turn?: false,
+            # Slash-command autocomplete state. Open when the textarea
+            # starts with `/` and has no whitespace yet — the user is
+            # mid-verb. `items` are slash-prefixed verbs; `idx` is the
+            # selected row (0-based).
+            autocomplete: nil,
             footer: @default_footer,
             prior_log_level: :info,
             run_task: nil
+
+  @type autocomplete ::
+          nil | %{required(:items) => [String.t()], required(:idx) => non_neg_integer()}
 
   @type t :: %__MODULE__{
           session: Session.t(),
@@ -82,6 +90,7 @@ defmodule ExAthena.Chat.Tui.State do
           show_details: boolean(),
           stream_parser: %{mode: atom(), pending: String.t(), close_tag: String.t() | nil},
           streamed_this_turn?: boolean(),
+          autocomplete: autocomplete(),
           footer: String.t(),
           prior_log_level: atom(),
           run_task: pid() | nil
@@ -336,7 +345,8 @@ defmodule ExAthena.Chat.Tui.State do
         details_stream_buffer: "",
         details_thinking_buffer: "",
         stream_parser: %{mode: :outside, pending: "", close_tag: nil},
-        streamed_this_turn?: false
+        streamed_this_turn?: false,
+        autocomplete: nil
     }
   end
 
@@ -366,6 +376,89 @@ defmodule ExAthena.Chat.Tui.State do
   def current_popup_selection(%__MODULE__{popup: nil}), do: nil
   def current_popup_selection(%__MODULE__{popup: {_, [], _}}), do: nil
   def current_popup_selection(%__MODULE__{popup: {_, items, idx}}), do: Enum.at(items, idx)
+
+  # ─ Slash-command autocomplete ────────────────────────────────────────────
+
+  @doc """
+  Recompute the autocomplete suggestions from the current textarea value.
+  Opens the popup when the value starts with `/` and has no whitespace
+  yet (the user is typing the verb). Closes it otherwise. Preserves the
+  selected index when possible so re-rendering doesn't jump it.
+  """
+  @spec update_autocomplete(t(), String.t()) :: t()
+  def update_autocomplete(%__MODULE__{} = state, value) when is_binary(value) do
+    %{state | autocomplete: autocomplete_for(value, state.autocomplete)}
+  end
+
+  @doc false
+  def autocomplete_for(value, prior \\ nil)
+
+  def autocomplete_for("/" <> rest = _value, prior) when rest != "" do
+    if String.match?(rest, ~r/\s/) do
+      nil
+    else
+      build_autocomplete(rest, prior)
+    end
+  end
+
+  def autocomplete_for("/", prior) do
+    # Bare slash — show every verb.
+    build_autocomplete("", prior)
+  end
+
+  def autocomplete_for(_value, _prior), do: nil
+
+  defp build_autocomplete(rest, prior) do
+    needle = String.downcase(rest)
+
+    items =
+      Commands.verbs()
+      |> Enum.filter(fn "/" <> verb -> String.starts_with?(verb, needle) end)
+
+    case items do
+      [] ->
+        nil
+
+      _ ->
+        # Preserve the selected verb across keystrokes when it's still
+        # in the filtered list; otherwise reset to 0.
+        idx =
+          case prior do
+            %{items: prior_items, idx: prior_idx} ->
+              case Enum.at(prior_items, prior_idx) do
+                nil -> 0
+                selected -> Enum.find_index(items, &(&1 == selected)) || 0
+              end
+
+            _ ->
+              0
+          end
+
+        %{items: items, idx: idx}
+    end
+  end
+
+  @doc "Move the autocomplete selection by `delta` (wraps top/bottom)."
+  @spec move_autocomplete(t(), integer()) :: t()
+  def move_autocomplete(%__MODULE__{autocomplete: nil} = state, _delta), do: state
+
+  def move_autocomplete(%__MODULE__{autocomplete: %{items: items, idx: idx}} = state, delta)
+      when is_integer(delta) do
+    n = length(items)
+    new_idx = Integer.mod(idx + delta, n)
+    %{state | autocomplete: %{items: items, idx: new_idx}}
+  end
+
+  @doc "Return the currently-selected autocomplete entry (or nil)."
+  @spec selected_autocomplete(t()) :: String.t() | nil
+  def selected_autocomplete(%__MODULE__{autocomplete: nil}), do: nil
+
+  def selected_autocomplete(%__MODULE__{autocomplete: %{items: items, idx: idx}}),
+    do: Enum.at(items, idx)
+
+  @doc "Clear the autocomplete popup state."
+  @spec close_autocomplete(t()) :: t()
+  def close_autocomplete(%__MODULE__{} = state), do: %{state | autocomplete: nil}
 
   # ─ Streaming-tag parser ──────────────────────────────────────────────────
 

--- a/lib/ex_athena/chat/tui/view.ex
+++ b/lib/ex_athena/chat/tui/view.ex
@@ -20,12 +20,12 @@ defmodule ExAthena.Chat.Tui.View do
   rect with a centered `List`.
   """
 
-  alias ExAthena.Chat.{Session, Tui.State}
+  alias ExAthena.Chat.{Commands, Session, Tui.State}
   alias ExRatatui.Frame
   alias ExRatatui.Layout
   alias ExRatatui.Layout.Rect
   alias ExRatatui.Style
-  alias ExRatatui.Widgets.{Block, List, Paragraph, Popup, Textarea, Throbber, WidgetList}
+  alias ExRatatui.Widgets.{Block, Clear, List, Paragraph, Popup, Textarea, Throbber, WidgetList}
 
   @input_height 3
   @footer_height 1
@@ -59,7 +59,7 @@ defmodule ExAthena.Chat.Tui.View do
         {messages(state, messages_rect.width), messages_rect},
         {input(state), input_rect},
         {footer(state), footer_rect}
-      ] ++ details_widget(state, details_rect)
+      ] ++ details_widget(state, details_rect) ++ autocomplete_widget(state, input_rect)
 
     case popup(state, messages_rect) do
       nil -> widgets
@@ -81,6 +81,55 @@ defmodule ExAthena.Chat.Tui.View do
     # is two cells narrower. We use the interior width for wrap calculation.
     inner = max(details_rect.width - 2, 1)
     [{details(state, inner), details_rect}]
+  end
+
+  # ─ Autocomplete (slash command suggestions) ───────────────────────────────
+
+  @ac_max_rows 10
+  @ac_block %Block{
+    title: " commands · Tab to accept · Esc to close ",
+    borders: [:all],
+    border_type: :rounded,
+    border_style: %Style{fg: :light_blue}
+  }
+
+  defp autocomplete_widget(%State{autocomplete: nil}, _input_rect), do: []
+
+  defp autocomplete_widget(%State{autocomplete: %{items: items, idx: idx}}, input_rect) do
+    descs = Commands.descriptions()
+    label_width = items |> Enum.map(&String.length/1) |> Enum.max(fn -> 8 end)
+
+    labels =
+      Enum.map(items, fn cmd ->
+        desc = Map.get(descs, cmd, "")
+        pad = max(0, label_width - String.length(cmd))
+        cmd <> String.duplicate(" ", pad) <> "  " <> desc
+      end)
+
+    body_height = min(length(labels), @ac_max_rows)
+    # +2 for the block's top/bottom borders.
+    height = body_height + 2
+
+    inner_width = labels |> Enum.map(&String.length/1) |> Enum.max(fn -> 20 end)
+    width = min(inner_width + 4, input_rect.width)
+
+    rect = %Rect{
+      x: input_rect.x,
+      y: max(input_rect.y - height, 0),
+      width: width,
+      height: height
+    }
+
+    list = %List{
+      items: labels,
+      selected: idx,
+      block: @ac_block,
+      highlight_style: %Style{fg: :black, bg: :light_blue, modifiers: [:bold]},
+      highlight_symbol: "▸ "
+    }
+
+    # Clear the underlying messages area first so the popup is opaque.
+    [{%Clear{}, rect}, {list, rect}]
   end
 
   @doc "Build the header status string from a session."

--- a/test/ex_athena/chat/tui/state_test.exs
+++ b/test/ex_athena/chat/tui/state_test.exs
@@ -334,6 +334,41 @@ defmodule ExAthena.Chat.Tui.StateTest do
     end
   end
 
+  describe "autocomplete_for/2" do
+    test "is nil for an empty / non-slash input" do
+      assert State.autocomplete_for("") == nil
+      assert State.autocomplete_for("hello") == nil
+    end
+
+    test "opens with every verb on bare /" do
+      assert %{items: items, idx: 0} = State.autocomplete_for("/")
+      # All canonical verbs.
+      assert "/help" in items
+      assert "/cd" in items
+      assert "/details" in items
+    end
+
+    test "filters to verbs starting with the typed prefix" do
+      assert %{items: ["/cd"], idx: 0} = State.autocomplete_for("/cd")
+      assert %{items: items, idx: 0} = State.autocomplete_for("/c")
+      # /cd and /clear both start with /c.
+      assert "/cd" in items
+      assert "/clear" in items
+      refute "/help" in items
+    end
+
+    test "closes when whitespace appears in the verb" do
+      assert State.autocomplete_for("/cd ~/test") == nil
+      assert State.autocomplete_for("/help ") == nil
+    end
+
+    test "preserves the selected verb across keystrokes when still in filtered list" do
+      prior = %{items: ["/cd", "/clear"], idx: 1}
+      # Narrow /c → /cl — /clear should remain selected (still in the list).
+      assert %{items: ["/clear"], idx: 0} = State.autocomplete_for("/cl", prior)
+    end
+  end
+
   describe "parse_stream_chunk/2 — streaming <think> parser" do
     @start %{mode: :outside, pending: "", close_tag: nil}
 


### PR DESCRIPTION
## Summary

When the user types `/` (or `/m`, `/cl`, ...) a floating popup appears just above the input bar listing matching slash commands with one-line descriptions. Filters live as more characters are typed; closes once whitespace appears in the verb.

**Keys (only when popup is open):**
- `Tab` — accept highlighted suggestion (replaces textarea with `<verb> `)
- `Up` / `Down` — navigate (wraps top↔bottom)
- `Esc` — close
- `Enter` — still submits (intentional; Tab is the acceptance key)

## Changes

- `Commands.verbs/0` — canonical slash-prefixed verbs.
- `Commands.descriptions/0` — per-verb one-liners.
- `State.autocomplete_for/2` — builds suggestion list from textarea value; preserves the selected verb across keystrokes when still in the filtered list.
- `Tui.forward_to_textarea` — re-reads textarea value after each keypress and refreshes the popup. Tab/Up/Down/Esc are intercepted only while the popup is open.
- `View` renders a `Clear + List` pair just above the input rect with a rounded blue border and `▸ ` highlight symbol. Sizes itself to the widest "verb  description" line.
- Reset on `clear_session/1` so the popup doesn't survive `/clear`.

## Test plan
- [x] `mix compile --force` clean
- [x] `mix format` clean
- [x] `mix test` — 760 tests (5 new), same 1 pre-existing flake
- [ ] Manual: `mix athena.chat`, type `/` and confirm a popup appears with all verbs
- [ ] Manual: type `/c` and confirm filter narrows to `/cd` and `/clear`
- [ ] Manual: Tab accepts; Up/Down navigate; Esc closes; typing a space closes