### PR TITLE
fix(loop): preserve caller-supplied spawn_agent_opts; bump to 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and ExAthena adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+## v0.12.0 — Interactive REPL, prompt contract hardening, subagent opts fix
+
 ### Added
 
 - **`mix athena.chat` — interactive terminal REPL.** Drops you into a
@@ -19,6 +21,23 @@ and ExAthena adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   block showing model, mode, iteration, token usage, and cost. New modules:
   `ExAthena.Chat.Repl`, `ExAthena.Chat.Session`, `ExAthena.Chat.Commands`,
   `ExAthena.Chat.Renderer`, `ExAthena.Chat.Ollama`.
+
+### Changed
+
+- **`ExAthena.Request.new/2` now fails loud on an invalid prompt.** The prompt
+  contract is `String.t() | nil`; a non-string prompt (most commonly a
+  content-block list built by a caller that should have used the `:images`
+  opt) previously degraded silently into an empty user message, swallowing the
+  whole turn. It now raises `ArgumentError`, consistent with `normalize_images/1`.
+
+### Fixed
+
+- **Caller-supplied `assigns[:spawn_agent_opts]` is no longer clobbered.**
+  `Loop.run/2` overwrote it with the auto-derived provider config via
+  `Map.put`, discarding any options the caller passed (e.g. a `:mock`
+  responder, `:tools`, `:memory`). Switched to `Map.put_new` so explicit
+  caller config — and a grandparent's config when this loop is itself a
+  subagent — survives, matching the documented intent.
 
 ## v0.11.0 — Public multimodal capability function
 

--- a/lib/ex_athena/loop.ex
+++ b/lib/ex_athena/loop.ex
@@ -551,7 +551,7 @@ defmodule ExAthena.Loop do
           :tool_timeout_ms,
           Keyword.get(opts, :tool_timeout_ms, @default_tool_timeout_ms)
         )
-        |> Map.put(:spawn_agent_opts, inherited_provider_opts)
+        |> Map.put_new(:spawn_agent_opts, inherited_provider_opts)
 
       ctx =
         ExAthena.ToolContext.new(

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExAthena.MixProject do
   use Mix.Project
 
-  @version "0.11.0"
+  @version "0.12.0"
   @source_url "https://github.com/udin-io/ex_athena"
 
   def project do


### PR DESCRIPTION
## Summary

Fixes the pre-existing `NamedSubagentTest` "spawn writes a sidechain JSONL transcript" failure and prepares the 0.12.0 release.

**Root cause:** `Loop.build_initial_state/2` set `assigns[:spawn_agent_opts]` with `Map.put`, **overwriting** any value the caller already provided. The auto-derived value (`inherit_provider_opts/2`) only carries `[provider, base_url, model, api_key, permission_mode]` — so a caller that passed `spawn_agent_opts: [provider: :mock, mock: [responder: …], tools: [], memory: false]` lost the `:mock` responder. The spawned subagent then called the mock provider with no responder → `{:error, :mock_not_configured}` → `error_during_execution` at iteration 0, and never produced its "subagent finished" text.

The comment on that line already documented the intended `Map.put_new` semantics ("keeps a grandparent's config when this loop is itself a subagent"). The shipped code used `Map.put`. This switches to `Map.put_new`, so explicit caller config — and a grandparent's config in nested-subagent runs — survives. The auto-inheritance still works for the common case (caller doesn't pass `spawn_agent_opts`), so commit 3afaf4e's goal is preserved.

## Changes

- `lib/ex_athena/loop.ex` — `Map.put` → `Map.put_new` for `:spawn_agent_opts`.
- `mix.exs` — `@version` 0.11.0 → 0.12.0.
- `CHANGELOG.md` — cut a `v0.12.0` section folding in the unreleased `mix athena.chat` REPL, the prior fail-loud prompt-contract change (#92), and this fix.

## Test plan

- [x] `mix test test/ex_athena/loop/named_subagent_test.exs` — 3 passing (was 1 failing)
- [x] `mix test` — **809 tests, 0 failures** (was 1 failure on `main`)
- Note: the existing `NamedSubagentTest` is the regression test — it asserts the sidechain transcript contains the subagent's output, which only happens when the responder survives.