### PR TITLE
feat(tui): Changes tab in details pane with live git diff in cwd

### DIFF
--- a/lib/ex_athena/chat/commands.ex
+++ b/lib/ex_athena/chat/commands.ex
@@ -32,6 +32,9 @@ defmodule ExAthena.Chat.Commands do
     "details" => :details,
     "cd" => :cd,
     "pwd" => :pwd,
+    "tab" => :tab,
+    "diff" => :diff,
+    "timeline" => :timeline,
     "help" => :help,
     "?" => :help
   }
@@ -78,6 +81,9 @@ defmodule ExAthena.Chat.Commands do
       "details",
       "cd",
       "pwd",
+      "tab",
+      "diff",
+      "timeline",
       "help",
       "exit"
     ]
@@ -100,6 +106,9 @@ defmodule ExAthena.Chat.Commands do
       "/details" => "toggle the details pane",
       "/cd" => "set the working directory",
       "/pwd" => "print the current directory",
+      "/tab" => "switch the details tab (timeline ↔ changes)",
+      "/diff" => "show the Changes tab (git diff in cwd)",
+      "/timeline" => "show the Timeline tab",
       "/help" => "show full usage help",
       "/exit" => "leave the chat"
     }
@@ -123,6 +132,9 @@ defmodule ExAthena.Chat.Commands do
       /cd PATH           set the working directory for tools
                          (`~` is expanded; the chat process does not chdir)
       /pwd               print the current working directory
+      /tab               cycle the details-pane tab (Timeline ↔ Changes)
+      /diff              switch to the Changes tab (live `git diff` in cwd)
+      /timeline          switch back to the Timeline tab
       /help, /?          show this help
       /exit, /quit, /q   leave the chat
 

--- a/lib/ex_athena/chat/tui.ex
+++ b/lib/ex_athena/chat/tui.ex
@@ -79,6 +79,7 @@ defmodule ExAthena.Chat.Tui do
       |> Map.put(:input_ref, input_ref)
       |> Map.put(:prior_log_level, prior_log_level)
       |> banner_events()
+      |> maybe_kick_git_diff()
 
     schedule_tick()
 
@@ -235,7 +236,18 @@ defmodule ExAthena.Chat.Tui do
   end
 
   def handle_info({:athena_event, event}, %State{} = state) do
-    {:noreply, State.append_loop_event(state, event)}
+    state = State.append_loop_event(state, event)
+
+    # Kick off a fresh `git diff` whenever a tool result lands — that's
+    # the point where the working tree may have changed. Bounded async,
+    # never blocks the UI.
+    state =
+      case event do
+        {:tool_result, _} -> maybe_kick_git_diff(state)
+        _ -> state
+      end
+
+    {:noreply, state}
   end
 
   def handle_info({:athena_done, result}, %State{} = state) do
@@ -246,8 +258,13 @@ defmodule ExAthena.Chat.Tui do
       |> State.set_loading(false)
       |> Map.put(:run_task, nil)
       |> append_status_row()
+      |> maybe_kick_git_diff()
 
     {:noreply, new_state}
+  end
+
+  def handle_info({:git_diff, lines}, %State{} = state) when is_list(lines) do
+    {:noreply, State.set_git_diff(state, lines)}
   end
 
   def handle_info({:athena_error, reason}, %State{} = state) do
@@ -370,6 +387,31 @@ defmodule ExAthena.Chat.Tui do
     |> noreply()
   end
 
+  defp dispatch_command(:tab, _args, state) do
+    state = State.cycle_details_tab(state)
+    label = state.details_tab |> Atom.to_string() |> String.capitalize()
+    state = maybe_kick_git_diff(state)
+
+    state
+    |> State.append_event({:info, "details tab → " <> label})
+    |> noreply()
+  end
+
+  defp dispatch_command(:diff, _args, state) do
+    state
+    |> State.set_details_tab(:changes)
+    |> State.append_event({:info, "details tab → Changes"})
+    |> maybe_kick_git_diff()
+    |> noreply()
+  end
+
+  defp dispatch_command(:timeline, _args, state) do
+    state
+    |> State.set_details_tab(:timeline)
+    |> State.append_event({:info, "details tab → Timeline"})
+    |> noreply()
+  end
+
   defp dispatch_command(:cd, [], state) do
     append_and_noreply(
       state,
@@ -391,6 +433,7 @@ defmodule ExAthena.Chat.Tui do
         state
         |> update_in_session(&Session.set_cwd(&1, expanded))
         |> State.append_event({:info, "cwd → " <> expanded})
+        |> maybe_kick_git_diff()
         |> noreply()
     end
   end
@@ -483,6 +526,42 @@ defmodule ExAthena.Chat.Tui do
        "provider=#{session.provider}  model=#{session.model}  mode=#{inspect(session.mode)}"}
     )
     |> State.append_event({:info, cwd_line})
