### PR TITLE
feat: stop button to interrupt LLM stream

### DIFF
--- a/lib/ex_athena/web/live/chat_live.ex
+++ b/lib/ex_athena/web/live/chat_live.ex
@@ -113,6 +113,23 @@ defmodule ExAthena.Web.Live.ChatLive do
     end
   end
 
+  def handle_event("stop", _params, socket) do
+    if pid = socket.assigns.streaming_task_pid do
+      Process.exit(pid, :kill)
+    end
+
+    {:noreply,
+     assign(socket,
+       streaming: false,
+       streaming_task_pid: nil,
+       stream_text: "",
+       stream_events: [],
+       stream_tool_ui: %{},
+       current_action: nil,
+       pending_assistant_msg_id: nil
+     )}
+  end
+
   # --- New-session modal ---
 
   def handle_event("show_modal", _params, socket) do
@@ -561,6 +578,9 @@ defmodule ExAthena.Web.Live.ChatLive do
 
   def handle_info({:athena, _other}, socket), do: {:noreply, socket}
 
+  def handle_info({:athena_done, _result}, %{assigns: %{streaming: false}} = socket),
+    do: {:noreply, socket}
+
   def handle_info({:athena_done, result}, socket) do
     usage = result.usage || %{}
 
@@ -599,6 +619,7 @@ defmodule ExAthena.Web.Live.ChatLive do
         ex_messages: ex_messages,
         tool_uis: new_tool_uis,
         streaming: false,
+        streaming_task_pid: nil,
         stream_text: "",
         stream_events: [],
         stream_tool_ui: %{},
@@ -620,8 +641,17 @@ defmodule ExAthena.Web.Live.ChatLive do
     {:noreply, socket}
   end
 
+  def handle_info({:athena_error, _reason}, %{assigns: %{streaming: false}} = socket),
+    do: {:noreply, socket}
+
   def handle_info({:athena_error, reason}, socket) do
-    {:noreply, assign(socket, streaming: false, current_action: nil, error: inspect(reason))}
+    {:noreply,
+     assign(socket,
+       streaming: false,
+       streaming_task_pid: nil,
+       current_action: nil,
+       error: inspect(reason)
+     )}
   end
 
   # ---------------------------------------------------------------------------
@@ -910,12 +940,13 @@ defmodule ExAthena.Web.Live.ChatLive do
               phx-hook="SubmitOnEnter"
             ></textarea>
             <button
-              class={"btn-send#{if @streaming or is_nil(@cwd), do: " btn-send--disabled", else: ""}"}
-              type="submit"
-              disabled={@streaming or is_nil(@cwd)}
+              class={if @streaming, do: "btn-stop", else: "btn-send#{if is_nil(@cwd), do: " btn-send--disabled", else: ""}"}
+              type={if @streaming, do: "button", else: "submit"}
+              phx-click={if @streaming, do: "stop"}
+              disabled={not @streaming and is_nil(@cwd)}
             >
               <%= if @streaming do %>
-                <span class="spinner"></span>
+                ■
               <% else %>
                 ↑
               <% end %>
@@ -1363,28 +1394,29 @@ defmodule ExAthena.Web.Live.ChatLive do
     new_ex_msg = Messages.user(text)
     ex_messages = socket.assigns.ex_messages ++ [new_ex_msg]
 
