### PR TITLE
fix(tui): show inline edit diffs + untracked files in the Changes tab

### DIFF
--- a/lib/ex_athena/chat/tui.ex
+++ b/lib/ex_athena/chat/tui.ex
@@ -755,7 +755,7 @@ defmodule ExAthena.Chat.Tui do
   end
 
   defp render_untracked_file(rel, cwd) do
-    header = [
+    header_base = [
       "diff --git a/#{rel} b/#{rel}",
       "new file mode 100644",
       "--- /dev/null",
@@ -766,13 +766,17 @@ defmodule ExAthena.Chat.Tui do
 
     case File.stat(path) do
       {:ok, %{type: :regular, size: size}} when size > @max_untracked_bytes ->
-        header ++ ["+(file too large to show: #{size} bytes)"]
+        # Synthesize a 1-line hunk header so the structured diff parser
+        # counts the placeholder as part of the file rather than dropping
+        # bare `+` lines that have no enclosing hunk.
+        header_base ++
+          ["@@ -0,0 +1,1 @@", "+(file too large to show: #{size} bytes)"]
 
       {:ok, %{type: :regular}} ->
         case File.read(path) do
           {:ok, content} ->
             if binary_content?(content) do
-              header ++ ["+(binary file)"]
+              header_base ++ ["@@ -0,0 +1,1 @@", "+(binary file)"]
             else
               lines = String.split(content, "\n")
               total = length(lines)
@@ -785,7 +789,9 @@ defmodule ExAthena.Chat.Tui do
                   do: ["+… (#{total - shown} more lines)"],
                   else: []
 
-              header ++ diff_lines ++ footer
+              # `@@ -0,0 +1,N @@` — git's convention for a new file.
+              hunk_header = "@@ -0,0 +1,#{shown + length(footer)} @@"
+              header_base ++ [hunk_header] ++ diff_lines ++ footer
             end
 
           _ ->

--- a/lib/ex_athena/chat/tui/view.ex
+++ b/lib/ex_athena/chat/tui/view.ex
@@ -824,51 +824,47 @@ defmodule ExAthena.Chat.Tui.View do
     end
   end
 
-  defp diff_preview_rows(%{lines: lines, changed_lines: changed, total_lines: total}, width) do
-    {added, removed} =
-      Enum.reduce(lines, {0, 0}, fn
-        {:ins, _}, {a, r} -> {a + 1, r}
-        {:del, _}, {a, r} -> {a, r + 1}
-        _, acc -> acc
+  # Edit / Write / apply_patch tool UI payloads carry the raw `before`
+  # and `after` strings — not a pre-diffed line list — so we compute the
+  # Myers diff inline. Same logic as ChatLive's `build_ui_entry(:diff)`
+  # in the web LiveView (chat_live.ex:1568).
+  defp diff_preview_rows(%{before: before, after: aft}, width) do
+    before_lines = String.split(to_string(before), "\n")
+    after_lines = String.split(to_string(aft), "\n")
+
+    all_lines =
+      Elixir.List.myers_difference(before_lines, after_lines)
+      |> Enum.flat_map(fn
+        {:eq, ls} -> Enum.map(ls, &{:eq, &1})
+        {:ins, ls} -> Enum.map(ls, &{:ins, &1})
+        {:del, ls} -> Enum.map(ls, &{:del, &1})
       end)
+
+    added = Enum.count(all_lines, fn {k, _} -> k == :ins end)
+    removed = Enum.count(all_lines, fn {k, _} -> k == :del end)
 
     stat_text =
       cond do
-        added > 0 and removed > 0 ->
-          "  └ +#{added} −#{removed} lines (#{changed}/#{total} changed)"
-
-        added > 0 ->
-          "  └ Added #{added} line#{if added == 1, do: "", else: "s"}"
-
-        removed > 0 ->
-          "  └ Removed #{removed} line#{if removed == 1, do: "", else: "s"}"
-
-        true ->
-          "  └ #{changed} line#{if changed == 1, do: "", else: "s"} changed"
+        added > 0 and removed > 0 -> "  └ +#{added} −#{removed} lines"
+        added > 0 -> "  └ Added #{added} line#{if added == 1, do: "", else: "s"}"
+        removed > 0 -> "  └ Removed #{removed} line#{if removed == 1, do: "", else: "s"}"
+        true -> "  └ no net change"
       end
 
     stat_row =
       {%Paragraph{text: stat_text, style: %Style{fg: :dark_gray}, wrap: true},
        wrapped_height(stat_text, width)}
 
-    # Show the first ~6 non-equal lines as colored diff snippets.
     snippet_rows =
-      lines
+      all_lines
       |> Enum.reject(fn {kind, _} -> kind == :eq end)
       |> Enum.take(6)
       |> Enum.map(fn {kind, line} ->
-        prefix =
+        {prefix, style} =
           case kind do
-            :ins -> "    + "
-            :del -> "    - "
-            _ -> "      "
-          end
-
-        style =
-          case kind do
-            :ins -> %Style{fg: :green}
-            :del -> %Style{fg: :red}
-            _ -> %Style{fg: :dark_gray}
+            :ins -> {"    + ", %Style{fg: :green}}
+            :del -> {"    - ", %Style{fg: :red}}
+            _ -> {"      ", %Style{fg: :dark_gray}}
           end
 
         text = prefix <> truncate(line, max(width - 6, 20))

--- a/test/ex_athena/tools/glob_grep_test.exs
+++ b/test/ex_athena/tools/glob_grep_test.exs
@@ -89,7 +89,11 @@ defmodule ExAthena.Tools.GlobGrepTest do
       File.write!(Path.join(dir, "node_modules/foo/bar.js"), "// needle\n")
       File.write!(Path.join(dir, ".git/HEAD"), "ref: needle\n")
       File.write!(Path.join(dir, "priv/static/assets/app.css"), "/* needle */\n")
-      File.write!(Path.join(dir, "tmp/scratch.ex"), "defmodule Scratch do\n  def needle, do: :ok\nend\n")
+
+      File.write!(
+        Path.join(dir, "tmp/scratch.ex"),
+        "defmodule Scratch do\n  def needle, do: :ok\nend\n"
+      )
 
       on_exit(fn -> File.rm_rf!(dir) end)
       {:ok, ctx: ToolContext.new(cwd: dir)}


### PR DESCRIPTION
## Why

User report: "the inline diff is not showing in chat and the added files are not shown."

Both were cosmetic regressions from earlier PRs:

### 1. Inline edit diffs never appeared

The Edit / Write / apply_patch tools emit a \`:tool_ui :diff\` payload that carries only \`before\` / \`after\` (raw strings) — but my \`diff_preview_rows/2\` (from #76) was pattern-matching on a pre-diffed \`%{lines: …, changed_lines: …, total_lines: …}\` shape. Every block with a :diff UI fell through to the catch-all clause and rendered nothing.

**Fix:** Compute the Myers diff inline (\`Elixir.List.myers_difference/2\`, fully qualified because the \`ExRatatui.Widgets.List\` alias shadows it). Renders \`Added N lines\` / \`Removed N lines\` plus the first 6 colored changed lines. Matches the web LiveView's \`build_ui_entry(:diff)\`.

### 2. Untracked files were missing from the Changes tab

When the agent creates a brand-new file, \`render_untracked_file/2\` synthesizes a unified-diff stanza for it — but it had no \`@@\` hunk header. The structured parser (#77) only added \`+\` lines when \`current_hunk\` was set, so the body was silently dropped.

**Fix:** Add a \`@@ -0,0 +1,N @@\` line (git's convention for new files) before the \`+\` body so the parser keeps it.

## Test plan
- [x] \`mix compile\` clean (no warnings)
- [x] \`mix test test/ex_athena/chat\` — 136 tests pass
- [ ] Manual: agent runs Edit → chat shows \`● Update(path)\` block with colored diff snippet
- [ ] Manual: agent creates a new file → Changes tab shows the new file