### PR TITLE
feat(tools): exclude _build/deps/node_modules from Glob/Grep by default

### DIFF
--- a/lib/ex_athena/permissions.ex
+++ b/lib/ex_athena/permissions.ex
@@ -257,4 +257,17 @@ defmodule ExAthena.Permissions do
   @doc "Static list of read-only tool names the `:plan` phase permits."
   @spec readonly_tools() :: [String.t()]
   def readonly_tools, do: @readonly_tools
+
+  @artifact_dirs ~w(_build/ deps/ node_modules/ .git/ priv/static/ tmp/)
+
+  @doc """
+  Path prefixes that `Glob`/`Grep` skip by default — build outputs and
+  dependency caches that pollute the model's context without adding signal.
+
+  Each entry ends in `/` so plain `String.starts_with?/2` matches a whole
+  directory and never a same-named file at the root. Pass
+  `include_artifacts: true` to either tool to bypass the filter.
+  """
+  @spec artifact_dirs() :: [String.t()]
+  def artifact_dirs, do: @artifact_dirs
 end

--- a/lib/ex_athena/tools/glob.ex
+++ b/lib/ex_athena/tools/glob.ex
@@ -6,6 +6,8 @@ defmodule ExAthena.Tools.Glob do
 
     * `pattern` (required) — `Path.wildcard/1`-compatible pattern, e.g. `lib/**/*.ex`.
     * `max_results` (optional, default 200) — cap on the number of paths returned.
+    * `include_artifacts` (optional, default false) — when true, returns paths under
+      `_build/`, `deps/`, `node_modules/`, `.git/`, `priv/static/`, and `tmp/` too.
 
   Result is a newline-separated list of paths relative to `ctx.cwd`.
   """
@@ -14,6 +16,8 @@ defmodule ExAthena.Tools.Glob do
 
   @default_max 200
   @hard_cap 5_000
+
+  @artifact_dirs ExAthena.Permissions.artifact_dirs()
 
   @impl true
   def name, do: "glob"
@@ -28,7 +32,12 @@ defmodule ExAthena.Tools.Glob do
       type: "object",
       properties: %{
         pattern: %{type: "string", description: "Path.wildcard pattern"},
-        max_results: %{type: "integer", description: "cap on results (default 200)"}
+        max_results: %{type: "integer", description: "cap on results (default 200)"},
+        include_artifacts: %{
+          type: "boolean",
+          description:
+            "Include `_build/`, `deps/`, `node_modules/`, `.git/`, `priv/static/`, `tmp/` paths (default false)"
+        }
       },
       required: ["pattern"]
     }
@@ -40,12 +49,14 @@ defmodule ExAthena.Tools.Glob do
   @impl true
   def execute(%{"pattern" => pattern} = args, %{cwd: cwd}) when is_binary(pattern) do
     max = clamp(Map.get(args, "max_results", @default_max))
+    include_artifacts = Map.get(args, "include_artifacts", false) == true
 
     results =
       cwd
       |> Path.join(pattern)
       |> Path.wildcard()
       |> Enum.map(&Path.relative_to(&1, cwd))
+      |> filter_artifacts(include_artifacts)
       |> Enum.take(max)
 
     ui = %{
@@ -64,6 +75,14 @@ defmodule ExAthena.Tools.Glob do
 
   defp clamp(n) when is_integer(n) and n > 0, do: min(n, @hard_cap)
   defp clamp(_), do: @default_max
+
+  defp filter_artifacts(paths, true), do: paths
+
+  defp filter_artifacts(paths, false) do
+    Enum.reject(paths, fn path ->
+      Enum.any?(@artifact_dirs, &String.starts_with?(path, &1))
+    end)
+  end
 
   defp format([]), do: "(no matches)"
   defp format(results), do: Enum.join(results, "\n")

--- a/lib/ex_athena/tools/grep.ex
+++ b/lib/ex_athena/tools/grep.ex
@@ -10,12 +10,16 @@ defmodule ExAthena.Tools.Grep do
     * `pattern` (required) — regex.
     * `path_glob` (optional) — restrict the scan to files matching this glob.
     * `max_results` (optional, default 200) — cap on matching lines returned.
+    * `include_artifacts` (optional, default false) — when true, also scans paths
+      under `_build/`, `deps/`, `node_modules/`, `.git/`, `priv/static/`, `tmp/`.
   """
 
   @behaviour ExAthena.Tool
 
   @default_max 200
   @hard_cap 2_000
+
+  @artifact_dirs ExAthena.Permissions.artifact_dirs()
 
   @impl true
   def name, do: "grep"
