### PR TITLE
feat(tui): Claude-Code style tool blocks + inline todos + diff hints

### DIFF
--- a/lib/ex_athena/chat/tui/state.ex
+++ b/lib/ex_athena/chat/tui/state.ex
@@ -16,7 +16,6 @@ defmodule ExAthena.Chat.Tui.State do
   alias ExAthena.Result
   alias ExAthena.Streaming.Event, as: StreamEvent
 
-  @preview_chars 200
   @default_footer "Enter: send  Ctrl+C: quit  /help"
 
   @type event_kind ::
@@ -25,6 +24,7 @@ defmodule ExAthena.Chat.Tui.State do
           | :tool_call
           | :tool_result
           | :tool_result_error
+          | :tool_block
           | :error
           | :warning
           | :info
@@ -32,7 +32,7 @@ defmodule ExAthena.Chat.Tui.State do
           | :thinking
           | :detail_header
 
-  @type event_row :: {event_kind(), String.t()}
+  @type event_row :: {event_kind(), term()}
 
   @type popup ::
           nil
@@ -52,6 +52,11 @@ defmodule ExAthena.Chat.Tui.State do
             loading?: false,
             popup: nil,
             events: [],
+            # Structured tool-call records keyed by tool_call_id. Events
+            # carry only a `{:tool_block, id}` reference; State holds the
+            # rich data (status, output preview, todos…) so the renderer
+            # can lay out a unified "● Tool(args) / └ output" block.
+            tool_blocks: %{},
             details: [],
             details_scroll_offset: 0,
             details_stream_buffer: "",
@@ -96,6 +101,7 @@ defmodule ExAthena.Chat.Tui.State do
           loading?: boolean(),
           popup: popup(),
           events: [event_row()],
+          tool_blocks: %{String.t() => map()},
           details: [event_row()],
           details_scroll_offset: non_neg_integer(),
           details_stream_buffer: String.t(),
@@ -195,29 +201,70 @@ defmodule ExAthena.Chat.Tui.State do
 
   def append_loop_event(
         %__MODULE__{} = state,
-        {:tool_call, %ToolCall{name: name, arguments: args}}
+        {:tool_call, %ToolCall{id: id, name: name, arguments: args}}
       ) do
+    block = %{
+      id: id,
+      name: name,
+      args: args,
+      status: :pending,
+      output_preview: nil,
+      total_lines: 0,
+      total_bytes: 0,
+      todos: parse_todos_from_call(name, args)
+    }
+
     state
-    |> append_event({:tool_call, "→ #{name}(#{preview_args(args)})"})
+    |> Map.update!(:tool_blocks, &Map.put(&1, id, block))
+    |> append_event({:tool_block, id})
     |> append_detail_header("→ #{name}")
     |> append_detail_lines(:tool_call, format_args_full(args))
   end
 
   def append_loop_event(
         %__MODULE__{} = state,
-        {:tool_result, %ToolResult{content: content, is_error: is_error}}
+        {:tool_result, %ToolResult{tool_call_id: id, content: content, is_error: is_error} = tr}
       ) do
-    kind = if is_error, do: :tool_result_error, else: :tool_result
+    content_str = to_string(content)
+    status = if is_error, do: :error, else: :success
+    {preview, total_lines} = preview_lines(content_str)
     arrow = if is_error, do: "✗", else: "←"
 
+    detail_kind = if is_error, do: :tool_result_error, else: :tool_result
+
     state
-    |> append_event({kind, "← #{summarize_result(content)}"})
+    |> Map.update!(:tool_blocks, fn blocks ->
+      case Map.get(blocks, id) do
+        nil ->
+          # No matching call (shouldn't happen, but stay defensive).
+          Map.put(blocks, id, %{
+            id: id,
+            name: maybe_get_field(tr, :name) || "?",
+            args: %{},
+            status: status,
+            output_preview: preview,
+            total_lines: total_lines,
+            total_bytes: byte_size(content_str),
+            todos: nil
+          })
+
+        block ->
+          Map.put(blocks, id, %{
+            block
+            | status: status,
+              output_preview: preview,
+              total_lines: total_lines,
+              total_bytes: byte_size(content_str)
+          })
+      end
+    end)
     |> append_detail_header("#{arrow} result")
-    |> append_detail_lines(kind, to_string(content))
+    |> append_detail_lines(detail_kind, content_str)
   end
 
