### PR TITLE
feat(permissions): add plan_mode_tools/0 (readonly + bash)

### DIFF
--- a/lib/ex_athena/permissions.ex
+++ b/lib/ex_athena/permissions.ex
@@ -274,6 +274,18 @@ defmodule ExAthena.Permissions do
   @spec readonly_tools() :: [String.t()]
   def readonly_tools, do: @readonly_tools
 
+  @doc """
+  Tools to advertise to the model during read-only planning/scope phases.
+  Same as `readonly_tools/0` plus `"bash"`, which is conditionally allowed
+  in `:plan` (read-only commands only — see `check_phase/3`).
+
+  Hosts that build their plan-mode tool list from this stay in sync with
+  the permissions layer automatically when ex_athena widens or narrows
+  what's safe in plan phase.
+  """
+  @spec plan_mode_tools() :: [String.t()]
+  def plan_mode_tools, do: @readonly_tools ++ ["bash"]
+
   @artifact_dirs ~w(_build/ deps/ node_modules/ .git/ priv/static/ tmp/)
 
   @doc """

--- a/test/ex_athena/permissions_test.exs
+++ b/test/ex_athena/permissions_test.exs
@@ -137,4 +137,20 @@ defmodule ExAthena.PermissionsTest do
     {:deny, denial} = Permissions.check(call("write"), ctx(:plan), %{})
     assert is_binary(to_string(denial))
   end
+
+  describe "plan_mode_tools/0" do
+    test "is readonly_tools/0 plus bash" do
+      assert Permissions.plan_mode_tools() == Permissions.readonly_tools() ++ ["bash"]
+    end
+
+    test "includes bash" do
+      assert "bash" in Permissions.plan_mode_tools()
+    end
+
+    test "includes the existing readonly set" do
+      for tool <- Permissions.readonly_tools() do
+        assert tool in Permissions.plan_mode_tools()
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Hosts that derive their plan-phase tool list from \`readonly_tools/0\` lose bash entirely.
- udin_code does this (\`athena_runner/query.ex:30\`), so qwen3.5 never sees bash advertised in :plan — even though my recent #90 lets read-only bash through at runtime.
- Add \`plan_mode_tools/0\` = \`readonly_tools/0 ++ [\"bash\"]\`. Hosts swap to it; the runtime check (#90) keeps bash safe.

## Test plan
- [x] \`mix test test/ex_athena/permissions_test.exs\` — 16/16 (+ 3 new tests on plan_mode_tools/0)