@@ -32,7 +36,12 @@ defmodule ExAthena.Tools.Grep do
       properties: %{
         pattern: %{type: "string"},
         path_glob: %{type: "string"},
-        max_results: %{type: "integer"}
+        max_results: %{type: "integer"},
+        include_artifacts: %{
+          type: "boolean",
+          description:
+            "Include `_build/`, `deps/`, `node_modules/`, `.git/`, `priv/static/`, `tmp/` paths (default false)"
+        }
       },
       required: ["pattern"]
     }
@@ -45,10 +54,11 @@ defmodule ExAthena.Tools.Grep do
   def execute(%{"pattern" => pattern} = args, %{cwd: cwd}) when is_binary(pattern) do
     max = clamp(Map.get(args, "max_results", @default_max))
     glob = Map.get(args, "path_glob")
+    include_artifacts = Map.get(args, "include_artifacts", false) == true
 
     case System.find_executable("rg") do
-      nil -> elixir_grep(pattern, glob, cwd, max)
-      rg -> rg_grep(rg, pattern, glob, cwd, max)
+      nil -> elixir_grep(pattern, glob, cwd, max, include_artifacts)
+      rg -> rg_grep(rg, pattern, glob, cwd, max, include_artifacts)
     end
   end
 
@@ -57,12 +67,15 @@ defmodule ExAthena.Tools.Grep do
   defp clamp(n) when is_integer(n) and n > 0, do: min(n, @hard_cap)
   defp clamp(_), do: @default_max
 
-  defp rg_grep(rg, pattern, glob, cwd, max) do
+  defp rg_grep(rg, pattern, glob, cwd, max, include_artifacts) do
     # Pass `.` explicitly — rg hangs on stdin when it can't detect a path arg
     # and runs under Port.
+    base_args = ["--no-heading", "--line-number", "--max-count", to_string(max), pattern, "."]
+
     args =
-      ["--no-heading", "--line-number", "--max-count", to_string(max), pattern, "."]
+      base_args
       |> maybe_prepend_glob(glob)
+      |> prepend_artifact_excludes(include_artifacts)
 
     case System.cmd(rg, args, cd: cwd, stderr_to_stdout: true) do
       {output, 0} -> build_payload(pattern, take_lines(output, max))
@@ -87,13 +100,27 @@ defmodule ExAthena.Tools.Grep do
   defp maybe_prepend_glob(args, nil), do: args
   defp maybe_prepend_glob(args, glob), do: ["--glob", glob | args]
 
-  defp elixir_grep(pattern, glob, cwd, max) do
+  defp prepend_artifact_excludes(args, true), do: args
+
+  defp prepend_artifact_excludes(args, false) do
+    # Each dir ends in `/` in @artifact_dirs; strip the trailing slash for the
+    # ripgrep `!dir/**` shape and stick the exclusions at the front of args.
+    @artifact_dirs
+    |> Enum.flat_map(fn dir ->
+      bare = String.trim_trailing(dir, "/")
+      ["--glob", "!#{bare}/**"]
+    end)
+    |> Enum.concat(args)
+  end
+
+  defp elixir_grep(pattern, glob, cwd, max, include_artifacts) do
     with {:ok, regex} <- Regex.compile(pattern) do
       files =
         cwd
         |> Path.join(glob || "**/*")
         |> Path.wildcard()
         |> Enum.filter(&File.regular?/1)
+        |> Enum.reject(&artifact_path?(&1, cwd, include_artifacts))
 
       matches =
         files
@@ -109,6 +136,13 @@ defmodule ExAthena.Tools.Grep do
     else
       {:error, {msg, _offset}} -> {:error, {:invalid_regex, to_string(msg)}}
     end
+  end
+
+  defp artifact_path?(_path, _cwd, true), do: false
+
+  defp artifact_path?(path, cwd, false) do
+    rel = Path.relative_to(path, cwd)
+    Enum.any?(@artifact_dirs, &String.starts_with?(rel, &1))
   end
 
   defp scan_file(path, body, regex, cwd) do

--- a/test/ex_athena/tools/glob_grep_test.exs
+++ b/test/ex_athena/tools/glob_grep_test.exs
@@ -61,4 +61,82 @@ defmodule ExAthena.Tools.GlobGrepTest do
   test "Grep requires pattern", %{ctx: ctx} do
     assert {:error, :missing_pattern} = Grep.execute(%{}, ctx)
   end
