### PR TITLE
chore(release): prepare v0.12.0 for Hex publish

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,5 @@
 # Used by "mix format"
 [
+  import_deps: [:phoenix, :phoenix_live_view],
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,28 +7,79 @@ and ExAthena adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
-## v0.12.0 — Interactive REPL, prompt contract hardening, subagent opts fix
+## v0.12.0 — Interactive TUI, web UI, llama.cpp provider, thinking, prompt hardening
 
-### Added
+The headline release for ExAthena's two new front-ends — a full-screen
+terminal TUI (`mix athena.chat`) and a Phoenix LiveView web UI
+(`mix athena.web`) — plus first-class llama.cpp support, real-time
+thinking/reasoning streaming, and a batch of tool/permission refinements. The
+TUI and web stacks ship as **optional** dependencies so the core library stays
+lean (see _Changed → Packaging_).
 
-- **`mix athena.chat` — interactive terminal REPL.** Drops you into a
-  streaming chat session against the ExAthena agent loop, defaulting to the
-  `:ollama` provider, the model configured under `config :ex_athena, :ollama`,
-  the `:react` runner, and every builtin tool. Slash commands (`/model`,
-  `/mode`, `/tools`, `/clear`, `/help`, `/exit`) switch state mid-session;
-  `/model` lists live models from `GET /api/tags`. Built on
-  [`owl`](https://hex.pm/packages/owl) with a pinned `Owl.LiveScreen` status
-  block showing model, mode, iteration, token usage, and cost. New modules:
-  `ExAthena.Chat.Repl`, `ExAthena.Chat.Session`, `ExAthena.Chat.Commands`,
-  `ExAthena.Chat.Renderer`, `ExAthena.Chat.Ollama`.
+### Added — interactive TUI (`mix athena.chat`)
+
+- **Full-screen terminal chat built on [`ex_ratatui`](https://hex.pm/packages/ex_ratatui).**
+  A streaming REPL against the ExAthena agent loop, defaulting to the `:ollama`
+  provider, the `:react` runner, and every builtin tool. Slash commands switch
+  state mid-session and `/model` lists live models from the provider.
+- **Split messages / details panes** — the conversation streams on the left
+  while a togglable details pane (`/details`) shows tool activity and a live
+  **Changes** tab (#62, #71).
+- **Real-time text + thinking** — assistant text and reasoning stream as they
+  arrive; `<think>` blocks are extracted from `:content` into a dedicated
+  thinking pane (#63, #65). A "thinking…" placeholder shows while the model is
+  silent.
+- **Live `git diff` Changes tab** — shows the working-tree diff in the cwd,
+  including untracked files, with compact side-by-side and inline rendering,
+  and a self-explanatory empty/error state (#71, #74, #77, #81).
+- **Claude-Code-style tool blocks** in the messages pane, with a compact
+  single-line tool-result preview and an `/expand` command to view a collapsed
+  result in full (#76).
+- **Navigation & input** — scrollable panes via PgUp/PgDn (Shift targets the
+  details pane) (#75), auto-scroll-to-bottom as content grows (#70),
+  slash-command autocomplete with Enter-to-accept (#69, #73), and Up/Down input
+  history (#86).
+- **Mouse support** — wheel scrolls panes and clicks switch tabs (#78), with
+  `/mouse on|off` to restore native terminal text selection (#88).
+- **Working directory control** — `--path` / `-p` launch flag and `/cd`
+  command, with the effective cwd always shown in the status bar / banner /
+  `/pwd` (#66, #68).
+- **Stop button** — replaces the spinner so you can interrupt a running LLM
+  stream (#89). Plus the ExAthena logo on the sidebar title (#83).
+
+### Added — web interface (`mix athena.web`)
+
+- **Phoenix LiveView chat UI** served by Bandit at `http://0.0.0.0:4000`:
+  sessions, fork, a diff viewer, an action indicator, and markdown rendering
+  (#58), with the same messages / details split-pane layout as the TUI (#62).
+
+### Added — providers
+
+- **llama.cpp provider** — `provider: :llamacpp` talks to a local llama-server
+  through `req_llm`, including correct tool-call argument streaming (#55, #57).
+- **Thinking / reasoning plumbed through `req_llm` to loop events** — reasoning
+  deltas now surface as loop events so front-ends can render them live (#64).
+  Inline `%LLMDB.Model{}` specs are passed through to suppress req_llm's
+  unverified-model warning.
 
 ### Changed
 
+- **Tooling.** `Glob` / `Grep` now exclude `_build`, `deps`, and `node_modules`
+  by default, including nested copies in Phoenix-in-subdir layouts (#80, #82).
+  `Write` now emits a `:diff` UI payload like `Edit` (#85).
+- **Permissions.** New `ExAthena.Permissions.plan_mode_tools/0` (read-only
+  tools + bash) (#91), and read-only bash commands are now allowed in the
+  `:plan` phase (#90).
 - **`ExAthena.Request.new/2` now fails loud on an invalid prompt.** The prompt
   contract is `String.t() | nil`; a non-string prompt (most commonly a
   content-block list built by a caller that should have used the `:images`
   opt) previously degraded silently into an empty user message, swallowing the
-  whole turn. It now raises `ArgumentError`, consistent with `normalize_images/1`.
+  whole turn. It now raises `ArgumentError`, consistent with `normalize_images/1` (#92).
+- **Packaging — TUI/web deps are now `optional`.** `ex_ratatui`, `phoenix`,
+  `phoenix_live_view`, and `bandit` are marked `optional: true`. The core agent
+  loop never starts a web server or a TUI, so library consumers no longer pull
+  in Phoenix + Bandit transitively. Add these deps yourself to use
+  `mix athena.chat` / `mix athena.web` (see the README).
 
 ### Fixed
 
@@ -37,7 +88,18 @@ and ExAthena adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `Map.put`, discarding any options the caller passed (e.g. a `:mock`
   responder, `:tools`, `:memory`). Switched to `Map.put_new` so explicit
   caller config — and a grandparent's config when this loop is itself a
-  subagent — survives, matching the documented intent.
+  subagent — survives, matching the documented intent (#93).
+- **Compaction token accounting.** `tokens_for` now counts `tool_result`
+  payloads, so compaction triggers on the true conversation size instead of
+  undercounting tool-heavy turns (#84).
+- **Subagents inherit the parent provider** — a spawned agent is now given the
+  parent's provider configuration instead of falling back to the default (#61).
+- **Chat turn timeouts.** Replaced the `:infinity` chat timeout with a 24h
+  integer and stopped timing out a turn while the model is still thinking.
+- **Mouse capture** writes to `/dev/tty` rather than `:standard_io`, fixing a
+  crash when stdio is redirected (#79).
+- **Quieter chat logs** — debug logs are silenced during `mix athena.chat` and
+  the chat log gate is raised from `:info` to `:warning`.
 
 ## v0.11.0 — Public multimodal capability function
 

--- a/README.md
+++ b/README.md
@@ -10,21 +10,22 @@ Code SDK that runs on **Ollama**, **OpenAI-compatible endpoints**
 **Google Gemini**, or **Anthropic Claude** itself — with the same tools,
 hooks, permissions, and streaming semantics across every provider.
 
-> **Status (v0.4):** the operational-harness release. Builds on v0.3's
-> loop kernel with file-based memory (`AGENTS.md`/`CLAUDE.md`),
-> Claude Code-style skills (`SKILL.md` with progressive disclosure), a
-> five-stage compaction pipeline with reactive recovery on
-> context-window errors, 14 hook events with `{:inject, msg}` /
-> `{:transform, prompt}` returns, five permission modes (`:plan` /
-> `:default` / `:accept_edits` / `:trusted` / `:bypass_permissions`),
-> structured tool results with rich UI payloads, custom agent
-> definitions with optional git-worktree isolation, sidechain
-> transcripts, and append-only session storage with file-checkpointing
-> + `/rewind`. Backed by 248 tests.
+> **Status (v0.12):** two front-ends land on top of the agent loop — a
+> full-screen terminal TUI (`mix athena.chat`, built on `ex_ratatui`) with
+> split message/details panes, real-time thinking, a live `git diff` Changes
+> tab, mouse support, and a stop button; and a Phoenix LiveView web UI
+> (`mix athena.web`) with session recall, fork, and a diff viewer. This
+> release also adds a first-class **llama.cpp** provider and streams
+> thinking/reasoning deltas as loop events. The TUI/web deps (`ex_ratatui`,
+> `phoenix`, `phoenix_live_view`, `bandit`) are now **optional**, so the core
+> library stays lean. See the [v0.12.0 changelog](CHANGELOG.md#v0120--interactive-tui-web-ui-llamacpp-provider-thinking-prompt-hardening)
+> for the full list.
 >
-> See the [v0.4.0 changelog](CHANGELOG.md#v040--operational-harness-memory-skills-hooks-modes-agents-storage)
-> for the full list and migration notes (one breaking change: 6 builtin
-> tools now return `{:ok, text, ui}` 3-tuples).
+> The operational harness it builds on — file-based memory
+> (`AGENTS.md`/`CLAUDE.md`), Claude Code-style skills, a five-stage compaction
+> pipeline, 14 hook events, five permission modes, custom agents with
+> git-worktree isolation, and append-only session storage with checkpointing —
+> is documented under [The operational harness](#the-operational-harness-v04).
 
 ## Why
 
@@ -47,15 +48,23 @@ Or manually — add to `mix.exs`:
 ```elixir
 def deps do
   [
-    {:ex_athena, "~> 0.4"},
+    {:ex_athena, "~> 0.12"},
     # optional — only needed for the Claude provider:
-    {:claude_code, "~> 0.36"}
+    {:claude_code, "~> 0.36"},
+    # optional — only needed for the TUI (`mix athena.chat`):
+    {:ex_ratatui, "~> 0.10"},
+    # optional — only needed for the web UI (`mix athena.web`):
+    {:phoenix, "~> 1.7"},
+    {:phoenix_live_view, "~> 1.0"},
+    {:bandit, "~> 1.5"}
   ]
 end
 ```
 
-…then run `mix ex_athena.install` once to wire up defaults, or configure
-manually (see [Configuration](#configuration)).
+The core agent loop has no Phoenix/TUI dependency; add the optional deps above
+only if you want `mix athena.chat` or `mix athena.web`. Then run
+`mix ex_athena.install` once to wire up defaults, or configure manually (see
+[Configuration](#configuration)).
 
 ## Quick start
 
@@ -150,6 +159,8 @@ The sidebar lets you switch provider, model, and mode without restarting. Featur
 
 The web UI is a Phoenix LiveView application that requires no separate server process — `mix athena.web` starts everything in one command. Sessions are serialized with `:erlang.term_to_binary` and survive restarts. The JS bundle is served directly from the installed `phoenix` and `phoenix_live_view` hex packages, so there is no npm or esbuild step.
 
+> **Note:** `phoenix`, `phoenix_live_view`, and `bandit` are optional dependencies. Add them to your `mix.exs` (see [Install](#install)) before running `mix athena.web`.
+
 ## Providers
 
 | Provider | Module | Notes |
@@ -207,7 +218,7 @@ ExAthena.query("…",
 The agent loop (Phase 2) will pick the protocol based on the provider's
 declared capabilities, and fall back when the model gets it wrong.
 
-## What's in v0.4
+## The operational harness (v0.4)
 
 The "1.6% reasoning, 98.4% harness" upgrade — built around the
 [Claude Code paper](https://arxiv.org/abs/2604.14228)'s observation

--- a/config/config.exs
+++ b/config/config.exs
@@ -6,7 +6,6 @@ end
 
 import_config "#{config_env()}.exs"
 
-
 # To use a local llama.cpp server instead:
 #
 #   mix athena.chat --provider llamacpp
@@ -14,4 +13,3 @@ import_config "#{config_env()}.exs"
 # or set it as the default:
 #
 #   config :ex_athena, default_provider: :llamacpp
-

--- a/lib/ex_athena/web/endpoint.ex
+++ b/lib/ex_athena/web/endpoint.ex
@@ -8,8 +8,7 @@ defmodule ExAthena.Web.Endpoint do
     same_site: "Lax"
   ]
 
-  socket "/live", Phoenix.LiveView.Socket,
-    websocket: [connect_info: [session: @session_options]]
+  socket "/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]]
 
   # Serve pre-built ESM files from each package's priv/static so we
   # can use an importmap — no npm or esbuild step required.

--- a/lib/ex_athena/web/live/chat_live.ex
+++ b/lib/ex_athena/web/live/chat_live.ex
@@ -403,6 +403,7 @@ defmodule ExAthena.Web.Live.ChatLive do
   def handle_event("focus_detail", %{"id" => tool_call_id}, socket) do
     {:noreply, push_event(socket, "focus-detail", %{tool_call_id: tool_call_id})}
   end
+
   def handle_event("toggle_diff_panel", _params, socket) do
     {:noreply, assign(socket, show_diff_panel: !socket.assigns.show_diff_panel)}
   end
@@ -1612,7 +1613,11 @@ defmodule ExAthena.Web.Live.ChatLive do
     end
   end
 
-  defp build_ui_entry(:process, %{command: cmd, exit_code: code, stdout: out, duration_ms: ms}, _cwd) do
+  defp build_ui_entry(
+         :process,
+         %{command: cmd, exit_code: code, stdout: out, duration_ms: ms},
+         _cwd
+       ) do
     %{
       kind: :process,
       command: cmd,

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,6 @@ defmodule ExAthena.MixProject do
 
   defp deps do
     [
-      {:ex_ratatui, "~> 0.10"},
       {:req, "~> 0.5"},
       {:req_llm, "~> 1.10"},
       {:jason, "~> 1.4"},
@@ -40,9 +39,13 @@ defmodule ExAthena.MixProject do
       {:telemetry, "~> 1.3"},
       {:claude_code, "~> 0.36", optional: true},
       {:igniter, "~> 0.6", optional: true},
-      {:phoenix, "~> 1.7"},
-      {:phoenix_live_view, "~> 1.0"},
-      {:bandit, "~> 1.5"},
+      # Optional — only needed for the interactive TUI (`mix athena.chat`) and the
+      # web UI (`mix athena.web`). The core agent loop never starts them, so library
+      # consumers aren't forced to pull in Phoenix/Bandit/ex_ratatui.
+      {:ex_ratatui, "~> 0.10", optional: true},
+      {:phoenix, "~> 1.7", optional: true},
+      {:phoenix_live_view, "~> 1.0", optional: true},
+      {:bandit, "~> 1.5", optional: true},
       {:bypass, "~> 2.1", only: :test},
       {:ex_doc, "~> 0.34", only: :dev, runtime: false},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},


### PR DESCRIPTION
## Summary

Prepares **v0.12.0** for a clean Hex publish. The version was already bumped in `mix.exs` (HEAD `91e7fa1`), but the release was not publish-ready: the changelog covered only 3 of ~30 PRs since `v0.11.0`, the README still said v0.4, and the new TUI/web stacks were hard dependencies forcing Phoenix + Bandit onto every library consumer.

## Changes

- **`chore(deps)`** — mark `ex_ratatui`, `phoenix`, `phoenix_live_view`, and `bandit` as `optional: true`. They're only used by the on-demand `mix athena.chat` TUI and `mix athena.web` web UI; the core agent loop never starts them. Library consumers no longer pull in Phoenix + Bandit transitively.
- **`docs`** — rewrite the v0.12.0 CHANGELOG to cover all work since v0.11.0 (the `ex_ratatui` TUI, the Phoenix web UI, the llama.cpp provider, thinking/reasoning streaming, and the tool/permission changes). The previous entry described the REPL as owl-based, which #60 had replaced with `ex_ratatui`. Refresh the README status/install for v0.12 and document the now-optional TUI/web deps.
- **`chore(format)`** — add `import_deps: [:phoenix, :phoenix_live_view]` to `.formatter.exs`. The web interface introduced Phoenix router/endpoint/LiveView modules in idiomatic paren-less macro style, but the formatter never imported Phoenix's `locals_without_parens`, so `mix format --check-formatted` failed. Also normalizes the few drifted files.

## Test plan

All run locally and green:

- `mix compile --force --warnings-as-errors` ✓
- `mix format --check-formatted` ✓
- `mix test` → **809 tests, 0 failures**
- `mix credo` ✓
- `mix docs` ✓
- `mix hex.build` ✓ — package metadata correctly shows all four deps as `(optional)`; tarball includes `lib` (incl. `chat/tui`, `web`, mix tasks), `priv`, `guides`, README/LICENSE/CHANGELOG.

## Post-merge

Tag `v0.12.0` and run `mix hex.publish` (requires Hex auth).