-  def append_loop_event(%__MODULE__{} = state, {:tool_ui, %{kind: kind, payload: payload}}) do
+  def append_loop_event(%__MODULE__{} = state, {:tool_ui, %{kind: kind, payload: payload} = ui}) do
     state
+    |> attach_tool_ui_to_block(ui)
     |> append_detail_header("ui · #{kind}")
     |> append_detail_lines(:info, format_tool_ui(kind, payload))
   end
@@ -356,6 +403,7 @@ defmodule ExAthena.Chat.Tui.State do
       state
       | session: Session.clear_messages(session),
         events: [],
+        tool_blocks: %{},
         stream_buffer: "",
         details: [],
         details_scroll_offset: 0,
@@ -662,6 +710,46 @@ defmodule ExAthena.Chat.Tui.State do
     end
   end
 
+  # ─ Tool-block helpers ────────────────────────────────────────────────────
+
+  # Detect a todo_write call and extract the todos list so the renderer
+  # can show inline checkboxes instead of a generic tool block.
+  defp parse_todos_from_call("todo_write", %{"todos" => todos}) when is_list(todos), do: todos
+  defp parse_todos_from_call("todo_write", %{todos: todos}) when is_list(todos), do: todos
+  defp parse_todos_from_call(_name, _args), do: nil
+
+  # Cap how many output lines we keep on the block for the inline preview.
+  # The full text is still routed to the details pane.
+  @preview_max_lines 4
+
+  defp preview_lines(""), do: {[], 0}
+
+  defp preview_lines(content) when is_binary(content) do
+    content
+    |> String.trim_trailing("\n")
+    |> String.split("\n")
+    |> case do
+      [""] -> {[], 0}
+      lines -> {Enum.take(lines, @preview_max_lines), length(lines)}
+    end
+  end
+
+  # Attach a :tool_ui payload to its matching block (looked up by
+  # tool_call_id). No-op if the block isn't found.
+  defp attach_tool_ui_to_block(state, %{tool_call_id: id, kind: kind, payload: payload}) do
+    Map.update!(state, :tool_blocks, fn blocks ->
+      case Map.get(blocks, id) do
+        nil -> blocks
+        block -> Map.put(blocks, id, Map.put(block, :ui, %{kind: kind, payload: payload}))
+      end
+    end)
+  end
+
+  defp attach_tool_ui_to_block(state, _), do: state
+
+  defp maybe_get_field(map, key) when is_map(map), do: Map.get(map, key)
+  defp maybe_get_field(_, _), do: nil
+
   # ─ Details-pane helpers ──────────────────────────────────────────────────
 
   @doc false
@@ -707,28 +795,6 @@ defmodule ExAthena.Chat.Tui.State do
   defp format_tool_ui(kind, payload), do: "#{kind}: #{inspect(payload, pretty: true)}"
 
   # ─ Helpers ────────────────────────────────────────────────────────────────
-
-  defp summarize_result(content) do
-    text = content |> to_string() |> String.trim_trailing("\n")
-    lines = String.split(text, "\n")
-    first_line = lines |> List.first("") |> truncate(@preview_chars)
-
-    case length(lines) do
-      1 -> first_line
-      n -> "#{first_line} · #{n} lines"
-    end
-  end
-
-  defp preview_args(args) when is_map(args) and map_size(args) == 0, do: ""
-
-  defp preview_args(args) when is_map(args) do
-    Enum.map_join(args, ", ", fn {k, v} -> "#{k}: #{truncate(inspect_value(v), 60)}" end)
-  end
-
-  defp preview_args(other), do: inspect(other)
-
-  defp inspect_value(v) when is_binary(v), do: inspect(v)
-  defp inspect_value(v), do: inspect(v, limit: 5, printable_limit: 60)
 
   defp truncate(text, limit) when is_binary(text) do
     case String.length(text) do

--- a/lib/ex_athena/chat/tui/view.ex
+++ b/lib/ex_athena/chat/tui/view.ex
@@ -218,18 +218,31 @@ defmodule ExAthena.Chat.Tui.View do
            events: events,
            loading?: loading?,
            session: session,
-           messages_scroll: above_bottom
+           messages_scroll: above_bottom,
+           tool_blocks: tool_blocks
          },
          width,
          height
        ) do
     items =
       events
-      |> Enum.map(&row_widget(&1, session.model, width))
+      |> Enum.flat_map(&event_to_widgets(&1, session.model, width, tool_blocks))
       |> append_throbber(loading?)
 
     %WidgetList{items: items, scroll_offset: scroll_offset(items, height, above_bottom)}
   end
