### PR TITLE
fix(tui): include untracked files in the Changes tab diff

### DIFF
--- a/lib/ex_athena/chat/tui.ex
+++ b/lib/ex_athena/chat/tui.ex
@@ -560,33 +560,116 @@ defmodule ExAthena.Chat.Tui do
     state
   end
 
+  # Per-file caps when synthesizing diffs for untracked files. Untracked
+  # files don't show up in `git diff HEAD`, so we generate a synthetic
+  # "new file" diff for each — but cap so a generated/binary blob doesn't
+  # flood the pane.
+  @max_untracked_lines 500
+  @max_untracked_bytes 100_000
+
   defp fetch_git_diff(cwd) do
-    case System.cmd("git", ["diff", "HEAD"], cd: cwd, stderr_to_stdout: true) do
-      {output, 0} ->
-        case String.trim(output) do
-          "" -> ["(no changes vs HEAD)", "cwd: #{cwd}"]
-          trimmed -> String.split(trimmed, "\n")
+    case System.cmd("git", ["rev-parse", "--show-toplevel"],
+           cd: cwd,
+           stderr_to_stdout: true
+         ) do
+      {_root, 0} ->
+        tracked = run_git_diff(cwd)
+        untracked = render_untracked_files(cwd)
+
+        case {tracked, untracked} do
+          {[], []} -> ["(no changes vs HEAD)", "cwd: #{cwd}"]
+          _ -> tracked ++ untracked
         end
 
-      {output, exit_code} ->
-        # Common case: not a git repo, returns "fatal: not a git repository".
-        [
-          "git diff failed (exit #{exit_code}) in #{cwd}:"
-          | String.split(String.trim(output), "\n")
-        ]
+      {output, _exit} ->
+        ["not a git repository (cwd: #{cwd})" | String.split(String.trim(output), "\n")]
     end
   rescue
     e in ErlangError ->
       case e.original do
-        :enoent ->
-          ["`git` executable not found on PATH"]
-
-        other ->
-          ["git diff crashed: " <> inspect(other)]
+        :enoent -> ["`git` executable not found on PATH"]
+        other -> ["git crashed: " <> inspect(other)]
       end
 
     e ->
-      ["git diff crashed: " <> Exception.message(e)]
+      ["git crashed: " <> Exception.message(e)]
+  end
+
+  defp run_git_diff(cwd) do
+    case System.cmd("git", ["diff", "HEAD", "--color=never"], cd: cwd, stderr_to_stdout: true) do
+      {output, 0} -> output |> String.trim_trailing("\n") |> String.split("\n", trim: true)
+      _ -> []
+    end
+  end
+
+  # `git ls-files --others --exclude-standard` lists files not tracked
+  # and not gitignored. For each, synthesize a `--- /dev/null` /
+  # `+++ b/<path>` diff so new files appear in the same Changes view.
+  defp render_untracked_files(cwd) do
+    case System.cmd("git", ["ls-files", "--others", "--exclude-standard"],
+           cd: cwd,
+           stderr_to_stdout: true
+         ) do
+      {output, 0} ->
+        output
+        |> String.trim()
+        |> String.split("\n", trim: true)
+        |> Enum.flat_map(&render_untracked_file(&1, cwd))
+
+      _ ->
+        []
+    end
+  end
+
+  defp render_untracked_file(rel, cwd) do
+    header = [
+      "diff --git a/#{rel} b/#{rel}",
+      "new file mode 100644",
+      "--- /dev/null",
+      "+++ b/#{rel}"
+    ]
+
+    path = Path.join(cwd, rel)
+
+    case File.stat(path) do
+      {:ok, %{type: :regular, size: size}} when size > @max_untracked_bytes ->
+        header ++ ["+(file too large to show: #{size} bytes)"]
+
+      {:ok, %{type: :regular}} ->
+        case File.read(path) do
+          {:ok, content} ->
+            if binary_content?(content) do
+              header ++ ["+(binary file)"]
+            else
+              lines = String.split(content, "\n")
+              total = length(lines)
+              visible = Enum.take(lines, @max_untracked_lines)
+              shown = length(visible)
+              diff_lines = Enum.map(visible, &("+" <> &1))
+
+              footer =
+                if total > shown,
+                  do: ["+… (#{total - shown} more lines)"],
+                  else: []
+
+              header ++ diff_lines ++ footer
+            end
+
+          _ ->
+            []
+        end
+
+      _ ->
+        []
+    end
+  end
+
+  # Cheap binary heuristic: NUL byte in the first 1KB.
+  defp binary_content?(""), do: false
+
+  defp binary_content?(content) do
+    head_size = min(byte_size(content), 1024)
+    :binary.match(binary_part(content, 0, head_size), <<0>>) != :nomatch
   end
 
   defp restore_logger(%State{prior_log_level: level} = state) do


### PR DESCRIPTION
## Why

\`git diff HEAD\` only reports modifications to **tracked** files. New files the agent creates (the common case for AI-generated code) were completely invisible in the Changes tab even though they sat there in the working tree. User report: "diff is not showing changed files although there are uncommitted changes".

## Fix

\`fetch_git_diff/1\` now does three steps:

1. **Verify cwd is a git repo** via \`git rev-parse --show-toplevel\` — non-git dirs get a clear "not a git repository (cwd: …)" message instead of a confusing git diff error.
2. **Run \`git diff HEAD --color=never\`** for modifications to tracked files (same as before).
3. **Run \`git ls-files --others --exclude-standard\`** to find untracked, non-gitignored files, and synthesize a \`--- /dev/null\` / \`+++ b/<path>\` diff for each so they render in the same colored view.

Per-file caps keep the panel responsive:
- 100 KB max per untracked file (larger → "(file too large to show)")
- 500 lines max per file (truncated with "+… N more lines" footer)
- NUL-byte heuristic skips binary content as "(binary file)"

## Test plan
- [x] \`mix compile\` clean
- [x] \`mix format\` clean
- [x] \`mix test test/ex_athena/chat\` — 126 tests pass
- [ ] Manual: have the agent create a new file, switch to Changes tab, confirm it appears as a green new-file diff
- [ ] Manual: modify an existing tracked file, confirm it still shows
- [ ] Manual: drop a binary or huge file, confirm the truncation messages render correctly