### PR TITLE
feat(tui): /mouse on|off to restore terminal text selection

### DIFF
--- a/lib/ex_athena/chat/commands.ex
+++ b/lib/ex_athena/chat/commands.ex
@@ -35,6 +35,7 @@ defmodule ExAthena.Chat.Commands do
     "tab" => :tab,
     "diff" => :diff,
     "timeline" => :timeline,
+    "mouse" => :mouse,
     "help" => :help,
     "?" => :help
   }
@@ -84,6 +85,7 @@ defmodule ExAthena.Chat.Commands do
       "tab",
       "diff",
       "timeline",
+      "mouse",
       "help",
       "exit"
     ]
@@ -109,6 +111,7 @@ defmodule ExAthena.Chat.Commands do
       "/tab" => "switch the details tab (timeline ↔ changes)",
       "/diff" => "show Changes tab — `/diff side` for split, `/diff inline` for unified",
       "/timeline" => "show the Timeline tab",
+      "/mouse" => "toggle mouse capture (off lets the terminal copy/paste natively)",
       "/help" => "show full usage help",
       "/exit" => "leave the chat"
     }
@@ -136,6 +139,11 @@ defmodule ExAthena.Chat.Commands do
       /diff [side|inline]  switch to Changes tab; optionally set the layout
                          (`side` = side-by-side, `inline` = unified)
       /timeline          switch back to the Timeline tab
+      /mouse [on|off]    toggle mouse capture (off lets your terminal copy
+                         text via the usual click-drag; on enables wheel-
+                         scrolling + tab clicks). Many terminals also let
+                         you bypass capture by holding Option (macOS) or
+                         Shift while click-dragging.
       /help, /?          show this help
       /exit, /quit, /q   leave the chat
 

--- a/lib/ex_athena/chat/tui.ex
+++ b/lib/ex_athena/chat/tui.ex
@@ -557,6 +557,30 @@ defmodule ExAthena.Chat.Tui do
     |> noreply()
   end
 
+  defp dispatch_command(:mouse, args, state) do
+    requested =
+      case args |> Enum.map(&String.downcase/1) |> List.first() do
+        "on" -> true
+        "off" -> false
+        _ -> not state.mouse_enabled
+      end
+
+    if requested do
+      # X10 click reporting + SGR (extended coords) — same sequences
+      # Tui.start/1 writes on app startup.
+      write_to_tty("\e[?1000h\e[?1006h")
+    else
+      write_to_tty("\e[?1006l\e[?1000l")
+    end
+
+    label = if requested, do: "on", else: "off (terminal text selection restored)"
+
+    state
+    |> State.set_mouse_enabled(requested)
+    |> State.append_event({:info, "mouse capture → " <> label})
+    |> noreply()
+  end
+
   defp dispatch_command(:diff, args, state) do
     case args |> Enum.map(&String.downcase/1) |> List.first() do
       mode when mode in ["side", "side-by-side", "split"] ->

--- a/lib/ex_athena/chat/tui/state.ex
+++ b/lib/ex_athena/chat/tui/state.ex
@@ -85,6 +85,11 @@ defmodule ExAthena.Chat.Tui.State do
             # restore it.
             history_idx: nil,
             history_draft: "",
+            # Whether crossterm mouse reporting is currently enabled. We
+            # turn it on at App start via ANSI on /dev/tty (see Tui.start/1)
+            # and let the user toggle with /mouse so they can drop back to
+            # native terminal text selection.
+            mouse_enabled: true,
             # Which tab is active in the right details pane.
             details_tab: :timeline,
             # Lines of `git diff HEAD` for the :changes tab. Refreshed
@@ -124,6 +129,7 @@ defmodule ExAthena.Chat.Tui.State do
           autocomplete: autocomplete(),
           history_idx: non_neg_integer() | nil,
           history_draft: String.t(),
+          mouse_enabled: boolean(),
           details_tab: :timeline | :changes,
           git_diff_lines: [String.t()],
           git_diff_scroll_offset: non_neg_integer(),
@@ -713,6 +719,11 @@ defmodule ExAthena.Chat.Tui.State do
   @spec reset_history_nav(t()) :: t()
   def reset_history_nav(%__MODULE__{} = state),
     do: %{state | history_idx: nil, history_draft: ""}
+
+  @doc "Record whether crossterm mouse capture is currently on."
+  @spec set_mouse_enabled(t(), boolean()) :: t()
+  def set_mouse_enabled(%__MODULE__{} = state, enabled?) when is_boolean(enabled?),
+    do: %{state | mouse_enabled: enabled?}
 
   # ─ Streaming-tag parser ──────────────────────────────────────────────────
 

--- a/test/ex_athena/chat/commands_test.exs
+++ b/test/ex_athena/chat/commands_test.exs
@@ -83,7 +83,7 @@ defmodule ExAthena.Chat.CommandsTest do
       text = Commands.help_text()
 
       for verb <-
-            ~w(/model /mode /tools /clear /expand /details /cd /pwd /tab /diff /timeline /help /exit) do
+            ~w(/model /mode /tools /clear /expand /details /cd /pwd /tab /diff /timeline /mouse /help /exit) do
         assert text =~ verb, "expected help text to mention #{verb}"
       end
     end
@@ -121,6 +121,12 @@ defmodule ExAthena.Chat.CommandsTest do
     test "parses /diff with a layout argument" do
       assert Commands.parse("/diff side") == {:command, :diff, ["side"]}
       assert Commands.parse("/diff inline") == {:command, :diff, ["inline"]}
+    end
+
+    test "parses /mouse with and without on/off" do
+      assert Commands.parse("/mouse") == {:command, :mouse, []}
+      assert Commands.parse("/mouse on") == {:command, :mouse, ["on"]}
+      assert Commands.parse("/mouse off") == {:command, :mouse, ["off"]}
     end
   end
 end


### PR DESCRIPTION
## Why

PR #78 enabled crossterm mouse capture so wheel-scroll + tab clicks work, but capture also intercepts the click-drag the terminal would normally use for text selection — you can't copy from the chat.

## Fix

New \`/mouse\` slash command that toggles capture at runtime:

\`\`\`
/mouse           toggle
/mouse on        enable wheel + tab clicks
/mouse off       disable; native terminal selection works again
\`\`\`

Dispatcher writes the same ANSI sequences \`Tui.start/1\` uses (\`\\e[?1000h\\e[?1006h\` to enable, matching \`l\` variants to disable) via \`write_to_tty/1\` so it bypasses BEAM's I/O. \`State.mouse_enabled\` tracks the current setting.

\`/help\` also documents the modifier-key trick: many terminals (iTerm2, Terminal.app, Alacritty, kitty) let you bypass mouse capture by holding **Option** on macOS or **Shift** while click-dragging — no toggle needed for one-off selections.

## Test plan
- [x] \`mix compile\` clean
- [x] \`mix test\` — 143 tests pass (1 new for parse)
- [ ] Manual: launch chat (mouse on by default), try to click-drag select → blocked
- [ ] Manual: \`/mouse off\` → text selection works
- [ ] Manual: \`/mouse on\` → wheel scroll + tab clicks work again
- [ ] Manual: \`/mouse\` (no args) toggles