### PR TITLE
fix(read): reject empty and whitespace-only path arg

### DIFF
--- a/lib/ex_athena/chat/tui/state.ex
+++ b/lib/ex_athena/chat/tui/state.ex
@@ -78,6 +78,13 @@ defmodule ExAthena.Chat.Tui.State do
             # mid-verb. `items` are slash-prefixed verbs; `idx` is the
             # selected row (0-based).
             autocomplete: nil,
+            # Up/Down history cursor for the input. `nil` = not navigating
+            # (the user is typing fresh); an integer N = the Nth-most-recent
+            # prior user message (0 = newest). `history_draft` holds whatever
+            # was in the textarea before navigation started so Down can
+            # restore it.
+            history_idx: nil,
+            history_draft: "",
             # Which tab is active in the right details pane.
             details_tab: :timeline,
             # Lines of `git diff HEAD` for the :changes tab. Refreshed
@@ -115,6 +122,8 @@ defmodule ExAthena.Chat.Tui.State do
           stream_parser: %{mode: atom(), pending: String.t(), close_tag: String.t() | nil},
           streamed_this_turn?: boolean(),
           autocomplete: autocomplete(),
+          history_idx: non_neg_integer() | nil,
+          history_draft: String.t(),
           details_tab: :timeline | :changes,
           git_diff_lines: [String.t()],
           git_diff_scroll_offset: non_neg_integer(),
@@ -615,6 +624,94 @@ defmodule ExAthena.Chat.Tui.State do
   @doc "Clear the autocomplete popup state."
   @spec close_autocomplete(t()) :: t()
   def close_autocomplete(%__MODULE__{} = state), do: %{state | autocomplete: nil}
+
+  # ─ Input history (Up/Down navigation) ────────────────────────────────────
+
+  @doc """
+  Return the list of prior user-message contents in this session,
+  newest-first. Used by the input's Up/Down history navigation.
+  """
+  @spec history(t()) :: [String.t()]
+  def history(%__MODULE__{session: nil}), do: []
+
+  def history(%__MODULE__{session: %{messages: msgs}}) when is_list(msgs) do
+    msgs
+    |> Enum.filter(fn
+      %{role: :user} -> true
+      _ -> false
+    end)
+    |> Enum.map(&extract_user_text/1)
+    |> Enum.reject(&(&1 in [nil, ""]))
+    |> Enum.reverse()
+  end
+
+  def history(_), do: []
+
+  defp extract_user_text(%{content: c}) when is_binary(c), do: c
+  defp extract_user_text(%{content: parts}) when is_list(parts) do
+    parts
+    |> Enum.map(fn
+      %{type: :text, text: t} when is_binary(t) -> t
+      %{text: t} when is_binary(t) -> t
+      _ -> ""
+    end)
+    |> Enum.join("")
+  end
+
+  defp extract_user_text(_), do: nil
+
+  @doc """
+  Step backward in input history (older). On the first call from a
+  fresh state, snapshots the current `draft` (whatever the user had
+  typed) so a later `history_next/2` can restore it.
+
+  Returns `{state, replacement_text}` — the caller writes
+  `replacement_text` into the textarea. Returns `{state, nil}` when
+  there's no history to navigate.
+  """
+  @spec history_prev(t(), String.t()) :: {t(), String.t() | nil}
+  def history_prev(%__MODULE__{} = state, draft) do
+    items = history(state)
+
+    case items do
+      [] ->
+        {state, nil}
+
+      _ ->
+        next_idx = (state.history_idx || -1) + 1
+        next_idx = min(next_idx, length(items) - 1)
+        new_draft = if is_nil(state.history_idx), do: draft, else: state.history_draft
+        new_state = %{state | history_idx: next_idx, history_draft: new_draft}
+        {new_state, Enum.at(items, next_idx)}
+    end
+  end
+
+  @doc """
+  Step forward in input history (newer). Past the newest entry
+  restores the saved draft and exits navigation mode.
+
+  Returns `{state, replacement_text}` — same contract as
+  `history_prev/2`.
+  """
+  @spec history_next(t()) :: {t(), String.t() | nil}
+  def history_next(%__MODULE__{history_idx: nil} = state), do: {state, nil}
+
+  def history_next(%__MODULE__{history_idx: 0} = state) do
+    # Off the end → restore the saved draft, exit navigation.
+    draft = state.history_draft
+    {%{state | history_idx: nil, history_draft: ""}, draft}
+  end
+
+  def history_next(%__MODULE__{history_idx: idx} = state) do
+    items = history(state)
+    new_idx = idx - 1
+    {%{state | history_idx: new_idx}, Enum.at(items, new_idx)}
+  end
+
+  @doc "Cancel any in-progress history navigation (e.g. on submit or typing)."
+  @spec reset_history_nav(t()) :: t()
+  def reset_history_nav(%__MODULE__{} = state),
+    do: %{state | history_idx: nil, history_draft: ""}
 
   # ─ Streaming-tag parser ──────────────────────────────────────────────────
 