+
+  # One event can produce multiple widget rows — a tool block expands
+  # into a header + indented preview lines + truncation hint, etc.
+  defp event_to_widgets({:tool_block, id}, _model, width, tool_blocks) do
+    case Map.get(tool_blocks, id) do
+      nil -> [{%Paragraph{text: "● (missing tool block)", style: %Style{fg: :dark_gray}}, 1}]
+      block -> render_tool_block(block, width)
+    end
+  end
+
+  defp event_to_widgets(row, model, width, _tool_blocks),
+    do: [row_widget(row, model, width)]
 
   @details_block %Block{
     title: " details ",
@@ -385,6 +398,240 @@ defmodule ExAthena.Chat.Tui.View do
     {%Paragraph{text: text, style: %Style{fg: :dark_gray}, wrap: true},
      wrapped_height(text, width)}
   end
+
+  # ── Tool block (Claude-Code style: `● Tool(args)` + indented preview) ──
+
+  defp render_tool_block(%{todos: todos} = block, width) when is_list(todos) do
+    # Todo list: header + one row per item with a checkbox.
+    bullet = status_bullet(block.status)
+
+    header_text =
+      "#{bullet} TodoWrite (#{length(todos)} item#{if length(todos) == 1, do: "", else: "s"})"
+
+    header = {
+      %Paragraph{
+        text: header_text,
+        style: %Style{fg: bullet_color(block.status), modifiers: [:bold]},
+        wrap: true
+      },
+      wrapped_height(header_text, width)
+    }
+
+    {pending_and_active, completed} =
+      Enum.split_with(todos, &(get_todo_status(&1) != "completed"))
+
+    visible_rows =
+      pending_and_active
+      |> Enum.map(&todo_row_widget(&1, width))
+      |> Kernel.++(maybe_collapsed_completed_row(completed, width))
+
+    [header | visible_rows]
+  end
+
+  defp render_tool_block(block, width) do
+    color = bullet_color(block.status)
+    header_text = tool_header_text(block)
+
+    header = {
+      %Paragraph{
+        text: header_text,
+        style: %Style{fg: color, modifiers: [:bold]},
+        wrap: true
+      },
+      wrapped_height(header_text, width)
+    }
+
+    preview_rows = preview_widget_rows(block, width)
+
+    [header | preview_rows]
+  end
+
+  # ── Status bullet helpers ──
+
+  defp status_bullet(:pending), do: "●"
+  defp status_bullet(:success), do: "●"
+  defp status_bullet(:error), do: "●"
+  defp status_bullet(_), do: "●"
+
+  defp bullet_color(:pending), do: :light_blue
+  defp bullet_color(:success), do: :green
+  defp bullet_color(:error), do: :red
+  defp bullet_color(_), do: :dark_gray
+
+  # ── Header rendering: `● Tool(args)` ──
+
+  defp tool_header_text(%{name: name, ui: %{kind: :diff, payload: %{path: path}}})
+       when name in ["edit", "write", "apply_patch"] do
+    "#{status_bullet(:success)} #{verb_for(name)}(#{Path.relative_to_cwd(path)})"
+  end
+
+  defp tool_header_text(%{name: name, args: args}) do
+    "#{status_bullet(:success)} #{tool_display_name(name)}(#{args_summary(name, args)})"
+  end
+
+  defp tool_display_name(name) do
+    name
+    |> String.split("_")
+    |> Enum.map(&String.capitalize/1)
+    |> Enum.join("")
+  end
+
+  defp verb_for("write"), do: "Create"
+  defp verb_for("apply_patch"), do: "Patch"
+  defp verb_for(_), do: "Update"
+
+  defp args_summary("bash", %{"command" => cmd}) when is_binary(cmd), do: truncate(cmd, 100)
+  defp args_summary("bash", %{command: cmd}) when is_binary(cmd), do: truncate(cmd, 100)
+  defp args_summary("read", args), do: get_arg(args, "path") |> Path.relative_to_cwd()
+  defp args_summary("edit", args), do: get_arg(args, "path") |> Path.relative_to_cwd()
+  defp args_summary("write", args), do: get_arg(args, "path") |> Path.relative_to_cwd()
+  defp args_summary("grep", args), do: get_arg(args, "pattern")
+  defp args_summary("glob", args), do: get_arg(args, "pattern")
+  defp args_summary("web_fetch", args), do: args |> get_arg("url") |> truncate(80)
+  defp args_summary(_name, args) when args == %{} or is_nil(args), do: ""
+  defp args_summary(_name, args), do: args |> compact_args() |> truncate(80)
+
+  defp get_arg(args, key) when is_map(args) do
+    Map.get(args, key) || Map.get(args, String.to_atom(key)) || ""
+  end
+
+  defp get_arg(_args, _key), do: ""
+
+  defp compact_args(args) when is_map(args) do
+    Enum.map_join(args, ", ", fn {k, v} -> "#{k}: #{inspect(v)}" end)
+  end
+
+  defp compact_args(other), do: inspect(other)
+
+  # ── Indented preview rows ──
+
+  defp preview_widget_rows(%{ui: %{kind: :diff, payload: payload}} = _block, width) do
+    diff_preview_rows(payload, width)
+  end
+
+  defp preview_widget_rows(%{output_preview: nil}, _width), do: []
+
+  defp preview_widget_rows(%{output_preview: [], total_lines: _}, _width), do: []
+
+  defp preview_widget_rows(%{output_preview: lines, total_lines: total}, width) do
+    visible_count = length(lines)
+    preview_color = %Style{fg: :dark_gray}
+
+    visible =
+      lines
+      |> Enum.with_index()
+      |> Enum.map(fn {line, idx} ->
+        text = if idx == 0, do: "  └ #{line}", else: "    #{line}"
+        {%Paragraph{text: text, style: preview_color, wrap: true}, wrapped_height(text, width)}
+      end)
+
+    if total > visible_count do
+      remaining = total - visible_count
+
+      hint =
+        "    … +#{remaining} line#{if remaining == 1, do: "", else: "s"} (/expand 1 for full)"
+
+      visible ++
+        [{%Paragraph{text: hint, style: %Style{fg: :dark_gray, modifiers: [:italic]}}, 1}]
+    else
+      visible
+    end
+  end
+
+  defp diff_preview_rows(%{lines: lines, changed_lines: changed, total_lines: total}, width) do
+    {added, removed} =
+      Enum.reduce(lines, {0, 0}, fn
+        {:ins, _}, {a, r} -> {a + 1, r}
+        {:del, _}, {a, r} -> {a, r + 1}
+        _, acc -> acc
+      end)
+
+    stat_text =
+      cond do
+        added > 0 and removed > 0 ->
+          "  └ +#{added} −#{removed} lines (#{changed}/#{total} changed)"
+
+        added > 0 ->
+          "  └ Added #{added} line#{if added == 1, do: "", else: "s"}"
+
+        removed > 0 ->
+          "  └ Removed #{removed} line#{if removed == 1, do: "", else: "s"}"
+
+        true ->
+          "  └ #{changed} line#{if changed == 1, do: "", else: "s"} changed"
+      end
+
+    stat_row =
+      {%Paragraph{text: stat_text, style: %Style{fg: :dark_gray}, wrap: true},
+       wrapped_height(stat_text, width)}
+
+    # Show the first ~6 non-equal lines as colored diff snippets.
+    snippet_rows =
+      lines
+      |> Enum.reject(fn {kind, _} -> kind == :eq end)
+      |> Enum.take(6)
+      |> Enum.map(fn {kind, line} ->
+        prefix =
+          case kind do
+            :ins -> "    + "
+            :del -> "    - "
+            _ -> "      "
+          end
+
+        style =
+          case kind do
+            :ins -> %Style{fg: :green}
+            :del -> %Style{fg: :red}
+            _ -> %Style{fg: :dark_gray}
+          end
+
+        text = prefix <> truncate(line, max(width - 6, 20))
+        {%Paragraph{text: text, style: style, wrap: false}, 1}
+      end)
+
+    [stat_row | snippet_rows]
+  end
+
+  defp diff_preview_rows(_payload, _width), do: []
+
+  # ── Todo list rendering ──
+
+  defp todo_row_widget(todo, width) do
+    {marker, color} = todo_marker(get_todo_status(todo))
+    content = get_todo_field(todo, "content") || ""
+    text = "  #{marker} #{content}"
+    {%Paragraph{text: text, style: %Style{fg: color}, wrap: true}, wrapped_height(text, width)}
+  end
+
+  defp maybe_collapsed_completed_row([], _width), do: []
+
+  defp maybe_collapsed_completed_row(completed, width) do
+    n = length(completed)
+    text = "    … +#{n} completed"
+
+    [
+      {%Paragraph{text: text, style: %Style{fg: :dark_gray, modifiers: [:italic]}, wrap: true},
+       wrapped_height(text, width)}
+    ]
+  end
+
+  defp todo_marker("completed"), do: {"✓", :green}
+  defp todo_marker("in_progress"), do: {"◐", :light_blue}
+  defp todo_marker(_), do: {"□", :dark_gray}
+
+  defp get_todo_status(todo), do: get_todo_field(todo, "status") || "pending"
+
+  defp get_todo_field(todo, key) when is_map(todo) do
+    Map.get(todo, key) || Map.get(todo, String.to_atom(key))
+  end
+
+  defp get_todo_field(_, _), do: nil
+
+  defp truncate(text, max) when is_binary(text) and is_integer(max) do
+    if String.length(text) <= max, do: text, else: String.slice(text, 0, max - 1) <> "…"
+  end
+
+  defp truncate(other, max), do: other |> to_string() |> truncate(max)
 
   defp row_widget({:user, text}, _model, width) do
     full = "me ▸ " <> text

--- a/test/ex_athena/chat/tui/state_test.exs
+++ b/test/ex_athena/chat/tui/state_test.exs
@@ -48,7 +48,7 @@ defmodule ExAthena.Chat.Tui.StateTest do
       assert state.events == []
     end
 
-    test ":tool_call adds a one-line arrow row" do
+    test ":tool_call records a :tool_block reference + a structured block by id" do
       tc = %ToolCall{id: "1", name: "Read", arguments: %{"path" => "lib/foo.ex"}}
 
       state =
@@ -56,50 +56,96 @@ defmodule ExAthena.Chat.Tui.StateTest do
         |> State.new()
         |> State.append_loop_event({:tool_call, tc})
 
-      assert [{:tool_call, line}] = state.events
-      assert line =~ "→ Read"
-      assert line =~ "path"
-      assert line =~ "lib/foo.ex"
+      assert state.events == [{:tool_block, "1"}]
+
+      assert %{id: "1", name: "Read", args: %{"path" => "lib/foo.ex"}, status: :pending} =
+               Map.get(state.tool_blocks, "1")
     end
 
-    test ":tool_result success uses :tool_result kind" do
+    test ":tool_result transitions the matching block to :success" do
+      tc = %ToolCall{id: "1", name: "Read", arguments: %{"path" => "lib/foo.ex"}}
       tr = %ToolResult{tool_call_id: "1", content: "file contents", is_error: false}
 
       state =
         Session.new()
         |> State.new()
+        |> State.append_loop_event({:tool_call, tc})
         |> State.append_loop_event({:tool_result, tr})
 
-      assert [{:tool_result, line}] = state.events
-      assert line =~ "← file contents"
+      # Still only one event row — the same block reference.
+      assert state.events == [{:tool_block, "1"}]
+      block = Map.get(state.tool_blocks, "1")
+      assert block.status == :success
+      assert block.output_preview == ["file contents"]
     end
 
-    test ":tool_result error uses :tool_result_error kind" do
+    test ":tool_result transitions the matching block to :error" do
+      tc = %ToolCall{id: "1", name: "Bash", arguments: %{}}
       tr = %ToolResult{tool_call_id: "1", content: "boom", is_error: true}
 
       state =
         Session.new()
         |> State.new()
+        |> State.append_loop_event({:tool_call, tc})
         |> State.append_loop_event({:tool_result, tr})
 
-      assert [{:tool_result_error, line}] = state.events
-      assert line =~ "boom"
+      block = Map.get(state.tool_blocks, "1")
+      assert block.status == :error
+      assert block.output_preview == ["boom"]
     end
 
-    test ":tool_result with multi-line content collapses into a count" do
+    test ":tool_result captures a multi-line preview + total" do
+      tc = %ToolCall{id: "1", name: "Bash", arguments: %{}}
       content = "exit 0\nCHANGELOG.md\nLICENSE\nREADME.md\n_build/"
       tr = %ToolResult{tool_call_id: "1", content: content, is_error: false}
 
       state =
         Session.new()
         |> State.new()
+        |> State.append_loop_event({:tool_call, tc})
         |> State.append_loop_event({:tool_result, tr})
 
-      assert [{:tool_result, line}] = state.events
-      assert line =~ "← exit 0"
-      assert line =~ "5 lines"
-      refute line =~ "CHANGELOG.md"
-      assert length(String.split(line, "\n")) == 1
+      block = Map.get(state.tool_blocks, "1")
+      assert block.total_lines == 5
+      # First 4 lines kept (preview_max_lines); the rest is captured as "remaining".
+      assert length(block.output_preview) == 4
+    end
+
+    test "todo_write tool call extracts the todos list on the block" do
+      todos = [
+        %{"content" => "Step 1", "status" => "completed"},
+        %{"content" => "Step 2", "status" => "in_progress"}
+      ]
+
+      tc = %ToolCall{id: "1", name: "todo_write", arguments: %{"todos" => todos}}
+
+      state =
+        Session.new()
+        |> State.new()
+        |> State.append_loop_event({:tool_call, tc})
+
+      block = Map.get(state.tool_blocks, "1")
+      assert block.todos == todos
+    end
+
+    test ":tool_ui :diff payload attaches to the matching block" do
+      tc = %ToolCall{id: "1", name: "edit", arguments: %{"path" => "foo.ex"}}
+
+      ui = %{
+        tool_call_id: "1",
+        kind: :diff,
+        payload: %{path: "foo.ex", before: "old", after: "new"}
+      }
+
+      state =
+        Session.new()
+        |> State.new()
+        |> State.append_loop_event({:tool_call, tc})
+        |> State.append_loop_event({:tool_ui, ui})
+
+      block = Map.get(state.tool_blocks, "1")
+      assert block.ui.kind == :diff
+      assert block.ui.payload.path == "foo.ex"
     end
 
     test ":error adds a warn row" do
@@ -201,7 +247,7 @@ defmodule ExAthena.Chat.Tui.StateTest do
 
       assert [
                {:assistant, "first"},
-               {:tool_call, _},
+               {:tool_block, _},
                {:assistant, "second"}
              ] = state.events
     end


### PR DESCRIPTION
## Summary

Tool calls + results in the messages pane are now a unified, indented block instead of two separate \`→\` / \`←\` rows. Matches the Claude Code TUI style and bundles three improvements requested via screenshots:

\`\`\`
● Bash(git checkout -b feat/runner-attribution-label && ls test/udin_code/)
  └ Switched to a new branch 'feat/runner-attribution-label'
    admin
    agent_test.exs
    … +18 lines (/expand 1 for full)

● TodoWrite (6 items)
  □ Show ex_athena/selected model name when ex_athena is running
  ◐ Read all budget/runaway-protection touchpoints
  ✓ Remove research_budget + byte_cap from athena_runner.ex
    … +3 completed

● Update(lib/ex_athena/chat/tui/state.ex)
  └ Added 5 lines
    + tool_blocks: %{},
    + # Structured tool-call records keyed by tool_call_id.
    - @type event_row :: {event_kind(), String.t()}
    + @type event_row :: {event_kind(), term()}
\`\`\`

## What changed

### Tool summarization
- Single \`● Tool(args)\` header per tool call, indented preview rows underneath, \`+N lines\` hint at the bottom.
- Status bullet colors: pending = light blue, success = green, error = red.
- Per-tool arg formatting: Bash → command, Read/Edit/Write → relative path, Grep/Glob → pattern, WebFetch → url.

### Inline todo lists
- \`todo_write\` calls are detected and rendered with a checkbox per todo (\`✓\` completed, \`◐\` in_progress, \`□\` pending).
- Completed items collapse to "… +N completed" to keep focus on what's open.

### Inline git-diff hints
- When an Edit/Write/apply_patch tool has an attached \`:tool_ui :diff\`, the block header becomes \`Update(path)\` (or Create / Patch) and the preview shows \`Added N lines\` plus the first ~6 changed lines colored green/red — a git-style hint right in the chat, not buried in the details pane.

## Implementation

- State gains \`tool_blocks :: %{id => block}\` plus a new \`:tool_block\` event row kind that carries only the id. The previous separate \`:tool_call\` / \`:tool_result\` rows are gone — one event per tool, structured state per id.
- \`:tool_ui\` events with a matching \`tool_call_id\` attach to the corresponding block so the renderer can show inline diffs.
- View switched \`events |> Enum.map(...)\` to \`Enum.flat_map(...)\` so a single event can produce multiple widget rows.
- \`clear_session/1\` resets \`tool_blocks\`.

## Test plan
- [x] \`mix compile\` clean
- [x] \`mix format\` clean
- [x] \`mix test\` — 772 tests pass, same 1 pre-existing flake. Tests rewritten to match the new tool-block model.
- [ ] Manual: a turn that runs Bash → confirm \`● Bash(cmd)\` block with indented preview
- [ ] Manual: \`todo_write\` call → confirm checkboxes render with the right markers
- [ ] Manual: agent edits a file → confirm \`● Update(path)\` with colored diff snippet inline