+  end
+
+  # ── Git diff (Changes tab) ────────────────────────────────────────────
+
+  # Spawn an unsupervised Task that shells out to `git diff HEAD` in the
+  # session's cwd and sends `{:git_diff, lines}` back to this process.
+  # Wrapped in try/rescue/catch per the CLAUDE.md Task.start guidance.
+  # Errors / non-git directories result in an empty diff (silently).
+  defp maybe_kick_git_diff(state) do
+    parent = self()
+    cwd = state.session.cwd || File.cwd!()
+
+    Task.start(fn ->
+      try do
+        lines = fetch_git_diff(cwd)
+        send(parent, {:git_diff, lines})
+      rescue
+        _ -> send(parent, {:git_diff, []})
+      catch
+        _, _ -> send(parent, {:git_diff, []})
+      end
+    end)
+
+    state
+  end
+
+  defp fetch_git_diff(cwd) do
+    case System.cmd("git", ["diff", "HEAD"], cd: cwd, stderr_to_stdout: true) do
+      {output, 0} ->
+        output |> String.trim_trailing("\n") |> String.split("\n")
+
+      _ ->
+        []
+    end
+  rescue
+    _ -> []
   end
 
   defp restore_logger(%State{prior_log_level: level} = state) do

--- a/lib/ex_athena/chat/tui/state.ex
+++ b/lib/ex_athena/chat/tui/state.ex
@@ -67,6 +67,12 @@ defmodule ExAthena.Chat.Tui.State do
             # mid-verb. `items` are slash-prefixed verbs; `idx` is the
             # selected row (0-based).
             autocomplete: nil,
+            # Which tab is active in the right details pane.
+            details_tab: :timeline,
+            # Lines of `git diff HEAD` for the :changes tab. Refreshed
+            # asynchronously after every tool result and on /cd.
+            git_diff_lines: [],
+            git_diff_scroll_offset: 0,
             footer: @default_footer,
             prior_log_level: :info,
             run_task: nil
@@ -91,6 +97,9 @@ defmodule ExAthena.Chat.Tui.State do
           stream_parser: %{mode: atom(), pending: String.t(), close_tag: String.t() | nil},
           streamed_this_turn?: boolean(),
           autocomplete: autocomplete(),
+          details_tab: :timeline | :changes,
+          git_diff_lines: [String.t()],
+          git_diff_scroll_offset: non_neg_integer(),
           footer: String.t(),
           prior_log_level: atom(),
           run_task: pid() | nil
@@ -376,6 +385,33 @@ defmodule ExAthena.Chat.Tui.State do
   def current_popup_selection(%__MODULE__{popup: nil}), do: nil
   def current_popup_selection(%__MODULE__{popup: {_, [], _}}), do: nil
   def current_popup_selection(%__MODULE__{popup: {_, items, idx}}), do: Enum.at(items, idx)
+
+  # ─ Details-pane tabs (timeline / changes) ────────────────────────────────
+
+  @details_tabs [:timeline, :changes]
+
+  @doc "Returns the ordered list of tab atoms used in the details pane."
+  @spec details_tabs() :: [atom()]
+  def details_tabs, do: @details_tabs
+
+  @doc "Switch to the next tab in order, wrapping to the first."
+  @spec cycle_details_tab(t()) :: t()
+  def cycle_details_tab(%__MODULE__{details_tab: tab} = state) do
+    idx = Enum.find_index(@details_tabs, &(&1 == tab)) || 0
+    next = Enum.at(@details_tabs, Integer.mod(idx + 1, length(@details_tabs)))
+    %{state | details_tab: next}
+  end
+
+  @spec set_details_tab(t(), atom()) :: t()
+  def set_details_tab(%__MODULE__{} = state, tab) when tab in @details_tabs do
+    %{state | details_tab: tab}
+  end
+
+  @doc "Replace the cached `git diff` output with a fresh list of lines."
+  @spec set_git_diff(t(), [String.t()]) :: t()
+  def set_git_diff(%__MODULE__{} = state, lines) when is_list(lines) do
+    %{state | git_diff_lines: lines}
+  end
 
   # ─ Slash-command autocomplete ────────────────────────────────────────────
 

