### PR TITLE
fix(tui): compile-guard ex_ratatui so optional is truly optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,13 @@ lean (see _Changed → Packaging_).
   responder, `:tools`, `:memory`). Switched to `Map.put_new` so explicit
   caller config — and a grandparent's config when this loop is itself a
   subagent — survives, matching the documented intent (#93).
+- **TUI modules now compile when the optional `:ex_ratatui` dep is absent.**
+  `ExAthena.Chat.Tui` (`use ExRatatui.App`) and `…Tui.View` (compile-time
+  `%ExRatatui.Widgets.Tabs{}` struct literal) referenced ExRatatui at compile
+  time, so despite `ex_ratatui` being `optional` every consumer that didn't pull
+  it failed to compile ExAthena entirely (`module ExRatatui.App is not loaded`).
+  Both modules — and the `mix athena.chat` dispatch — are now guarded behind
+  `Code.ensure_loaded?/1`, so optional is truly optional.
 - **Compaction token accounting.** `tokens_for` now counts `tool_result`
   payloads, so compaction triggers on the true conversation size instead of
   undercounting tool-heavy turns (#84).

--- a/lib/ex_athena/chat/tui.ex
+++ b/lib/ex_athena/chat/tui.ex
@@ -1,3 +1,8 @@
+# The TUI requires the OPTIONAL `:ex_ratatui` dependency. Guard the whole
+# module so ExAthena still compiles for consumers that don't pull ex_ratatui
+# (declared `optional: true`). Without this, `use ExRatatui.App` raises
+# `module ExRatatui.App is not loaded` at compile time for every such consumer.
+if Code.ensure_loaded?(ExRatatui.App) do
 defmodule ExAthena.Chat.Tui do
   @moduledoc """
   Full-screen TUI App for `mix athena.chat`, built on `ExRatatui.App`.
@@ -941,4 +946,5 @@ defmodule ExAthena.Chat.Tui do
   end
 
   defp reconcile_initial_session(session), do: session
+end
 end

--- a/lib/ex_athena/chat/tui/view.ex
+++ b/lib/ex_athena/chat/tui/view.ex
@@ -1,3 +1,7 @@
+# Guarded on the OPTIONAL `:ex_ratatui` dep — this module references ExRatatui
+# widget structs at compile time (e.g. `%ExRatatui.Widgets.Tabs{}`), so it
+# can't compile for consumers that don't pull ex_ratatui. See ExAthena.Chat.Tui.
+if Code.ensure_loaded?(ExRatatui.App) do
 defmodule ExAthena.Chat.Tui.View do
   @moduledoc """
   Pure view function for `ExAthena.Chat.Tui`. Turns a `%State{}` into the
@@ -1022,4 +1026,5 @@ defmodule ExAthena.Chat.Tui.View do
 
     {popup_widget, messages_rect}
   end
+end
 end

--- a/lib/mix/tasks/athena.chat.ex
+++ b/lib/mix/tasks/athena.chat.ex
@@ -54,7 +54,16 @@ defmodule Mix.Tasks.Athena.Chat do
       |> maybe_put_mode(parsed[:mode])
       |> maybe_put_path(parsed[:path])
 
-    Tui.start(opts)
+    # The TUI is only compiled when the optional :ex_ratatui dep is present.
+    # Dispatch dynamically so this task still compiles when Tui is absent.
+    if Code.ensure_loaded?(Tui) do
+      apply(Tui, :start, [opts])
+    else
+      Mix.raise(
+        "mix athena.chat requires the optional :ex_ratatui dependency. " <>
+          "Add `{:ex_ratatui, \"~> 0.10\"}` to your deps and re-run."
+      )
+    end
   end
 
   defp maybe_put(opts, _key, nil), do: opts


### PR DESCRIPTION
## Summary

**Publish-blocker for v0.12.0.** `ExAthena.Chat.Tui` (`use ExRatatui.App`) and `ExAthena.Chat.Tui.View` (compile-time `%ExRatatui.Widgets.Tabs{}` struct literal) reference the **optional** `:ex_ratatui` dependency at compile time. Even though `ex_ratatui` is declared `optional: true`, any consumer that doesn't pull it **fails to compile ExAthena entirely**:

```
error: module ExRatatui.App is not loaded and could not be found
  lib/ex_athena/chat/tui.ex:24: use ExRatatui.App
```

This was caught by a downstream consumer (a Phoenix app using ExAthena via a path dep without the TUI deps) — a clean compile fails. It would break the published v0.12.0 for every consumer that doesn't add the TUI stack.

## Fix

- Wrap `ExAthena.Chat.Tui` and `ExAthena.Chat.Tui.View` in `if Code.ensure_loaded?(ExRatatui.App) do … end`. In ExAthena's own build (and any consumer that adds `ex_ratatui`) the modules compile and the TUI works; consumers without it skip the modules and compile cleanly.
- `mix athena.chat` now dispatches via `apply(Tui, :start, [opts])` behind a `Code.ensure_loaded?(Tui)` check, raising a clear "add `:ex_ratatui`" hint instead of an `UndefinedFunctionError` when the TUI isn't compiled.

Minimal-diff wrap (no reindent) to keep `git blame` intact on the TUI modules.

## Test plan

- [x] ExAthena own build (`mix compile`) — TUI module still compiled (ex_ratatui present)
- [x] Consumer build **without** ex_ratatui — ExAthena compiles cleanly, `.app` generated, TUI modules skipped (verified end-to-end via the downstream path-dep app: full 108-file compile succeeds, app boots)
- [x] No new compile warnings (task dispatch is dynamic)

Recommend landing this before the v0.12.0 Hex publish.