### PR TITLE
fix(tools): Write emits a :diff UI payload like Edit

### DIFF
--- a/lib/ex_athena/tools/write.ex
+++ b/lib/ex_athena/tools/write.ex
@@ -41,8 +41,32 @@ defmodule ExAthena.Tools.Write do
          {:ok, content} <- fetch_content(args),
          :ok <- File.mkdir_p(Path.dirname(path)),
          _ <- maybe_snapshot(ctx, path),
+         before = read_existing(path),
          :ok <- File.write(path, content) do
-      {:ok, "wrote #{byte_size(content)} bytes to #{Path.relative_to(path, ctx.cwd)}"}
+      llm = "wrote #{byte_size(content)} bytes to #{Path.relative_to(path, ctx.cwd)}"
+
+      ui = %{
+        kind: :diff,
+        payload: %{
+          path: path,
+          before: before,
+          after: content,
+          replacements: nil
+        }
+      }
+
+      {:ok, llm, ui}
+    end
+  end
+
+  # `""` for new files so the TUI's diff renderer treats the entire new
+  # content as added lines (Myers diff over [""] vs split(content) yields
+  # all `:ins`). Errors (permission denied, etc.) also map to `""` — the
+  # write itself either succeeded with that prior state or hasn't run yet.
+  defp read_existing(path) do
+    case File.read(path) do
+      {:ok, content} -> content
+      _ -> ""
     end
   end
 

--- a/test/ex_athena/tools/write_edit_test.exs
+++ b/test/ex_athena/tools/write_edit_test.exs
@@ -13,13 +13,15 @@ defmodule ExAthena.Tools.WriteEditTest do
 
   describe "Write" do
     test "creates a file and reports byte count", %{dir: dir, ctx: ctx} do
-      assert {:ok, msg} = Write.execute(%{"path" => "hello.txt", "content" => "hi"}, ctx)
+      assert {:ok, msg, _ui} =
+               Write.execute(%{"path" => "hello.txt", "content" => "hi"}, ctx)
+
       assert msg =~ "wrote 2 bytes"
       assert File.read!(Path.join(dir, "hello.txt")) == "hi"
     end
 
     test "creates parent directories automatically", %{dir: dir, ctx: ctx} do
-      assert {:ok, _} =
+      assert {:ok, _, _} =
                Write.execute(%{"path" => "nested/deeply/file.txt", "content" => "x"}, ctx)
 
       assert File.read!(Path.join(dir, "nested/deeply/file.txt")) == "x"
@@ -28,13 +30,38 @@ defmodule ExAthena.Tools.WriteEditTest do
     test "overwrites existing files", %{dir: dir, ctx: ctx} do
       path = Path.join(dir, "over.txt")
       File.write!(path, "old")
-      assert {:ok, _} = Write.execute(%{"path" => "over.txt", "content" => "new"}, ctx)
+      assert {:ok, _, _} = Write.execute(%{"path" => "over.txt", "content" => "new"}, ctx)
       assert File.read!(path) == "new"
     end
 
     test "missing arguments rejected", %{ctx: ctx} do
       assert {:error, :missing_path} = Write.execute(%{}, ctx)
       assert {:error, :missing_content} = Write.execute(%{"path" => "x"}, ctx)
+    end
+
+    test "emits a :diff UI payload with before=\"\" for new files",
+         %{dir: dir, ctx: ctx} do
+      content = "first line\nsecond line\n"
+
+      assert {:ok, _msg, %{kind: :diff, payload: payload}} =
+               Write.execute(%{"path" => "new.txt", "content" => content}, ctx)
+
+      assert payload.path == Path.join(dir, "new.txt")
+      assert payload.before == ""
+      assert payload.after == content
+    end
+
+    test "emits a :diff UI payload with the prior content as `before` on overwrite",
+         %{dir: dir, ctx: ctx} do
+      path = Path.join(dir, "over.txt")
+      File.write!(path, "old contents")
+
+      assert {:ok, _msg, %{kind: :diff, payload: payload}} =
+               Write.execute(%{"path" => "over.txt", "content" => "new contents"}, ctx)
+
+      assert payload.path == path
+      assert payload.before == "old contents"
+      assert payload.after == "new contents"
     end
   end
 


### PR DESCRIPTION
## Why

User report: \"the inline diff is not showing in chat\" — even after PR #81 fixed the renderer.

Root cause: \`Write\` returned a bare \`{:ok, llm_text}\` 2-tuple and emitted no UI payload at all. The TUI's inline-diff render is gated on \`block.ui.kind == :diff\` (\`tool_header_text/1\` and \`preview_widget_rows/1\`), so only Edit ever rendered with a colored snippet. The agent uses Write for new files / full rewrites much more than Edit, which is why the chat looked diff-less.

## Fix

Match Edit's payload from \`Write.execute/2\`:

1. Read the prior file contents (\`""\` for new files) before \`File.write/2\`.
2. Return \`{:ok, llm_text, %{kind: :diff, payload: %{path, before, after, replacements: nil}}}\`.

Reused machinery (no other code changes needed):
- \`react.ex:253-260\` turns 3-tuple returns into \`:tool_ui\` events.
- \`Tui.State.attach_tool_ui_to_block/2\` attaches them by \`tool_call_id\`.
- \`Tui.View.diff_preview_rows/2\` computes \`Elixir.List.myers_difference/2\` over \`before\`/\`after\` (PR #81).

Write blocks now render as \`● Create(path)\` + \`└ Added N lines\` + the first ~6 colored snippet lines.

## Out of scope

\`apply_patch\` emits \`kind: :patch\` (not \`:diff\`) — its inline diff also won't render. Follow-up.

## Test plan
- [x] \`mix compile\` clean
- [x] \`mix test test/ex_athena/tools/write_edit_test.exs\` — 10 tests pass (4 updated for 3-tuple shape, 2 new for new-file / overwrite payload)
- [x] \`mix test\` — 790 tests, same 1 pre-existing flake as main
- [ ] Manual: agent creates a new file → chat shows \`● Create(path)\` with green \`+\` lines
- [ ] Manual: agent overwrites an existing file → chat shows both old and new lines (red \`-\` + green \`+\`)