### PR TITLE
fix(tools): also exclude nested _build/deps/... (Phoenix-in-subdir layouts)

### DIFF
--- a/lib/ex_athena/tools/glob.ex
+++ b/lib/ex_athena/tools/glob.ex
@@ -79,8 +79,14 @@ defmodule ExAthena.Tools.Glob do
   defp filter_artifacts(paths, true), do: paths
 
   defp filter_artifacts(paths, false) do
-    Enum.reject(paths, fn path ->
-      Enum.any?(@artifact_dirs, &String.starts_with?(path, &1))
+    Enum.reject(paths, &artifact_path?/1)
+  end
+
+  defp artifact_path?(path) do
+    Enum.any?(@artifact_dirs, fn dir ->
+      # Matches at root (`_build/...`) and nested (`web/_build/...`) — the
+      # leading-slash check is what catches Phoenix-in-subdir layouts.
+      String.starts_with?(path, dir) or String.contains?(path, "/" <> dir)
     end)
   end
 

--- a/lib/ex_athena/tools/grep.ex
+++ b/lib/ex_athena/tools/grep.ex
@@ -103,12 +103,13 @@ defmodule ExAthena.Tools.Grep do
   defp prepend_artifact_excludes(args, true), do: args
 
   defp prepend_artifact_excludes(args, false) do
-    # Each dir ends in `/` in @artifact_dirs; strip the trailing slash for the
-    # ripgrep `!dir/**` shape and stick the exclusions at the front of args.
+    # ripgrep glob semantics: `!dir/**` only matches at the search root, so
+    # use `!**/dir/**` to also catch nested cases like `web/_build/...` in
+    # Phoenix-in-subdir layouts.
     @artifact_dirs
     |> Enum.flat_map(fn dir ->
       bare = String.trim_trailing(dir, "/")
-      ["--glob", "!#{bare}/**"]
+      ["--glob", "!**/#{bare}/**", "--glob", "!#{bare}/**"]
     end)
     |> Enum.concat(args)
   end
@@ -142,7 +143,11 @@ defmodule ExAthena.Tools.Grep do
 
   defp artifact_path?(path, cwd, false) do
     rel = Path.relative_to(path, cwd)
-    Enum.any?(@artifact_dirs, &String.starts_with?(rel, &1))
+
+    Enum.any?(@artifact_dirs, fn dir ->
+      # Matches at root and nested (`web/_build/...`); see Glob for the rationale.
+      String.starts_with?(rel, dir) or String.contains?(rel, "/" <> dir)
+    end)
   end
 
   defp scan_file(path, body, regex, cwd) do

--- a/test/ex_athena/tools/glob_grep_test.exs
+++ b/test/ex_athena/tools/glob_grep_test.exs
@@ -142,5 +142,50 @@ defmodule ExAthena.Tools.GlobGrepTest do
       assert output =~ "_build/"
       assert output =~ "deps/"
     end
+
+    test "Glob excludes nested artifact dirs (e.g. web/_build, web/deps)", %{ctx: ctx} do
+      # Phoenix-in-subdir layout: build/dep dirs are under `web/`, not at the root.
+      File.mkdir_p!(Path.join(ctx.cwd, "web/_build/dev/lib"))
+      File.mkdir_p!(Path.join(ctx.cwd, "web/deps/phoenix/lib"))
+      File.mkdir_p!(Path.join(ctx.cwd, "web/lib"))
+      File.mkdir_p!(Path.join(ctx.cwd, "web/priv/static/assets"))
+      File.write!(Path.join(ctx.cwd, "web/lib/app.ex"), "real\n")
+      File.write!(Path.join(ctx.cwd, "web/_build/dev/lib/template.ex"), "noise\n")
+      File.write!(Path.join(ctx.cwd, "web/deps/phoenix/lib/phoenix.ex"), "noise\n")
+      File.write!(Path.join(ctx.cwd, "web/priv/static/assets/app.css"), "noise\n")
+
+      {:ok, output, _ui} = Glob.execute(%{"pattern" => "web/**/*.ex"}, ctx)
+
+      assert output =~ "web/lib/app.ex"
+      refute output =~ "web/_build/"
+      refute output =~ "web/deps/"
+    end
+
+    test "Grep excludes nested artifact dirs (e.g. web/_build, web/deps)", %{ctx: ctx} do
+      File.mkdir_p!(Path.join(ctx.cwd, "web/_build/dev/lib"))
+      File.mkdir_p!(Path.join(ctx.cwd, "web/deps/phoenix/lib"))
+      File.mkdir_p!(Path.join(ctx.cwd, "web/lib"))
+
+      File.write!(
+        Path.join(ctx.cwd, "web/lib/app.ex"),
+        "defmodule WebApp do\n  def needle, do: :ok\nend\n"
+      )
+
+      File.write!(
+        Path.join(ctx.cwd, "web/_build/dev/lib/template.ex"),
+        "defmodule Tmpl do\n  def needle, do: :noise\nend\n"
+      )
+
+      File.write!(
+        Path.join(ctx.cwd, "web/deps/phoenix/lib/phoenix.ex"),
+        "defmodule Phx do\n  def needle, do: :noise\nend\n"
+      )
+
+      {:ok, output, _ui} = Grep.execute(%{"pattern" => "needle"}, ctx)
+
+      assert output =~ "web/lib/app.ex"
+      refute output =~ "web/_build/"
+      refute output =~ "web/deps/"
+    end
   end
 end


### PR DESCRIPTION
## Summary

Follow-up to #80. The artifact filter in Glob/Grep used \`String.starts_with?\` against the path prefix, which only matches \`_build/...\` at the search root. Nested cases like \`web/_build/...\` (Phoenix app under a subdir) slipped through — caught while monitoring a udin worktree where Glob still dumped \`web/_build/dev/lib/phoenix/priv/templates/phx.gen.auth/*.ex\` into the model's context despite #80 being live.

- \`Glob.artifact_path?/1\`: also check \`String.contains?(path, "/" <> dir)\` so the filter triggers when an artifact dir appears at any depth, not just at the root.
- \`Grep.artifact_path?/3\` (elixir_grep fallback): same fix.
- \`Grep.prepend_artifact_excludes/2\` (rg path): emit both \`!dir/**\` (root) and \`!**/dir/**\` (nested) as ripgrep glob excludes.
- Two new tests for the Phoenix-in-subdir layout (one for Glob, one for Grep).

## Test plan

- [x] \`mix test test/ex_athena/tools/glob_grep_test.exs\` — 13 tests pass (11 existing + 2 new for nested artifact dirs).
- [ ] After merge: rerun the udin scope_assessment session against a \`web/\` layout and confirm the first \`Glob\` returns \`web/lib/...\` first, no \`web/_build/...\` paths.