-    Task.start(fn ->
-      on_event = fn event -> send(pid, {:athena, event}) end
+    {:ok, task_pid} =
+      Task.start(fn ->
+        on_event = fn event -> send(pid, {:athena, event}) end
 
-      opts =
-        [
-          provider: safe_atom(provider, :llamacpp),
-          mode: safe_mode(mode),
-          messages: ex_messages,
-          tools: :all,
-          permission_mode: :accept_edits,
-          on_event: on_event,
-          timeout_ms: 24 * 60 * 60 * 1000
-        ]
-        |> maybe_put_model(model)
-        |> apply_base_url(provider)
-        |> maybe_put_cwd(socket.assigns.cwd)
+        opts =
+          [
+            provider: safe_atom(provider, :llamacpp),
+            mode: safe_mode(mode),
+            messages: ex_messages,
+            tools: :all,
+            permission_mode: :accept_edits,
+            on_event: on_event,
+            timeout_ms: 24 * 60 * 60 * 1000
+          ]
+          |> maybe_put_model(model)
+          |> apply_base_url(provider)
+          |> maybe_put_cwd(socket.assigns.cwd)
 
-      case ExAthena.run(nil, opts) do
-        {:ok, result} -> send(pid, {:athena_done, result})
-        {:error, reason} -> send(pid, {:athena_error, reason})
-      end
-    end)
+        case ExAthena.run(nil, opts) do
+          {:ok, result} -> send(pid, {:athena_done, result})
+          {:error, reason} -> send(pid, {:athena_error, reason})
+        end
+      end)
 
     user_detail = new_detail(:user_text, user_msg.id, %{text: text})
 
@@ -1393,6 +1425,7 @@ defmodule ExAthena.Web.Live.ChatLive do
        messages: socket.assigns.messages ++ [user_msg],
        ex_messages: ex_messages,
        streaming: true,
+       streaming_task_pid: task_pid,
        stream_text: "",
        stream_events: [],
        stream_tool_ui: %{},

--- a/priv/web/static/app.css
+++ b/priv/web/static/app.css
@@ -465,6 +465,24 @@ html, body { height: 100%; background: var(--bg); color: var(--text); font-famil
 .btn-send:hover        { background: #5eeaaf; }
 .btn-send--disabled    { opacity: 0.4; cursor: not-allowed; }
 
+.btn-stop {
+  background: #ff4d6d;
+  border: none;
+  border-radius: var(--radius);
+  color: #fff;
+  font-size: 16px;
+  font-weight: 700;
+  width: 44px;
+  height: 44px;
+  flex-shrink: 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s;
+}
+.btn-stop:hover { background: #ff2244; }
+
 /* Spinner */
 .spinner {
   width: 16px;
@@ -1490,6 +1508,65 @@ html, body { height: 100%; background: var(--bg); color: var(--text); font-famil
   font-size: 12px;
   text-align: center;
   line-height: 1.7;
+}
+
+/* ── File diff sections (expandable) ──────────────────────────────────────── */
+
+.file-diff-section {
+  border-bottom: 1px solid var(--border);
+}
+
+.file-diff-section:last-child {
+  border-bottom: none;
+}
+
+.file-diff-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  background: transparent;
+  border: none;
+  padding: 8px 12px;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.15s;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.file-diff-header:hover {
+  background: rgba(52, 211, 153, 0.04);
+}
+
+.file-diff-toggle {
+  color: var(--muted);
+  flex-shrink: 0;
+  font-size: 10px;
+  width: 12px;
+  text-align: center;
+}
+
+.file-diff-path {
+  flex: 1;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-diff-stats {
+  color: var(--muted);
+  font-size: 11px;
+  flex-shrink: 0;
+}
+
+.file-diff-section .ui-panel {
+  border-top: none;
+}
+
+.file-diff-section .diff-body {
+  max-height: none;
 }
 
 /* ── Git diff panel ──────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

- Submit button becomes a red **■** stop button while the LLM is streaming
- Clicking stop kills the agent task (`Process.exit(pid, :kill)`) and immediately resets all streaming state
- Guard clauses on `athena_done` / `athena_error` prevent stale messages from landing after cancellation

## Test plan

- [ ] Start a chat, confirm button turns red with ■ while streaming
- [ ] Click stop — streaming halts, button returns to ↑, textarea re-enables
- [ ] Let a response finish normally — button reverts correctly, no duplicate messages
- [ ] Verify config.exs is not included in this PR