### PR TITLE
feat(tui): Enter accepts the highlighted autocomplete suggestion

### DIFF
--- a/lib/ex_athena/chat/tui.ex
+++ b/lib/ex_athena/chat/tui.ex
@@ -124,27 +124,24 @@ defmodule ExAthena.Chat.Tui do
     {:noreply, State.close_autocomplete(state)}
   end
 
-  # Tab accepts the highlighted suggestion: replace the textarea contents
-  # with the selected verb (plus a trailing space so the user can immediately
-  # type arguments) and close the popup. If no popup is open Tab is dropped.
+  # Tab or Enter accepts the highlighted suggestion: replace the textarea
+  # contents with the selected verb (plus a trailing space so the user can
+  # immediately type arguments) and close the popup. Picking from the menu
+  # should complete the command text in the input box, not fire off the
+  # half-typed prefix as a chat message.
   defp handle_key(%Event.Key{code: "tab"}, %State{autocomplete: %{}} = state) do
-    case State.selected_autocomplete(state) do
-      nil ->
-        {:noreply, State.close_autocomplete(state)}
-
-      verb ->
-        if state.input_ref do
-          ExRatatui.textarea_set_value(state.input_ref, verb <> " ")
-        end
-
-        {:noreply, State.close_autocomplete(state)}
-    end
+    {:noreply, accept_autocomplete(state)}
   end
 
   defp handle_key(%Event.Key{code: "tab"}, state), do: {:noreply, state}
 
   defp handle_key(%Event.Key{code: "enter", modifiers: mods}, state) do
     cond do
+      match?(%{}, state.autocomplete) and State.selected_autocomplete(state) != nil ->
+        # Enter while the autocomplete popup is open with a selection:
+        # accept the suggestion. User can press Enter again to submit.
+        {:noreply, accept_autocomplete(state)}
+
       "shift" in mods ->
         # Shift+Enter inserts a newline into the textarea instead of submitting.
         if state.input_ref, do: ExRatatui.textarea_handle_key(state.input_ref, "enter", [])
@@ -155,9 +152,6 @@ defmodule ExAthena.Chat.Tui do
         {:noreply, state}
 
       true ->
-        # Close the autocomplete popup (if any) and submit whatever is
-        # in the textarea. Don't auto-accept the suggestion — Tab is the
-        # acceptance affordance; Enter is the submit affordance.
         state |> State.close_autocomplete() |> submit_input()
     end
   end
@@ -167,6 +161,20 @@ defmodule ExAthena.Chat.Tui do
   end
 
   defp handle_key(_, state), do: {:noreply, state}
+
+  defp accept_autocomplete(state) do
+    case State.selected_autocomplete(state) do
+      nil ->
+        State.close_autocomplete(state)
+
+      verb ->
+        if state.input_ref do
+          ExRatatui.textarea_set_value(state.input_ref, verb <> " ")
+        end
+
+        State.close_autocomplete(state)
+    end
+  end
 
   defp forward_to_textarea(%Event.Key{code: code, modifiers: mods}, state) do
     if state.input_ref do


### PR DESCRIPTION
## Why

Previously \`Tab\` was the only key that completed a verb from the autocomplete popup; \`Enter\` always submitted whatever was in the textarea. That made it easy to fire a half-typed command as a chat message when the popup was visible (e.g. typing \`/de\`, seeing \`/details\` highlighted, hitting Enter to "pick it" — actually submitted \`/de\` to the agent).

## Fix

\`Enter\`, when the autocomplete popup is open **with a highlighted row**, completes the verb into the input (same effect as Tab) and closes the popup. Press Enter again to submit. Tab still works the same.

Also factored the shared completion logic into \`accept_autocomplete/1\` and grouped it after the \`handle_key\` clauses so the compiler doesn't warn about split clauses.

## Test plan
- [x] \`mix compile\` clean (no clause-grouping warning)
- [x] \`mix format\` clean
- [x] \`mix test test/ex_athena/chat\` — 126 tests pass
- [ ] Manual: type \`/de\`, Enter → input becomes \`/details \` (with trailing space), popup closes; Enter again submits
- [ ] Manual: type \`hello world\` with no popup, Enter still submits as before