### PR TITLE
fix(request): fail loud on non-String/nil prompt

### DIFF
--- a/lib/ex_athena/request.ex
+++ b/lib/ex_athena/request.ex
@@ -92,7 +92,7 @@ defmodule ExAthena.Request do
   end
 
   # No prompt (nil or "") + images → merge into last user message or append new one
-  defp build_messages(_prompt, existing, image_parts) do
+  defp build_messages(prompt, existing, image_parts) when prompt in [nil, ""] do
     case find_last_user(existing) do
       {before, %Message{content: text} = msg, after_msgs} when is_binary(text) ->
         before ++ [%{msg | content: [ContentPart.text(text) | image_parts]}] ++ after_msgs
@@ -106,6 +106,18 @@ defmodule ExAthena.Request do
       :none ->
         existing ++ [Messages.user(image_parts)]
     end
+  end
+
+  # Any other prompt shape violates the `String.t() | nil` contract. The
+  # usual culprit is a content-block list (`[%{type: "text"}, …]`) built by
+  # a caller that should pass text as a string and images via the `:images`
+  # opt. Fail loud rather than silently degrading it into an empty user
+  # message, which swallows the whole turn (see ContentPart-style image
+  # specs handled by `normalize_images/1`).
+  defp build_messages(other, _existing, _image_parts) do
+    raise ArgumentError,
+          "invalid prompt #{inspect(other)}; expected a String or nil. " <>
+            "Pass pre-built messages via the :messages opt and inline images via the :images opt."
   end
 
   defp normalize_images([]), do: []

--- a/test/ex_athena/request_test.exs
+++ b/test/ex_athena/request_test.exs
@@ -140,4 +140,35 @@ defmodule ExAthena.RequestTest do
       assert [%ContentPart{type: :text, text: "new prompt"}, %ContentPart{type: :image}] = parts
     end
   end
+
+  describe "new/2 — invalid prompt shape (fail loud)" do
+    # The prompt contract is String.t() | nil. A non-string prompt — most
+    # commonly a content-block list like [%{type: "text"}, %{type: "image"}]
+    # built by a caller that should have used the :images opt — used to fall
+    # through to a silent empty user message, swallowing the whole turn.
+    test "content-block-list prompt raises ArgumentError" do
+      blocks = [
+        %{type: "text", text: "look at this"},
+        %{type: "image", source: %{type: "base64", media_type: "image/png", data: "abc"}}
+      ]
+
+      assert_raise ArgumentError, ~r/expected a String or nil/, fn ->
+        Request.new(blocks, [])
+      end
+    end
+
+    test "content-block-list prompt raises even when :images opt is also given" do
+      blocks = [%{type: "text", text: "hi"}]
+
+      assert_raise ArgumentError, ~r/expected a String or nil/, fn ->
+        Request.new(blocks, images: [%{data: <<0>>, media_type: "image/png"}])
+      end
+    end
+
+    test "non-string scalar prompt raises ArgumentError" do
+      assert_raise ArgumentError, ~r/expected a String or nil/, fn ->
+        Request.new(123, [])
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`Request.build_messages/3` had a catch-all clause that silently turned any **non-String prompt** into an empty user message — swallowing the entire turn. The most common trigger is a caller passing a content-block list (`[%{type: "text"}, %{type: "image"}]`) as the prompt when it should pass text as a `String` and images via the `:images` opt.

This exact footgun caused a real bug downstream (a design chat received "see attached screenshot" text with no image and replied as if it had no context — the list-shaped prompt degraded to an empty user message). The integration was fixed on the caller side, but the silent degradation in ExAthena is what made it hard to diagnose.

The prompt contract is `String.t() | nil`, so we now raise an `ArgumentError` for anything else — consistent with `normalize_images/1`, which already raises on malformed image specs. The legitimate `nil`/`""` + `:images` merge path is preserved via an explicit guard.

## Changes

- `lib/ex_athena/request.ex` — split the catch-all `build_messages/3` into (a) an explicit `prompt in [nil, ""]` clause for the images-merge path and (b) a raising clause for any other prompt shape.
- `test/ex_athena/request_test.exs` — added a "fail loud" describe block covering content-block-list prompts (with and without `:images`) and a non-string scalar.

## Test plan

- [x] `mix test test/ex_athena/request_test.exs` — 18 passing
- [x] `mix compile --warnings-as-errors` clean for lib
- Note: one unrelated test (`NamedSubagentTest` "spawn writes a sidechain JSONL transcript") fails identically on `main` before this change — pre-existing, not touched here.