### PR TITLE
feat(tui): scrollable panes via PgUp/PgDn (Shift for details)

### DIFF
--- a/lib/ex_athena/chat/tui.ex
+++ b/lib/ex_athena/chat/tui.ex
@@ -31,6 +31,9 @@ defmodule ExAthena.Chat.Tui do
 
   @modes [:react, :plan_and_solve, :reflexion]
   @tick_interval_ms 60
+  # Rows per PgUp/PgDn press. Roughly a half-page on a typical terminal —
+  # comfortable for skimming without overshooting.
+  @page_step 10
 
   @doc """
   Start the chat App and block until the user quits.
@@ -134,6 +137,33 @@ defmodule ExAthena.Chat.Tui do
   end
 
   defp handle_key(%Event.Key{code: "tab"}, state), do: {:noreply, state}
+
+  # ── Pane scrolling ────────────────────────────────────────────────────
+  # PgUp/PgDn scroll the messages pane (left). Add Shift to target the
+  # details pane (right). Home jumps to the very top; End returns to
+  # auto-bottom so new content follows again.
+
+  defp handle_key(%Event.Key{code: "pageup", modifiers: mods}, state) do
+    if "shift" in mods,
+      do: {:noreply, State.scroll_details(state, -@page_step)},
+      else: {:noreply, State.scroll_messages(state, -@page_step)}
+  end
+
+  defp handle_key(%Event.Key{code: "pagedown", modifiers: mods}, state) do
+    if "shift" in mods,
+      do: {:noreply, State.scroll_details(state, +@page_step)},
+      else: {:noreply, State.scroll_messages(state, +@page_step)}
+  end
+
+  defp handle_key(%Event.Key{code: "home", modifiers: mods}, state) do
+    if "shift" in mods,
+      do: {:noreply, State.scroll_details_top(state)},
+      else: {:noreply, State.scroll_messages_top(state)}
+  end
+
+  defp handle_key(%Event.Key{code: "end"}, state) do
+    {:noreply, State.reset_pane_scroll(state)}
+  end
 
   defp handle_key(%Event.Key{code: "enter", modifiers: mods}, state) do
     cond do
@@ -320,6 +350,7 @@ defmodule ExAthena.Chat.Tui do
       |> State.append_event({:user, text})
       |> State.set_loading(true)
       |> State.reset_stream_state()
+      |> State.reset_pane_scroll()
       |> update_in_session(&Session.append_user(&1, text))
 
     task_pid = Runner.start(state.session, self())

--- a/lib/ex_athena/chat/tui/state.ex
+++ b/lib/ex_athena/chat/tui/state.ex
@@ -42,6 +42,12 @@ defmodule ExAthena.Chat.Tui.State do
   defstruct session: nil,
             input_ref: nil,
             scroll_offset: 0,
+            # Manual scroll offsets. `nil` means "auto-pin to the bottom"
+            # (the default — new content stays in view). Set to an
+            # integer row count by PgUp/PgDn. End or a new user submit
+            # resets back to nil.
+            messages_scroll: nil,
+            details_scroll: nil,
             stream_buffer: "",
             loading?: false,
             popup: nil,
@@ -84,6 +90,8 @@ defmodule ExAthena.Chat.Tui.State do
           session: Session.t(),
           input_ref: reference() | nil,
           scroll_offset: non_neg_integer(),
+          messages_scroll: non_neg_integer() | nil,
+          details_scroll: non_neg_integer() | nil,
           stream_buffer: String.t(),
           loading?: boolean(),
           popup: popup(),
@@ -412,6 +420,51 @@ defmodule ExAthena.Chat.Tui.State do
   def set_git_diff(%__MODULE__{} = state, lines) when is_list(lines) do
     %{state | git_diff_lines: lines}
   end
+
+  # ─ Pane scrolling ────────────────────────────────────────────────────────
+
+  # Scrolling model: `messages_scroll` / `details_scroll` count the number
+  # of rows the user has scrolled *above the natural bottom* of the pane.
+  #
+  #   nil / 0    → at the bottom (auto-follow new content)
+  #   N > 0      → N rows above the bottom
+  #
+  # View resolves this each frame as `effective = max(auto_bottom - N, 0)`,
+  # so we never need to know the viewport size in State.
+
+  @doc """
+  Move the messages pane. `delta < 0` scrolls up (older content),
+  `delta > 0` scrolls down. Returns to the bottom when the offset would
+  go below 0. Idempotent at the top.
+  """
+  @spec scroll_messages(t(), integer()) :: t()
+  def scroll_messages(%__MODULE__{} = state, delta) when is_integer(delta) do
+    cur = state.messages_scroll || 0
+    %{state | messages_scroll: max(cur - delta, 0)}
+  end
+
+  @doc "Like scroll_messages/2 but for the details pane."
+  @spec scroll_details(t(), integer()) :: t()
+  def scroll_details(%__MODULE__{} = state, delta) when is_integer(delta) do
+    cur = state.details_scroll || 0
+    %{state | details_scroll: max(cur - delta, 0)}
+  end
+
+  @doc "Reset both panes back to auto-bottom (e.g. after Enter or End)."
+  @spec reset_pane_scroll(t()) :: t()
+  def reset_pane_scroll(%__MODULE__{} = state) do
+    %{state | messages_scroll: nil, details_scroll: nil}
+  end
+
+  @doc "Jump the messages pane to the top (a very large offset; View clamps)."
+  @spec scroll_messages_top(t()) :: t()
+  def scroll_messages_top(%__MODULE__{} = state),
+    do: %{state | messages_scroll: 1_000_000_000}
+
+  @doc "Jump the details pane to the top."
+  @spec scroll_details_top(t()) :: t()
+  def scroll_details_top(%__MODULE__{} = state),
+    do: %{state | details_scroll: 1_000_000_000}
 
   # ─ Slash-command autocomplete ────────────────────────────────────────────
 

--- a/lib/ex_athena/chat/tui/view.ex
+++ b/lib/ex_athena/chat/tui/view.ex
@@ -217,7 +217,8 @@ defmodule ExAthena.Chat.Tui.View do
          %State{
            events: events,
            loading?: loading?,
-           session: session
+           session: session,
+           messages_scroll: above_bottom
          },
          width,
          height
@@ -227,7 +228,7 @@ defmodule ExAthena.Chat.Tui.View do
       |> Enum.map(&row_widget(&1, session.model, width))
       |> append_throbber(loading?)
 
-    %WidgetList{items: items, scroll_offset: auto_scroll(items, height)}
+    %WidgetList{items: items, scroll_offset: scroll_offset(items, height, above_bottom)}
   end
 
   @details_block %Block{
@@ -237,9 +238,14 @@ defmodule ExAthena.Chat.Tui.View do
     border_style: %Style{fg: :dark_gray}
   }
 
-  defp details(%State{details: details}, width, height) do
+  defp details(%State{details: details, details_scroll: above_bottom}, width, height) do
     items = Enum.map(details, &detail_row_widget(&1, width))
-    %WidgetList{items: items, scroll_offset: auto_scroll(items, height), block: @details_block}
+
+    %WidgetList{
+      items: items,
+      scroll_offset: scroll_offset(items, height, above_bottom),
+      block: @details_block
+    }
   end
 
   @changes_block %Block{
@@ -261,9 +267,14 @@ defmodule ExAthena.Chat.Tui.View do
     }
   end
 
-  defp changes(%State{git_diff_lines: lines}, width, height) do
+  defp changes(%State{git_diff_lines: lines, details_scroll: above_bottom}, width, height) do
     items = Enum.map(lines, &diff_row_widget(&1, width))
-    %WidgetList{items: items, scroll_offset: auto_scroll(items, height), block: @changes_block}
+
+    %WidgetList{
+      items: items,
+      scroll_offset: scroll_offset(items, height, above_bottom),
+      block: @changes_block
+    }
   end
 
   # Color each diff line by its first character: `+` green, `-` red,
@@ -288,17 +299,23 @@ defmodule ExAthena.Chat.Tui.View do
   defp diff_line_style("cwd: " <> _), do: %Style{fg: :dark_gray, modifiers: [:italic]}
   defp diff_line_style(_), do: %Style{fg: :dark_gray}
 
-  # Compute a scroll_offset that pins the WidgetList to the bottom: sum
-  # the item heights, subtract the viewport height, clamp at 0. Once the
-  # content fits in the viewport this is 0 (top of list); as content
-  # grows past `height`, the offset advances so the latest items stay
-  # visible.
-  defp auto_scroll(items, height) when is_integer(height) and height > 0 do
+  # Compute a scroll_offset for a WidgetList. `above_bottom` is the user's
+  # manual scroll position (in rows above the natural bottom); nil = "at
+  # the bottom" (auto-pin to newest content). When the user has scrolled
+  # up, we step back from the auto-bottom by `above_bottom` rows, clamped
+  # to [0, max_offset] so it never escapes the content.
+  defp scroll_offset(items, height, above_bottom)
+       when is_integer(height) and height > 0 do
     total = items |> Enum.map(fn {_w, h} -> h end) |> Enum.sum()
-    max(total - height, 0)
+    auto = max(total - height, 0)
+
+    case above_bottom do
+      nil -> auto
+      n when is_integer(n) -> auto |> Kernel.-(n) |> max(0)
+    end
   end
 
-  defp auto_scroll(_items, _height), do: 0
+  defp scroll_offset(_items, _height, _above_bottom), do: 0
 
   # Estimate the number of rows a string occupies once it's wrapped at
   # `width` columns. Counts each explicit `\n` as a line break and uses

--- a/test/ex_athena/chat/tui/state_test.exs
+++ b/test/ex_athena/chat/tui/state_test.exs
@@ -334,6 +334,55 @@ defmodule ExAthena.Chat.Tui.StateTest do
     end
   end
 
+  describe "pane scrolling" do
+    test "scroll_messages/2 records rows-above-bottom" do
+      state = Session.new() |> State.new()
+      assert state.messages_scroll == nil
+
+      # Scroll up by 10 → 10 rows above bottom.
+      state = State.scroll_messages(state, -10)
+      assert state.messages_scroll == 10
+
+      # Another PgUp → 20 above.
+      state = State.scroll_messages(state, -10)
+      assert state.messages_scroll == 20
+
+      # PgDn brings it back down.
+      state = State.scroll_messages(state, +15)
+      assert state.messages_scroll == 5
+
+      # PgDn past the bottom clamps at 0.
+      state = State.scroll_messages(state, +100)
+      assert state.messages_scroll == 0
+    end
+
+    test "scroll_details/2 maintains its own offset" do
+      state = Session.new() |> State.new() |> State.scroll_details(-7)
+      assert state.details_scroll == 7
+      assert state.messages_scroll == nil
+    end
+
+    test "reset_pane_scroll/1 clears both offsets back to nil" do
+      state =
+        Session.new()
+        |> State.new()
+        |> State.scroll_messages(-10)
+        |> State.scroll_details(-5)
+        |> State.reset_pane_scroll()
+
+      assert state.messages_scroll == nil
+      assert state.details_scroll == nil
+    end
+
+    test "scroll_*_top/1 pins to the top with a huge offset" do
+      state = Session.new() |> State.new() |> State.scroll_messages_top()
+      assert state.messages_scroll > 1_000_000
+
+      state = State.scroll_details_top(state)
+      assert state.details_scroll > 1_000_000
+    end
+  end
+
   describe "details tabs" do
     test "default details_tab is :timeline" do
       state = Session.new() |> State.new()


### PR DESCRIPTION
## Why

Until now both panes were always pinned to the bottom — once content exceeded the viewport you couldn't scroll back to read earlier output.

## Summary

- **PgUp / PgDn** — scroll the messages pane (left)
- **Shift+PgUp / Shift+PgDn** — scroll the details pane (right)
- **Home** — jump messages pane to the top
- **Shift+Home** — jump details pane to the top
- **End** — reset both panes back to auto-pin-to-bottom

## Model

\`messages_scroll\` / \`details_scroll\` count rows *above the bottom* (not absolute offsets) — so View can clamp without needing to know the viewport size. \`nil\` / \`0\` = at the bottom (auto-follow). \`N > 0\` = N rows above the bottom.

While scrolled up, new content continues to grow at the natural bottom — your "N rows above bottom" position stays anchored relative to the bottom. Matches chat-UI conventions.

State auto-resets on user submit so the next turn auto-follows again.

## Test plan
- [x] \`mix compile\` clean
- [x] \`mix format\` clean
- [x] \`mix test test/ex_athena/chat\` — 130 tests pass (4 new)
- [ ] Manual: fill the messages pane, PgUp scrolls back; PgDn forwards; Home jumps to top; End returns to bottom
- [ ] Manual: Shift+PgUp/PgDn scrolls the details pane independently
- [ ] Manual: scroll up, then send a new message — auto-pins to bottom again