### PR TITLE
fix(tui): make Changes tab self-explanatory when diff is empty or fails

### DIFF
--- a/lib/ex_athena/chat/tui.ex
+++ b/lib/ex_athena/chat/tui.ex
@@ -555,13 +555,30 @@ defmodule ExAthena.Chat.Tui do
   defp fetch_git_diff(cwd) do
     case System.cmd("git", ["diff", "HEAD"], cd: cwd, stderr_to_stdout: true) do
       {output, 0} ->
-        output |> String.trim_trailing("\n") |> String.split("\n")
+        case String.trim(output) do
+          "" -> ["(no changes vs HEAD)", "cwd: #{cwd}"]
+          trimmed -> String.split(trimmed, "\n")
+        end
 
-      _ ->
-        []
+      {output, exit_code} ->
+        # Common case: not a git repo, returns "fatal: not a git repository".
+        [
+          "git diff failed (exit #{exit_code}) in #{cwd}:"
+          | String.split(String.trim(output), "\n")
+        ]
     end
   rescue
-    _ -> []
+    e in ErlangError ->
+      case e.original do
+        :enoent ->
+          ["`git` executable not found on PATH"]
+
+        other ->
+          ["git diff crashed: " <> inspect(other)]
+      end
+
+    e ->
+      ["git diff crashed: " <> Exception.message(e)]
   end
 
   defp restore_logger(%State{prior_log_level: level} = state) do

--- a/lib/ex_athena/chat/tui/view.ex
+++ b/lib/ex_athena/chat/tui/view.ex
@@ -97,9 +97,9 @@ defmodule ExAthena.Chat.Tui.View do
     ]
   end
 
-  defp details_tabs_widget(%State{details_tab: tab}) do
+  defp details_tabs_widget(%State{details_tab: tab} = state) do
     tabs = State.details_tabs()
-    titles = Enum.map(tabs, &tab_title/1)
+    titles = Enum.map(tabs, &tab_title(&1, state))
     selected = Enum.find_index(tabs, &(&1 == tab)) || 0
 
     %ExRatatui.Widgets.Tabs{
@@ -111,9 +111,21 @@ defmodule ExAthena.Chat.Tui.View do
     }
   end
 
-  defp tab_title(:timeline), do: " Timeline "
-  defp tab_title(:changes), do: " Changes (git diff) "
-  defp tab_title(other), do: " #{other} "
+  defp tab_title(:timeline, _state), do: " Timeline "
+
+  defp tab_title(:changes, %State{git_diff_lines: lines}) do
+    case changed_files_count(lines) do
+      0 -> " Changes "
+      n -> " Changes (#{n} file#{if n == 1, do: "", else: "s"}) "
+    end
+  end
+
+  defp tab_title(other, _state), do: " #{other} "
+
+  # Quick count of `diff --git` headers — one per modified file.
+  defp changed_files_count(lines) do
+    Enum.count(lines, &String.starts_with?(&1, "diff --git "))
+  end
 
   # ─ Autocomplete (slash command suggestions) ───────────────────────────────
 
@@ -240,7 +252,10 @@ defmodule ExAthena.Chat.Tui.View do
   defp changes(%State{git_diff_lines: []}, _width, _height) do
     %WidgetList{
       items: [
-        {%Paragraph{text: "No changes vs HEAD", style: %Style{fg: :dark_gray}}, 1}
+        {%Paragraph{
+           text: "Fetching `git diff` … (run /diff to refresh)",
+           style: %Style{fg: :dark_gray}
+         }, 1}
       ],
       block: @changes_block
     }
@@ -266,6 +281,11 @@ defmodule ExAthena.Chat.Tui.View do
   defp diff_line_style("@@" <> _), do: %Style{fg: :cyan}
   defp diff_line_style("+" <> _), do: %Style{fg: :green}
   defp diff_line_style("-" <> _), do: %Style{fg: :red}
+  defp diff_line_style("(no changes vs HEAD)"), do: %Style{fg: :dark_gray, modifiers: [:italic]}
+  defp diff_line_style("git diff failed" <> _), do: %Style{fg: :red, modifiers: [:bold]}
+  defp diff_line_style("git diff crashed" <> _), do: %Style{fg: :red, modifiers: [:bold]}
+  defp diff_line_style("`git` executable" <> _), do: %Style{fg: :red, modifiers: [:bold]}
+  defp diff_line_style("cwd: " <> _), do: %Style{fg: :dark_gray, modifiers: [:italic]}
   defp diff_line_style(_), do: %Style{fg: :dark_gray}
 
   # Compute a scroll_offset that pins the WidgetList to the bottom: sum


### PR DESCRIPTION
## Why

User reported "diff not showing for cwd" — turns out the Changes tab rendered nothing whenever \`git diff HEAD\` returned empty, errored, or git wasn't on PATH. So you couldn't tell empty-vs-broken at a glance.

## Fix

\`fetch_git_diff/1\` now always returns informational lines:

- **Empty diff** → \`["(no changes vs HEAD)", "cwd: <path>"]\` — confirms which cwd we checked.
- **Non-zero exit** → \`["git diff failed (exit N) in <cwd>:", stderr…]\` — surfaces the actual git error (e.g. \"not a git repository\").
- **git not on PATH** → \`["\`git\` executable not found on PATH"]\`.
- **Other crash** → \`["git diff crashed: <reason>"]\`.

The diff-line-style renderer recognizes these markers: empty/cwd lines are dim italic, error lines are bold red.

Also adds a "(N files)" badge to the **Changes** tab title (counted from \`diff --git \` headers) so it's obvious at a glance that changes exist before switching tabs. The pre-fetch empty state now reads "Fetching \`git diff\` …" with a hint to run /diff.

## Test plan
- [x] \`mix compile\` clean
- [x] \`mix format\` clean
- [x] \`mix test test/ex_athena/chat\` — 126 tests pass
- [ ] Manual: launch in a git repo with no changes → tab shows "(no changes vs HEAD)" and the cwd
- [ ] Manual: launch in a non-git dir → tab shows the git error
- [ ] Manual: make an uncommitted change → "(N files)" appears in the tab title