--- a/lib/ex_athena/chat/tui/view.ex
+++ b/lib/ex_athena/chat/tui/view.ex
@@ -77,12 +77,43 @@ defmodule ExAthena.Chat.Tui.View do
   defp details_widget(_state, nil), do: []
 
   defp details_widget(state, details_rect) do
-    # The details Block draws borders on all four sides, so the interior
+    [tabs_rect, content_rect] =
+      Layout.split(details_rect, :vertical, [{:length, 1}, {:min, 0}])
+
+    # The content Block draws borders on all four sides, so the interior
     # is two cells narrower AND two cells shorter than the outer rect.
-    inner_w = max(details_rect.width - 2, 1)
-    inner_h = max(details_rect.height - 2, 1)
-    [{details(state, inner_w, inner_h), details_rect}]
+    inner_w = max(content_rect.width - 2, 1)
+    inner_h = max(content_rect.height - 2, 1)
+
+    content_widget =
+      case state.details_tab do
+        :timeline -> details(state, inner_w, inner_h)
+        :changes -> changes(state, inner_w, inner_h)
+      end
+
+    [
+      {details_tabs_widget(state), tabs_rect},
+      {content_widget, content_rect}
+    ]
   end
+
+  defp details_tabs_widget(%State{details_tab: tab}) do
+    tabs = State.details_tabs()
+    titles = Enum.map(tabs, &tab_title/1)
+    selected = Enum.find_index(tabs, &(&1 == tab)) || 0
+
+    %ExRatatui.Widgets.Tabs{
+      titles: titles,
+      selected: selected,
+      style: %Style{fg: :dark_gray},
+      highlight_style: %Style{fg: :light_blue, modifiers: [:bold]},
+      divider: " │ "
+    }
+  end
+
+  defp tab_title(:timeline), do: " Timeline "
+  defp tab_title(:changes), do: " Changes (git diff) "
+  defp tab_title(other), do: " #{other} "
 
   # ─ Autocomplete (slash command suggestions) ───────────────────────────────
 
@@ -198,6 +229,44 @@ defmodule ExAthena.Chat.Tui.View do
     items = Enum.map(details, &detail_row_widget(&1, width))
     %WidgetList{items: items, scroll_offset: auto_scroll(items, height), block: @details_block}
   end
+
+  @changes_block %Block{
+    title: " changes · git diff HEAD ",
+    borders: [:left, :top, :bottom, :right],
+    border_type: :rounded,
+    border_style: %Style{fg: :dark_gray}
+  }
+
+  defp changes(%State{git_diff_lines: []}, _width, _height) do
+    %WidgetList{
+      items: [
+        {%Paragraph{text: "No changes vs HEAD", style: %Style{fg: :dark_gray}}, 1}
+      ],
+      block: @changes_block
+    }
+  end
+
+  defp changes(%State{git_diff_lines: lines}, width, height) do
+    items = Enum.map(lines, &diff_row_widget(&1, width))
+    %WidgetList{items: items, scroll_offset: auto_scroll(items, height), block: @changes_block}
+  end
+
+  # Color each diff line by its first character: `+` green, `-` red,
+  # `@@` (hunk header) cyan, `diff/index/---/+++` (file headers) yellow,
+  # everything else dim. Each line is a height-1 wrapped Paragraph.
+  defp diff_row_widget(line, width) do
+    style = diff_line_style(line)
+    {%Paragraph{text: line, style: style, wrap: true}, wrapped_height(line, width)}
+  end
+
+  defp diff_line_style("+++ " <> _), do: %Style{fg: :light_yellow, modifiers: [:bold]}
+  defp diff_line_style("--- " <> _), do: %Style{fg: :light_yellow, modifiers: [:bold]}
+  defp diff_line_style("diff " <> _), do: %Style{fg: :light_yellow, modifiers: [:bold]}
+  defp diff_line_style("index " <> _), do: %Style{fg: :dark_gray}
+  defp diff_line_style("@@" <> _), do: %Style{fg: :cyan}
+  defp diff_line_style("+" <> _), do: %Style{fg: :green}
+  defp diff_line_style("-" <> _), do: %Style{fg: :red}
+  defp diff_line_style(_), do: %Style{fg: :dark_gray}
 
   # Compute a scroll_offset that pins the WidgetList to the bottom: sum
   # the item heights, subtract the viewport height, clamp at 0. Once the

--- a/test/ex_athena/chat/commands_test.exs
+++ b/test/ex_athena/chat/commands_test.exs
@@ -82,7 +82,8 @@ defmodule ExAthena.Chat.CommandsTest do
     test "lists every slash command with a one-line description" do
       text = Commands.help_text()
 
