### PR TITLE
fix(tui): mouse-capture writes to /dev/tty, not :standard_io

### DIFF
--- a/lib/ex_athena/chat/tui.ex
+++ b/lib/ex_athena/chat/tui.ex
@@ -51,14 +51,31 @@ defmodule ExAthena.Chat.Tui do
     # ex_ratatui's NIF enables crossterm raw mode + alternate screen but
     # does NOT toggle mouse capture, so wheel/click events never reach us.
     # Enable X10 mouse reporting + SGR-extended mode (unlimited coords)
-    # ourselves via ANSI. Disabled in the {:DOWN, ...} cleanup below.
-    IO.write("\e[?1000h\e[?1006h")
+    # ourselves via ANSI. We bypass :standard_io and write to /dev/tty
+    # directly because suspend_beam_stdin_reader/0 above tears down
+    # BEAM's I/O subsystem — IO.write/2 to :standard_io would raise
+    # :terminated.
+    write_to_tty("\e[?1000h\e[?1006h")
 
     ref = Process.monitor(pid)
 
     receive do
       {:DOWN, ^ref, :process, ^pid, _reason} ->
-        IO.write("\e[?1006l\e[?1000l")
+        write_to_tty("\e[?1006l\e[?1000l")
+        :ok
+    end
+  end
+
+  defp write_to_tty(bytes) do
+    case File.open("/dev/tty", [:write, :raw]) do
+      {:ok, dev} ->
+        try do
+          IO.binwrite(dev, bytes)
+        after
+          File.close(dev)
+        end
+
+      _ ->
         :ok
     end
   end


### PR DESCRIPTION
## Why

#78 enabled mouse capture via \`IO.write/2\` to \`:standard_io\` AFTER \`suspend_beam_stdin_reader/0\`. That call kills \`:user_drv_reader\` and tears down BEAM's I/O subsystem, so the next \`:standard_io\` write raised \`:terminated\` and the chat crashed on launch:

\`\`\`
** (ErlangError) Erlang error: :terminated
    io.erl:198: :io.put_chars(:standard_io, "\e[?1000h\e[?1006h")
    lib/ex_athena/chat/tui.ex:55: ExAthena.Chat.Tui.start/1
\`\`\`

## Fix

Open \`/dev/tty\` with \`[:write, :raw]\` and write the escape codes there directly — same physical terminal, bypasses BEAM's I/O. One helper (\`write_to_tty/1\`) used for both the enable (on start) and the disable (on \`{:DOWN, ...}\`).

## Test plan
- [x] \`mix compile\` clean
- [x] \`mix test test/ex_athena/chat\` — 136 tests pass
- [ ] Manual: \`mix athena.chat\` launches without crashing; wheel + tab clicks still work