### PR TITLE
fix(tui): auto-scroll both panes to the bottom as content grows

### DIFF
--- a/lib/ex_athena/chat/tui/view.ex
+++ b/lib/ex_athena/chat/tui/view.ex
@@ -56,7 +56,7 @@ defmodule ExAthena.Chat.Tui.View do
     widgets =
       [
         {header(state), header_rect},
-        {messages(state, messages_rect.width), messages_rect},
+        {messages(state, messages_rect.width, messages_rect.height), messages_rect},
         {input(state), input_rect},
         {footer(state), footer_rect}
       ] ++ details_widget(state, details_rect) ++ autocomplete_widget(state, input_rect)
@@ -77,10 +77,11 @@ defmodule ExAthena.Chat.Tui.View do
   defp details_widget(_state, nil), do: []
 
   defp details_widget(state, details_rect) do
-    # The details Block draws a left + right border, so the interior width
-    # is two cells narrower. We use the interior width for wrap calculation.
-    inner = max(details_rect.width - 2, 1)
-    [{details(state, inner), details_rect}]
+    # The details Block draws borders on all four sides, so the interior
+    # is two cells narrower AND two cells shorter than the outer rect.
+    inner_w = max(details_rect.width - 2, 1)
+    inner_h = max(details_rect.height - 2, 1)
+    [{details(state, inner_w, inner_h), details_rect}]
   end
 
   # ─ Autocomplete (slash command suggestions) ───────────────────────────────
@@ -173,17 +174,17 @@ defmodule ExAthena.Chat.Tui.View do
          %State{
            events: events,
            loading?: loading?,
-           scroll_offset: scroll,
            session: session
          },
-         width
+         width,
+         height
        ) do
     items =
       events
       |> Enum.map(&row_widget(&1, session.model, width))
       |> append_throbber(loading?)
 
-    %WidgetList{items: items, scroll_offset: scroll}
+    %WidgetList{items: items, scroll_offset: auto_scroll(items, height)}
   end
 
   @details_block %Block{
@@ -193,10 +194,22 @@ defmodule ExAthena.Chat.Tui.View do
     border_style: %Style{fg: :dark_gray}
   }
 
-  defp details(%State{details: details, details_scroll_offset: scroll}, width) do
+  defp details(%State{details: details}, width, height) do
     items = Enum.map(details, &detail_row_widget(&1, width))
-    %WidgetList{items: items, scroll_offset: scroll, block: @details_block}
+    %WidgetList{items: items, scroll_offset: auto_scroll(items, height), block: @details_block}
   end
+
+  # Compute a scroll_offset that pins the WidgetList to the bottom: sum
+  # the item heights, subtract the viewport height, clamp at 0. Once the
+  # content fits in the viewport this is 0 (top of list); as content
+  # grows past `height`, the offset advances so the latest items stay
+  # visible.
+  defp auto_scroll(items, height) when is_integer(height) and height > 0 do
+    total = items |> Enum.map(fn {_w, h} -> h end) |> Enum.sum()
+    max(total - height, 0)
+  end
+
+  defp auto_scroll(_items, _height), do: 0
 
   # Estimate the number of rows a string occupies once it's wrapped at
   # `width` columns. Counts each explicit `\n` as a line break and uses

--- a/test/ex_athena/chat/tui/view_test.exs
+++ b/test/ex_athena/chat/tui/view_test.exs
@@ -190,17 +190,36 @@ defmodule ExAthena.Chat.Tui.ViewTest do
              end)
     end
 
-    test "scroll_offset is forwarded to the WidgetList",
+    test "scroll_offset auto-pins to the bottom when content overflows the viewport",
          %{session: session, frame: frame} do
+      # Fill the messages pane with more rows than fit in the frame.
       state =
         session
         |> State.new()
-        |> Map.put(:scroll_offset, 7)
+        |> then(fn s ->
+          Enum.reduce(1..50, s, fn n, acc ->
+            State.append_event(acc, {:assistant, "line #{n}"})
+          end)
+        end)
 
       widgets = View.build_frame(state, frame)
       list = find_widget_list(widgets)
 
-      assert list.scroll_offset == 7
+      # Total content height exceeds viewport — auto-scroll should be > 0.
+      assert list.scroll_offset > 0
+    end
+
+    test "scroll_offset stays at 0 when content fits in the viewport",
+         %{session: session, frame: frame} do
+      state =
+        session
+        |> State.new()
+        |> State.append_event({:assistant, "just one line"})
+
+      widgets = View.build_frame(state, frame)
+      list = find_widget_list(widgets)
+
+      assert list.scroll_offset == 0
     end
   end
 


### PR DESCRIPTION
## Why

\`WidgetList.scroll_offset\` was hardcoded to \`state.scroll_offset\` (always 0), so once the messages or details pane filled past the viewport the bottom got silently clipped — newest tool calls and replies vanished off-screen. Reported via screenshot.

## Fix

View computes the scroll offset per render: sum each item's row height, subtract the viewport height, clamp at 0. While content fits the offset stays 0; as it grows past the viewport the offset advances so the newest content stays visible.

- \`messages/3\` now takes \`width, height\`; computes \`auto_scroll(items, height)\`.
- \`details/3\` same; accounts for the details Block's top + bottom borders (\`inner_h = rect.height - 2\`).
- Updated the one view test that asserted the old "forward state.scroll_offset" behavior to assert the new "pins to bottom on overflow / stays at 0 when content fits" behavior.

The unused \`state.scroll_offset\` field stays in place — no-op for now, will be wired to manual scroll when keys are added.

## Test plan
- [x] \`mix compile\` clean
- [x] \`mix format\` clean
- [x] \`mix test test/ex_athena/chat\` — 121 tests pass (2 updated)
- [ ] Manual: \`mix athena.chat\`, fill the screen with several long turns, confirm both left and right panes keep the newest content visible