+
+  describe "build-artifact filtering" do
+    setup do
+      dir = Path.join(System.tmp_dir!(), "gg_filter_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(Path.join(dir, "lib"))
+      File.mkdir_p!(Path.join(dir, "_build/dev/lib/phoenix/priv/templates/phx.gen.auth"))
+      File.mkdir_p!(Path.join(dir, "deps/phoenix/lib"))
+      File.mkdir_p!(Path.join(dir, "node_modules/foo"))
+      File.mkdir_p!(Path.join(dir, ".git"))
+      File.mkdir_p!(Path.join(dir, "priv/static/assets"))
+      File.mkdir_p!(Path.join(dir, "tmp"))
+
+      File.write!(Path.join(dir, "lib/app.ex"), "defmodule App do\n  def needle, do: :ok\nend\n")
+
+      File.write!(
+        Path.join(dir, "_build/dev/lib/phoenix/priv/templates/phx.gen.auth/auth.ex"),
+        "defmodule Phx.Auth do\n  def needle, do: :ok\nend\n"
+      )
+
+      File.write!(
+        Path.join(dir, "deps/phoenix/lib/phoenix.ex"),
+        "defmodule Phoenix do\n  def needle, do: :ok\nend\n"
+      )
+
+      File.write!(Path.join(dir, "node_modules/foo/bar.js"), "// needle\n")
+      File.write!(Path.join(dir, ".git/HEAD"), "ref: needle\n")
+      File.write!(Path.join(dir, "priv/static/assets/app.css"), "/* needle */\n")
+      File.write!(Path.join(dir, "tmp/scratch.ex"), "defmodule Scratch do\n  def needle, do: :ok\nend\n")
+
+      on_exit(fn -> File.rm_rf!(dir) end)
+      {:ok, ctx: ToolContext.new(cwd: dir)}
+    end
+
+    test "Glob excludes _build, deps, node_modules, .git, priv/static, tmp by default",
+         %{ctx: ctx} do
+      {:ok, output, ui} = Glob.execute(%{"pattern" => "**/*.ex"}, ctx)
+
+      assert output =~ "lib/app.ex"
+      refute output =~ "_build/"
+      refute output =~ "deps/"
+      refute output =~ "tmp/"
+      assert ui.payload.count == 1
+    end
+
+    test "Glob honors include_artifacts: true and returns build/dep paths too",
+         %{ctx: ctx} do
+      {:ok, output, _ui} =
+        Glob.execute(%{"pattern" => "**/*.ex", "include_artifacts" => true}, ctx)
+
+      assert output =~ "lib/app.ex"
+      assert output =~ "_build/"
+      assert output =~ "deps/"
+      assert output =~ "tmp/"
+    end
+
+    test "Grep excludes the same artifact directories by default", %{ctx: ctx} do
+      {:ok, output, ui} = Grep.execute(%{"pattern" => "needle"}, ctx)
+
+      assert output =~ "lib/app.ex"
+      refute output =~ "_build/"
+      refute output =~ "deps/"
+      refute output =~ "node_modules/"
+      refute output =~ ".git/"
+      refute output =~ "priv/static/"
+      refute output =~ "tmp/"
+      assert ui.payload.count >= 1
+    end
+
+    test "Grep honors include_artifacts: true", %{ctx: ctx} do
+      {:ok, output, _ui} =
+        Grep.execute(%{"pattern" => "needle", "include_artifacts" => true}, ctx)
+
+      assert output =~ "lib/app.ex"
+      assert output =~ "_build/"
+      assert output =~ "deps/"
+    end
+  end
 end


### PR DESCRIPTION
## Summary

\`Glob\`/\`Grep\` previously returned every path \`Path.wildcard\` could see, including the build-output and dependency trees. In a downstream udin_code session this dragged a Phoenix scope-assessment off track — \`Glob **/*.ex\` returned mostly \`web/_build/dev/lib/phoenix/priv/templates/phx.gen.auth/*\` paths and the model concluded the project was about authentication.

- \`ExAthena.Permissions.artifact_dirs/0\` — canonical list of dir prefixes both tools skip: \`_build/\`, \`deps/\`, \`node_modules/\`, \`.git/\`, \`priv/static/\`, \`tmp/\`.
- \`Glob.execute/2\` rejects matching prefixes after \`Path.wildcard\`.
- \`Grep.execute/2\` passes \`--glob='!dir/**'\` for each prefix to ripgrep in the rg path, and rejects the same prefixes in the \`elixir_grep\` fallback.
- Both tools accept \`include_artifacts: true\` to bypass the filter when the model genuinely needs to inspect build output.

## Test plan

- [x] \`mix test test/ex_athena/tools/glob_grep_test.exs\` — 11 tests pass, including 4 new ones covering Glob default-exclude, Glob include-artifacts opt-in, Grep default-exclude, and Grep include-artifacts opt-in.
- [x] \`mix test\` — 780 tests, 1 pre-existing failure in \`test/ex_athena/loop/named_subagent_test.exs:93\` ("subagent finished" assertion); reproduces on \`main\` without this change.
- [ ] After merge: rerun the stuck udin_code ticket and confirm the first scope \`Glob\` returns \`web/lib/...\` first, not \`_build/...\`.