-      for verb <- ~w(/model /mode /tools /clear /expand /details /cd /pwd /help /exit) do
+      for verb <-
+            ~w(/model /mode /tools /clear /expand /details /cd /pwd /tab /diff /timeline /help /exit) do
         assert text =~ verb, "expected help text to mention #{verb}"
       end
     end
@@ -107,6 +108,14 @@ defmodule ExAthena.Chat.CommandsTest do
     test "parses /details on and /details off" do
       assert Commands.parse("/details on") == {:command, :details, ["on"]}
       assert Commands.parse("/details off") == {:command, :details, ["off"]}
+    end
+  end
+
+  describe "parse/1 details tab commands" do
+    test "parses /tab, /diff, /timeline" do
+      assert Commands.parse("/tab") == {:command, :tab, []}
+      assert Commands.parse("/diff") == {:command, :diff, []}
+      assert Commands.parse("/timeline") == {:command, :timeline, []}
     end
   end
 end

--- a/test/ex_athena/chat/tui/state_test.exs
+++ b/test/ex_athena/chat/tui/state_test.exs
@@ -334,6 +334,38 @@ defmodule ExAthena.Chat.Tui.StateTest do
     end
   end
 
+  describe "details tabs" do
+    test "default details_tab is :timeline" do
+      state = Session.new() |> State.new()
+      assert state.details_tab == :timeline
+    end
+
+    test "cycle_details_tab/1 walks the tab list and wraps" do
+      state = Session.new() |> State.new()
+      assert State.cycle_details_tab(state).details_tab == :changes
+
+      assert state
+             |> State.cycle_details_tab()
+             |> State.cycle_details_tab()
+             |> Map.get(:details_tab) == :timeline
+    end
+
+    test "set_details_tab/2 jumps to a specific tab" do
+      state = Session.new() |> State.new()
+      assert State.set_details_tab(state, :changes).details_tab == :changes
+      assert State.set_details_tab(state, :timeline).details_tab == :timeline
+    end
+
+    test "set_git_diff/2 stores the line list" do
+      state =
+        Session.new()
+        |> State.new()
+        |> State.set_git_diff(["diff --git a/foo b/foo", "+added"])
+
+      assert state.git_diff_lines == ["diff --git a/foo b/foo", "+added"]
+    end
+  end
+
   describe "autocomplete_for/2" do
     test "is nil for an empty / non-slash input" do
       assert State.autocomplete_for("") == nil


### PR DESCRIPTION
## Summary

The TUI details pane now has a 1-row tab strip at the top splitting it into two views:

- **Timeline** (default) — the existing event stream.
- **Changes** — colored output of `git diff HEAD` in the session cwd.

Switch with:
- `/tab` — cycle tabs
- `/diff` — jump to Changes (also kicks a fresh diff fetch)
- `/timeline` — jump back to Timeline

This is the TUI counterpart to PR #67 (which added a similar panel in the web LiveView).

## Implementation

- The diff is fetched **async** via an unsupervised `Task` that shells out to `git diff HEAD` in `session.cwd` (falling back to `File.cwd!()`), so the UI never blocks.
- Refresh kicks off on: mount, every `:tool_result` event (working tree may have changed), `:athena_done`, `/cd`, and `/diff`.
- Output is rendered with line-by-line coloring: `+` green, `-` red, `@@` cyan, file headers (`diff/---/+++`) bold yellow, context dim.
- Empty diff shows "No changes vs HEAD". Errors and non-git directories silently yield an empty diff.

### Files
- `Tui.State` — `details_tab`, `git_diff_lines`, `git_diff_scroll_offset` + cycle/set/set_git_diff helpers.
- `Tui.View` — vertical split of the details rect (Tabs strip + content block); renders timeline or changes based on `details_tab`. Colored diff renderer.
- `Chat.Commands` — `:tab` / `:diff` / `:timeline` verbs and updated help text.
- `Tui` — `{:git_diff, lines}` handler and `maybe_kick_git_diff/1` triggers at the points above.

## Test plan
- [x] `mix compile --force` clean
- [x] `mix format` clean
- [x] `mix test` — 766 tests (4 new in State, 1 new in Commands), same 1 pre-existing flake
- [ ] Manual: `mix athena.chat` in a git repo, `/diff`, confirm `git diff HEAD` shows colored
- [ ] Manual: edit a file via a tool call, confirm the Changes tab refreshes after `:tool_result`
- [ ] Manual: `/cd` into a non-git directory, confirm "No changes vs HEAD" appears (and no crash)