--- a/lib/ex_athena/tools/read.ex
+++ b/lib/ex_athena/tools/read.ex
@@ -76,7 +76,18 @@ defmodule ExAthena.Tools.Read do
     {start_line, end_line}
   end
 
-  defp fetch_path(%{"path" => path}, ctx), do: ToolContext.resolve_path(ctx, path)
+  defp fetch_path(%{"path" => path}, ctx) when is_binary(path) do
+    # An empty or whitespace-only path used to resolve to `cwd` (then on
+    # some filesystems return the contents of the first regular file —
+    # typically README). Reject explicitly so the model gets a clear
+    # `:missing_path` signal instead of `:not_a_regular_file` or a
+    # confusing partial read of the wrong file.
+    case String.trim(path) do
+      "" -> {:error, :missing_path}
+      trimmed -> ToolContext.resolve_path(ctx, trimmed)
+    end
+  end
+
   defp fetch_path(_, _), do: {:error, :missing_path}
 
   defp check_size(%File.Stat{size: size}) when size > @max_bytes,

--- a/test/ex_athena/tools/read_test.exs
+++ b/test/ex_athena/tools/read_test.exs
@@ -41,6 +41,14 @@ defmodule ExAthena.Tools.ReadTest do
     assert {:error, :missing_path} = Read.execute(%{}, ctx)
   end
 
+  test "rejects empty path arg (model hallucinated a read with no target)", %{ctx: ctx} do
+    assert {:error, :missing_path} = Read.execute(%{"path" => ""}, ctx)
+  end
+
+  test "rejects whitespace-only path arg", %{ctx: ctx} do
+    assert {:error, :missing_path} = Read.execute(%{"path" => "  \n"}, ctx)
+  end
+
   test "surfaces File.stat errors when file is missing", %{ctx: ctx} do
     assert {:error, :enoent} = Read.execute(%{"path" => "nonexistent"}, ctx)
   end


### PR DESCRIPTION
## Summary

When the model issued a Read call with \`path: \"\"\` (or \`path: \"  \\n\"\`), \`fetch_path\` delegated to \`ToolContext.resolve_path\` which happily expanded the empty string to \`cwd\` itself. On some path orderings the resolved cwd-as-target leaked file contents (e.g. README at root) instead of erroring, which let a stuck model loop on reading the same file dozens of times without realising it had no real target.

Reject empty or whitespace-only paths explicitly with \`:missing_path\` so the model gets the same clear signal as a fully-missing path arg.

## ⚠️ Branch contents

This branch's single commit **also includes ~97 lines of in-progress \`lib/ex_athena/chat/tui/state.ex\` and \`lib/ex_athena/chat/tui.ex\` edits** that were accidentally swept up by \`git add -A\` while the working tree had your uncommitted changes. Force-push to clean it was blocked by the safety classifier and you approved opening the PR as-is.

## Test plan

- [x] \`mix test test/ex_athena/tools/read_test.exs\` — 8/8 pass, two new tests cover empty-string and whitespace-only paths.