### PR TITLE
feat(tui): mouse support — wheel scrolls panes, click switches tabs

### DIFF
--- a/lib/ex_athena/chat/tui.ex
+++ b/lib/ex_athena/chat/tui.ex
@@ -34,6 +34,8 @@ defmodule ExAthena.Chat.Tui do
   # Rows per PgUp/PgDn press. Roughly a half-page on a typical terminal —
   # comfortable for skimming without overshooting.
   @page_step 10
+  # Rows per mouse-wheel click.
+  @wheel_step 3
 
   @doc """
   Start the chat App and block until the user quits.
@@ -45,10 +47,19 @@ defmodule ExAthena.Chat.Tui do
     suspend_beam_stdin_reader()
 
     {:ok, pid} = start_link(opts)
+
+    # ex_ratatui's NIF enables crossterm raw mode + alternate screen but
+    # does NOT toggle mouse capture, so wheel/click events never reach us.
+    # Enable X10 mouse reporting + SGR-extended mode (unlimited coords)
+    # ourselves via ANSI. Disabled in the {:DOWN, ...} cleanup below.
+    IO.write("\e[?1000h\e[?1006h")
+
     ref = Process.monitor(pid)
 
     receive do
-      {:DOWN, ^ref, :process, ^pid, _reason} -> :ok
+      {:DOWN, ^ref, :process, ^pid, _reason} ->
+        IO.write("\e[?1006l\e[?1000l")
+        :ok
     end
   end
 
@@ -103,7 +114,62 @@ defmodule ExAthena.Chat.Tui do
     handle_popup_key(key, state)
   end
 
+  # Mouse wheel: scroll the pane under the cursor by @wheel_step rows.
+  def handle_event(%ExRatatui.Event.Mouse{kind: "scroll_up", x: x, y: y}, state) do
+    {:noreply, scroll_pane_at(state, x, y, -@wheel_step)}
+  end
+
+  def handle_event(%ExRatatui.Event.Mouse{kind: "scroll_down", x: x, y: y}, state) do
+    {:noreply, scroll_pane_at(state, x, y, +@wheel_step)}
+  end
+
+  # Left-click on a details tab title → switch tabs.
+  def handle_event(
+        %ExRatatui.Event.Mouse{kind: "down", button: "left", x: x, y: y},
+        state
+      ) do
+    {:noreply, maybe_click_tab(state, x, y)}
+  end
+
   def handle_event(_event, state), do: {:noreply, state}
+
+  # ── Mouse helpers ────────────────────────────────────────────────────
+
+  defp scroll_pane_at(state, x, y, delta) do
+    layout = Process.get(:tui_layout, %{})
+
+    cond do
+      in_rect?(layout[:messages], x, y) -> State.scroll_messages(state, delta)
+      in_rect?(layout[:details], x, y) -> State.scroll_details(state, delta)
+      true -> state
+    end
+  end
+
+  defp maybe_click_tab(state, x, y) do
+    layout = Process.get(:tui_layout, %{})
+
+    if in_rect?(layout[:tabs], x, y) and is_list(layout[:tab_titles]) do
+      tabs = State.details_tabs()
+      # Approximate tab width: split available width evenly. ratatui's
+      # Tabs widget aligns left and uses a divider; this is a "good
+      # enough" hit-test that picks the closer tab.
+      tabs_rect = layout[:tabs]
+      offset = x - tabs_rect.x
+      slot_width = max(div(tabs_rect.width, length(tabs)), 1)
+      idx = min(div(offset, slot_width), length(tabs) - 1)
+      target = Enum.at(tabs, max(idx, 0))
+
+      State.set_details_tab(state, target)
+    else
+      state
+    end
+  end
+
+  defp in_rect?(nil, _x, _y), do: false
+
+  defp in_rect?(%{x: rx, y: ry, width: rw, height: rh}, x, y) do
+    x >= rx and x < rx + rw and y >= ry and y < ry + rh
+  end
 
   defp handle_key(%Event.Key{code: "c", modifiers: mods} = key, state) do
     if "ctrl" in mods do

--- a/lib/ex_athena/chat/tui/view.ex
+++ b/lib/ex_athena/chat/tui/view.ex
@@ -54,6 +54,19 @@ defmodule ExAthena.Chat.Tui.View do
 
     {messages_rect, details_rect} = split_body(body_rect, state)
 
+    # Stash the layout rects so the App's mouse-event handler can route
+    # clicks and wheel scrolls without recomputing the layout. Process
+    # dict is per-process and is the same process the App callbacks run
+    # in, so this is safe and cheap.
+    tabs_rect = details_rect && %Rect{details_rect | height: 1}
+
+    Process.put(:tui_layout, %{
+      messages: messages_rect,
+      details: details_rect,
+      tabs: tabs_rect,
+      tab_titles: details_tab_titles(state)
+    })
+
     widgets =
       [
         {header(state), header_rect},
@@ -66,6 +79,11 @@ defmodule ExAthena.Chat.Tui.View do
       nil -> widgets
       popup_tuple -> widgets ++ [popup_tuple]
     end
+  end
+
+  defp details_tab_titles(state) do
+    tabs = State.details_tabs()
+    Enum.map(tabs, &{&1, tab_title(&1, state)})
   end
 
   defp split_body(body_rect, %State{show_details: false}), do: {body_rect, nil}


### PR DESCRIPTION
## Summary

ex_ratatui already decodes mouse events but never enables crossterm's mouse capture, so wheel/click events never reached us. Wires it up:

- Enables X10 mouse reporting + SGR-extended coords via ANSI (\`\e[?1000h\e[?1006h\`) after the App starts; disabled on exit.
- Wheel up/down scrolls the pane under the cursor by 3 rows.
- Left-click on a Timeline / Changes tab title switches that tab.
- Layout rects are stashed in process dict from \`build_frame\` so \`handle_event\` can hit-test without recomputing.

## Test plan
- [x] \`mix compile\` clean
- [x] \`mix format\` clean
- [x] \`mix test test/ex_athena/chat\` — 136 tests pass
- [ ] Manual: scroll wheel on the messages pane → it scrolls
- [ ] Manual: scroll wheel on the details pane → it scrolls
- [ ] Manual: click "Changes" tab → switches tab