### PR TITLE
fix(permissions): allow read-only bash commands in :plan phase

### DIFF
--- a/lib/ex_athena/permissions.ex
+++ b/lib/ex_athena/permissions.ex
@@ -126,7 +126,7 @@ defmodule ExAthena.Permissions do
   def check(%ToolCall{name: name, arguments: args}, %ToolContext{} = ctx, opts) do
     with :allow <- check_disallowed(name, ctx.phase, opts),
          :allow <- check_allowed(name, opts),
-         :allow <- check_phase(name, ctx.phase),
+         :allow <- check_phase(name, args, ctx.phase),
          :allow <- check_callback(name, args, ctx, ctx.phase, opts) do
       :allow
     end
@@ -185,10 +185,26 @@ defmodule ExAthena.Permissions do
     end
   end
 
-  defp check_phase(name, :plan) do
+  defp check_phase(name, args, :plan) do
     cond do
       name in @readonly_tools ->
         :allow
+
+      name == "bash" ->
+        if ExAthena.Tools.Bash.read_only_command?(args) do
+          :allow
+        else
+          {:deny,
+           %Denial{
+             code: :phase_gated,
+             reason: "bash command is not read-only and is not allowed in plan phase",
+             metadata: %{
+               phase: :plan,
+               requested_tool: "bash",
+               allowed_tools: @readonly_tools ++ ["bash (read-only commands only)"]
+             }
+           }}
+        end
 
       name in @mutating_tools ->
         {:deny,
@@ -203,10 +219,10 @@ defmodule ExAthena.Permissions do
     end
   end
 
-  defp check_phase(_name, :bypass_permissions), do: :allow
-  defp check_phase(_name, :trusted), do: :allow
-  defp check_phase(_name, :accept_edits), do: :allow
-  defp check_phase(_name, _), do: :allow
+  defp check_phase(_name, _args, :bypass_permissions), do: :allow
+  defp check_phase(_name, _args, :trusted), do: :allow
+  defp check_phase(_name, _args, :accept_edits), do: :allow
+  defp check_phase(_name, _args, _), do: :allow
 
   # `:trusted`, `:bypass_permissions`, and the auto-allow set of
   # `:accept_edits` skip the callback. Everything else (default mode +

--- a/lib/ex_athena/tools/bash.ex
+++ b/lib/ex_athena/tools/bash.ex
@@ -18,12 +18,49 @@ defmodule ExAthena.Tools.Bash do
   @default_timeout 120_000
   @max_timeout 600_000
 
+  # Patterns that mark a command as a write/destructive operation. Anything
+  # NOT matching is treated as read-only. Used by `Permissions.check_phase/3`
+  # to allow read-only bash invocations in :plan phase while still blocking
+  # mutations.
+  @write_patterns [
+    ~r/\b(mkdir|touch|rm|mv|cp|chmod|chown)\b/,
+    ~r/\bgit\s+(add|commit|push|merge|rebase|checkout|reset|clean|stash|branch\s+-[dD])\b/,
+    ~r/\b(npm|yarn|pnpm|mix|bundle|pip|cargo)\s+(install|add|remove|update|new|init)\b/,
+    ~r/\bmix\s+(ecto\.migrate|ecto\.create|ecto\.rollback|ecto\.gen\.migration|ash\.codegen|phx\.gen)\b/,
+    ~r/[>|]\s*tee\b/,
+    ~r/>>?\s/,
+    ~r/\bsed\s+-i\b/,
+    ~r/\bdd\b/,
+    ~r/\btruncate\b/,
+    ~r/\bcurl\b.*-[oO]\b/,
+    ~r/\bwget\b/
+  ]
+
   @impl true
   def name, do: "bash"
 
   @impl true
   def description,
     do: "Run a shell command in the working directory. Captures stdout+stderr and the exit code."
+
+  @doc """
+  Classify a bash invocation's `args` as read-only or not. Used by the
+  permissions layer to allow read-only bash calls (cat, ls, grep, git log,
+  gh issue view, …) during `:plan` phase while still denying mutations
+  (rm, mkdir, redirects, git add/commit, mix ecto.migrate, …).
+
+  Returns `true` when `args["command"]` does not match any known
+  write/destructive pattern. Missing/empty command → `false` (treat as
+  not read-only so the model gets a clear phase-gated denial rather than
+  a silent allow).
+  """
+  @spec read_only_command?(map()) :: boolean()
+  def read_only_command?(%{"command" => cmd}) when is_binary(cmd) and cmd != "" do
+    trimmed = String.trim(cmd)
+    not Enum.any?(@write_patterns, fn pattern -> Regex.match?(pattern, trimmed) end)
+  end
+
+  def read_only_command?(_), do: false
 
   @impl true
   def schema do

--- a/test/ex_athena/permissions_test.exs
+++ b/test/ex_athena/permissions_test.exs
@@ -43,6 +43,64 @@ defmodule ExAthena.PermissionsTest do
     assert :allow = Permissions.check(call("glob"), ctx(:plan), %{})
   end
 
+  describe "plan phase — bash gating" do
+    test "allows read-only bash commands (cat, ls, grep, gh, git log/diff/status)" do
+      for cmd <- [
+            "cat lib/foo.ex",
+            "ls -la",
+            "grep -r Foo lib/",
+            "find . -name *.ex",
+            "gh issue view 58",
+            "git log --oneline -10",
+            "git diff",
+            "git status",
+            "head -50 README.md",
+            "tail -30 mix.exs",
+            "wc -l lib/foo.ex",
+            "mix help"
+          ] do
+        assert :allow = Permissions.check(call("bash", %{"command" => cmd}), ctx(:plan), %{}),
+               "expected read-only `#{cmd}` to be allowed in plan phase"
+      end
+    end
+
+    test "denies write/destructive bash commands" do
+      for cmd <- [
+            "rm -rf foo",
+            "mkdir new_dir",
+            "touch new.ex",
+            "mv a b",
+            "cp a b",
+            "echo hi > out.txt",
+            "echo hi >> out.txt",
+            "git add lib/foo.ex",
+            "git commit -m wip",
+            "git push",
+            "mix ecto.migrate",
+            "mix ash.codegen something",
+            "npm install foo",
+            "sed -i s/foo/bar/ file.ex"
+          ] do
+        assert {:deny,
+                %Denial{
+                  code: :phase_gated,
+                  metadata: %{phase: :plan, requested_tool: "bash"}
+                }} = Permissions.check(call("bash", %{"command" => cmd}), ctx(:plan), %{}),
+               "expected write/destructive `#{cmd}` to be denied in plan phase"
+      end
+    end
+
+    test "denies bash with missing command (defensive — treat as not read-only)" do
+      assert {:deny, %Denial{code: :phase_gated}} =
+               Permissions.check(call("bash", %{}), ctx(:plan), %{})
+    end
+
+    test "bash is unrestricted in :default phase" do
+      assert :allow =
+               Permissions.check(call("bash", %{"command" => "rm -rf foo"}), ctx(), %{})
+    end
+  end
+
   test "bypass_permissions allows everything" do
     assert :allow = Permissions.check(call("bash"), ctx(:bypass_permissions), %{})
     assert :allow = Permissions.check(call("write"), ctx(:bypass_permissions), %{})


### PR DESCRIPTION
## Summary
- The \`:plan\` phase had \`bash\` in \`@mutating_tools\`, so every bash invocation got a \`:phase_gated\` denial — including innocent read-only ones (\`gh issue view\`, \`git log\`, \`cat lib/foo.ex\`, \`mix help\`).
- Observed downstream: qwen3.5 on Ollama leans heavily on shell rather than \`Read\`/\`Glob\`/\`Grep\`, so the model stalled out on planning because every bash call was denied. (See udin_code companion PRs udin-io/udin_code#1558 + #1560.)

## Changes
- Add \`ExAthena.Tools.Bash.read_only_command?/1\` that returns \`true\` when the command matches no known write/destructive pattern (mkdir/rm/mv/cp, redirects \`>\`/\`>>\`, \`git add/commit/push/merge\`, \`mix ecto.migrate\`/\`ash.codegen\`/\`phx.gen\`, \`npm/yarn/pnpm/cargo … install/add/…\`, \`sed -i\`, \`dd\`, \`truncate\`, \`curl -o\`, \`wget\`).
- \`Permissions.check_phase/3\` (renamed from \`/2\` to receive args) special-cases bash in \`:plan\`: allow if read-only, deny otherwise with a clearer reason.
- Other phases (\`:default\`, \`:trusted\`, \`:accept_edits\`, \`:bypass_permissions\`) unchanged.

## Test plan
- [x] \`mix test test/ex_athena/permissions_test.exs\` — 18/18 (new tests cover allow-list, deny-list, missing-command defensive, default-phase passthrough)
- [x] \`mix test\` — full suite passes except 1 pre-existing failure (\`named_subagent_test.exs:93\`) unrelated to this change.