### PR TITLE
fix(compactor): tokens_for must count tool_result payloads

### DIFF
--- a/lib/ex_athena/compactor.ex
+++ b/lib/ex_athena/compactor.ex
@@ -83,8 +83,21 @@ defmodule ExAthena.Compactor do
     end)
   end
 
+  # Tool-result messages can carry kilobytes of bash/Read output. Counting
+  # them as a fixed 16 lets compaction's `should_compact?` underestimate the
+  # real prompt by ~10× — observed in production where a 94K-token prompt
+  # was reported as ~5K and compaction never fired before max_iterations.
+  defp tokens_for(%Message{role: :tool, tool_results: results}) when is_list(results) do
+    Enum.reduce(results, 0, fn tr, acc -> acc + 16 + result_tokens(tr) end)
+  end
+
   defp tokens_for(%Message{content: content}) when is_binary(content),
     do: div(byte_size(content), 4) + 8
 
   defp tokens_for(_), do: 16
+
+  defp result_tokens(%{content: content}) when is_binary(content),
+    do: div(byte_size(content), 4)
+
+  defp result_tokens(_), do: 0
 end

--- a/test/ex_athena/compactor_test.exs
+++ b/test/ex_athena/compactor_test.exs
@@ -1,0 +1,92 @@
+defmodule ExAthena.CompactorTest do
+  use ExUnit.Case, async: true
+
+  alias ExAthena.Compactor
+  alias ExAthena.Messages.{Message, ToolCall, ToolResult}
+
+  describe "estimate_tokens/1" do
+    test "counts text content at ~4 chars per token + 8 fixed overhead" do
+      msg = %Message{role: :user, content: String.duplicate("x", 4000)}
+      assert Compactor.estimate_tokens([msg]) == div(4000, 4) + 8
+    end
+
+    test "counts an assistant tool_calls message by JSON envelope size" do
+      msg = %Message{
+        role: :assistant,
+        content: nil,
+        tool_calls: [%ToolCall{id: "1", name: "bash", arguments: %{"cmd" => "ls"}}]
+      }
+
+      # 64 envelope + arguments JSON / 4
+      args_json = byte_size(Jason.encode!(%{"cmd" => "ls"}))
+      assert Compactor.estimate_tokens([msg]) == 64 + div(args_json, 4)
+    end
+
+    test "counts a tool_result message's payload (not a fixed 16-token blob)" do
+      # A multi-KB tool result — e.g. a long bash output or a big file read.
+      big_payload = String.duplicate("a", 40_000)
+
+      msg = %Message{
+        role: :tool,
+        content: nil,
+        tool_results: [%ToolResult{tool_call_id: "1", content: big_payload, is_error: false}]
+      }
+
+      tokens = Compactor.estimate_tokens([msg])
+      # Must reflect the real payload size, not collapse to ~16. Allow a
+      # generous floor so a future heuristic refinement doesn't break this
+      # test, but the failure observed in production was tokens == 16.
+      assert tokens >= div(40_000, 4),
+             "tool_result payload should count toward the estimate; got #{tokens}"
+    end
+
+    test "sums multiple tool_results in a single message" do
+      msg = %Message{
+        role: :tool,
+        content: nil,
+        tool_results: [
+          %ToolResult{tool_call_id: "1", content: String.duplicate("a", 4000), is_error: false},
+          %ToolResult{tool_call_id: "2", content: String.duplicate("b", 4000), is_error: false}
+        ]
+      }
+
+      assert Compactor.estimate_tokens([msg]) >= div(8000, 4)
+    end
+
+    test "tool_result with nil content stays cheap (no crash)" do
+      msg = %Message{
+        role: :tool,
+        content: nil,
+        tool_results: [%ToolResult{tool_call_id: "1", content: nil, is_error: true}]
+      }
+
+      tokens = Compactor.estimate_tokens([msg])
+      assert is_integer(tokens) and tokens >= 0
+    end
+
+    test "regression: a conversation dominated by tool_results no longer reads as ~16 tokens each" do
+      # Reproduces the production bug: 30 tool messages each holding ~3KB of
+      # bash output were collectively counted as ~480 tokens (16 * 30), so
+      # compaction never fired even though the real prompt was ~22.5K tokens.
+      msgs =
+        for i <- 1..30 do
+          %Message{
+            role: :tool,
+            content: nil,
+            tool_results: [
+              %ToolResult{
+                tool_call_id: "tc_#{i}",
+                content: String.duplicate("x", 3_000),
+                is_error: false
+              }
+            ]
+          }
+        end
+
+      tokens = Compactor.estimate_tokens(msgs)
+      # 30 messages × 3000 bytes / 4 chars-per-token = ~22_500. Pre-fix this
+      # returned ~480. Assert we're at least in the right order of magnitude.
+      assert tokens >= 15_000, "expected ~22.5K tokens, got #{tokens}"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

\`Compactor.estimate_tokens/1\` was undercounting tool-result messages by ~10× in production. Every \`%Message{role: :tool, tool_results: [...]}\` hit the catchall clause and got **16 tokens regardless of payload size**. With a loop dominated by Read/bash output (each tool_result holding kilobytes of content), the \`should_compact?\` trigger (60% of max_tokens, default 128_000 → ~77K) never fired even when the real prompt was ~94K tokens.

Observed downstream in a udin_code planning session: 25 iterations, ballooned to 94,631 input tokens on the final turn, terminated with \`:error_max_turns\` without ever invoking the compaction pipeline. No \`[:compaction, ...]\` event in the log.

- Add a \`tokens_for\` clause for \`%Message{role: :tool, tool_results: results}\` that sums each \`ToolResult\`'s \`byte_size(content)/4\` plus a small envelope overhead per result.
- New \`test/ex_athena/compactor_test.exs\` with 6 tests including a regression for the exact production shape (30 tool_results × 3KB each) that previously resolved to 480 tokens (16 × 30) and now resolves to ~22.5K — enough to cross the compaction threshold.

## Test plan

- [x] \`mix test test/ex_athena/compactor_test.exs\` — 6/6 pass
- [x] \`mix test\` — 788 tests, 1 unrelated pre-existing failure in \`named_subagent_test.exs:93\` (reproduces on \`main\`)
- [ ] After merge: rerun the udin_code planning session with the same model + corpus and confirm a \`[:compaction, …]\` telemetry event appears before \`:error_max_turns\` would otherwise fire