### PR TITLE
chore(release): v0.12.1 — hotfix optional ex_ratatui compile break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and ExAthena adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+## v0.12.1 — Optional TUI dep no longer breaks library consumers
+
+A hotfix for v0.12.0: the now-`optional` `:ex_ratatui` dependency was still
+referenced at compile time, so any consumer that didn't pull it failed to
+compile ExAthena at all. Upgrade straight to v0.12.1 — v0.12.0 has been retired
+on Hex.
+
+### Fixed
+
+- **TUI modules now compile when the optional `:ex_ratatui` dep is absent.**
+  `ExAthena.Chat.Tui` (`use ExRatatui.App`) and `…Tui.View` (compile-time
+  `%ExRatatui.Widgets.Tabs{}` struct literal) referenced ExRatatui at compile
+  time, so despite `ex_ratatui` being `optional` every consumer that didn't pull
+  it failed to compile ExAthena entirely (`module ExRatatui.App is not loaded`),
+  defeating the optional packaging shipped in v0.12.0. Both modules — and the
+  `mix athena.chat` dispatch — are now guarded behind `Code.ensure_loaded?/1`,
+  so optional is truly optional (#95).
+
 ## v0.12.0 — Interactive TUI, web UI, llama.cpp provider, thinking, prompt hardening
 
 The headline release for ExAthena's two new front-ends — a full-screen
@@ -89,13 +107,6 @@ lean (see _Changed → Packaging_).
   responder, `:tools`, `:memory`). Switched to `Map.put_new` so explicit
   caller config — and a grandparent's config when this loop is itself a
   subagent — survives, matching the documented intent (#93).
-- **TUI modules now compile when the optional `:ex_ratatui` dep is absent.**
-  `ExAthena.Chat.Tui` (`use ExRatatui.App`) and `…Tui.View` (compile-time
-  `%ExRatatui.Widgets.Tabs{}` struct literal) referenced ExRatatui at compile
-  time, so despite `ex_ratatui` being `optional` every consumer that didn't pull
-  it failed to compile ExAthena entirely (`module ExRatatui.App is not loaded`).
-  Both modules — and the `mix athena.chat` dispatch — are now guarded behind
-  `Code.ensure_loaded?/1`, so optional is truly optional.
 - **Compaction token accounting.** `tokens_for` now counts `tool_result`
   payloads, so compaction triggers on the true conversation size instead of
   undercounting tool-heavy turns (#84).

--- a/lib/ex_athena/chat/tui.ex
+++ b/lib/ex_athena/chat/tui.ex
@@ -3,948 +3,948 @@
 # (declared `optional: true`). Without this, `use ExRatatui.App` raises
 # `module ExRatatui.App is not loaded` at compile time for every such consumer.
 if Code.ensure_loaded?(ExRatatui.App) do
-defmodule ExAthena.Chat.Tui do
-  @moduledoc """
-  Full-screen TUI App for `mix athena.chat`, built on `ExRatatui.App`.
+  defmodule ExAthena.Chat.Tui do
+    @moduledoc """
+    Full-screen TUI App for `mix athena.chat`, built on `ExRatatui.App`.
 
-  Layout (see `ExAthena.Chat.Tui.View`):
+    Layout (see `ExAthena.Chat.Tui.View`):
 
-    * Header (1 row) — provider · model · mode · iter · tokens · cost.
-    * Messages (flex) — scrollback rendered from `state.events`.
-    * Input (3 rows) — multiline textarea bound to `state.input_ref`.
-    * Footer (1 row) — keyboard hints.
+      * Header (1 row) — provider · model · mode · iter · tokens · cost.
+      * Messages (flex) — scrollback rendered from `state.events`.
+      * Input (3 rows) — multiline textarea bound to `state.input_ref`.
+      * Footer (1 row) — keyboard hints.
 
-  When the user types a `/model` or `/mode` command with no arg, a modal
-  `Popup` overlays the messages area with a navigable list. Streaming
-  tokens accumulate in `state.stream_buffer` and flush into the most
-  recent assistant row every ~60 ms (`@tick_interval_ms`) so a fast
-  stream doesn't redraw the whole frame per token.
+    When the user types a `/model` or `/mode` command with no arg, a modal
+    `Popup` overlays the messages area with a navigable list. Streaming
+    tokens accumulate in `state.stream_buffer` and flush into the most
+    recent assistant row every ~60 ms (`@tick_interval_ms`) so a fast
+    stream doesn't redraw the whole frame per token.
 
-  The LLM run lives in an unsupervised `Task` owned by
-  `ExAthena.Chat.Tui.Runner` — see that module for the bridging
-  contract. The App receives `:athena_event`, `:athena_done`, and
-  `:athena_error` messages via `handle_info/2`.
-  """
+    The LLM run lives in an unsupervised `Task` owned by
+    `ExAthena.Chat.Tui.Runner` — see that module for the bridging
+    contract. The App receives `:athena_event`, `:athena_done`, and
+    `:athena_error` messages via `handle_info/2`.
+    """
 
-  use ExRatatui.App
+    use ExRatatui.App
 
-  alias ExAthena.Chat.{Commands, LlamaCpp, Ollama, Session}
-  alias ExAthena.Chat.Tui.{Runner, State, View}
-  alias ExAthena.Tools
-  alias ExRatatui.Event
-  alias ExRatatui.Frame
+    alias ExAthena.Chat.{Commands, LlamaCpp, Ollama, Session}
+    alias ExAthena.Chat.Tui.{Runner, State, View}
+    alias ExAthena.Tools
+    alias ExRatatui.Event
+    alias ExRatatui.Frame
 
-  @modes [:react, :plan_and_solve, :reflexion]
-  @tick_interval_ms 60
-  # Rows per PgUp/PgDn press. Roughly a half-page on a typical terminal —
-  # comfortable for skimming without overshooting.
-  @page_step 10
-  # Rows per mouse-wheel click.
-  @wheel_step 3
+    @modes [:react, :plan_and_solve, :reflexion]
+    @tick_interval_ms 60
+    # Rows per PgUp/PgDn press. Roughly a half-page on a typical terminal —
+    # comfortable for skimming without overshooting.
+    @page_step 10
+    # Rows per mouse-wheel click.
+    @wheel_step 3
 
-  @doc """
-  Start the chat App and block until the user quits.
+    @doc """
+    Start the chat App and block until the user quits.
 
-  Mirrors `ExAthena.Chat.Repl.start/1` so the Mix task signature is unchanged.
-  """
-  @spec start(keyword()) :: :ok
-  def start(opts \\ []) do
-    suspend_beam_stdin_reader()
+    Mirrors `ExAthena.Chat.Repl.start/1` so the Mix task signature is unchanged.
+    """
+    @spec start(keyword()) :: :ok
+    def start(opts \\ []) do
+      suspend_beam_stdin_reader()
 
-    {:ok, pid} = start_link(opts)
+      {:ok, pid} = start_link(opts)
 
-    # ex_ratatui's NIF enables crossterm raw mode + alternate screen but
-    # does NOT toggle mouse capture, so wheel/click events never reach us.
-    # Enable X10 mouse reporting + SGR-extended mode (unlimited coords)
-    # ourselves via ANSI. We bypass :standard_io and write to /dev/tty
-    # directly because suspend_beam_stdin_reader/0 above tears down
-    # BEAM's I/O subsystem — IO.write/2 to :standard_io would raise
-    # :terminated.
-    write_to_tty("\e[?1000h\e[?1006h")
+      # ex_ratatui's NIF enables crossterm raw mode + alternate screen but
+      # does NOT toggle mouse capture, so wheel/click events never reach us.
+      # Enable X10 mouse reporting + SGR-extended mode (unlimited coords)
+      # ourselves via ANSI. We bypass :standard_io and write to /dev/tty
+      # directly because suspend_beam_stdin_reader/0 above tears down
+      # BEAM's I/O subsystem — IO.write/2 to :standard_io would raise
+      # :terminated.
+      write_to_tty("\e[?1000h\e[?1006h")
 
-    ref = Process.monitor(pid)
+      ref = Process.monitor(pid)
 
-    receive do
-      {:DOWN, ^ref, :process, ^pid, _reason} ->
-        write_to_tty("\e[?1006l\e[?1000l")
-        :ok
+      receive do
+        {:DOWN, ^ref, :process, ^pid, _reason} ->
+          write_to_tty("\e[?1006l\e[?1000l")
+          :ok
+      end
     end
-  end
 
-  defp write_to_tty(bytes) do
-    case File.open("/dev/tty", [:write, :raw]) do
-      {:ok, dev} ->
-        try do
-          IO.binwrite(dev, bytes)
-        after
-          File.close(dev)
-        end
+    defp write_to_tty(bytes) do
+      case File.open("/dev/tty", [:write, :raw]) do
+        {:ok, dev} ->
+          try do
+            IO.binwrite(dev, bytes)
+          after
+            File.close(dev)
+          end
 
-      _ ->
-        :ok
+        _ ->
+          :ok
+      end
     end
-  end
 
-  # BEAM's `:user_drv_reader` polls stdin in a tight loop. When the ex_ratatui
-  # NIF tries to read raw keystrokes via crossterm, they race for fd 0 and
-  # roughly half the bytes get consumed by BEAM and discarded. The canonical
-  # fix is to launch with `-noinput`, but we can also stop the reader at
-  # runtime from the Mix task path — equivalent effect, transparent to users.
-  # See https://elixirforum.com/t/61856 for the original diagnosis.
-  defp suspend_beam_stdin_reader do
-    case Process.whereis(:user_drv_reader) do
-      nil -> :ok
-      pid -> Process.exit(pid, :kill)
+    # BEAM's `:user_drv_reader` polls stdin in a tight loop. When the ex_ratatui
+    # NIF tries to read raw keystrokes via crossterm, they race for fd 0 and
+    # roughly half the bytes get consumed by BEAM and discarded. The canonical
+    # fix is to launch with `-noinput`, but we can also stop the reader at
+    # runtime from the Mix task path — equivalent effect, transparent to users.
+    # See https://elixirforum.com/t/61856 for the original diagnosis.
+    defp suspend_beam_stdin_reader do
+      case Process.whereis(:user_drv_reader) do
+        nil -> :ok
+        pid -> Process.exit(pid, :kill)
+      end
     end
-  end
 
-  # ── App callbacks ────────────────────────────────────────────────────────
+    # ── App callbacks ────────────────────────────────────────────────────────
 
-  @impl true
-  def mount(opts) do
-    prior_log_level = Logger.level()
-    Logger.configure(level: :warning)
+    @impl true
+    def mount(opts) do
+      prior_log_level = Logger.level()
+      Logger.configure(level: :warning)
 
-    session = opts |> Session.new() |> reconcile_initial_session()
+      session = opts |> Session.new() |> reconcile_initial_session()
 
-    input_ref = ExRatatui.textarea_new()
+      input_ref = ExRatatui.textarea_new()
 
-    state =
-      session
-      |> State.new()
-      |> Map.put(:input_ref, input_ref)
-      |> Map.put(:prior_log_level, prior_log_level)
-      |> banner_events()
-      |> maybe_kick_git_diff()
+      state =
+        session
+        |> State.new()
+        |> Map.put(:input_ref, input_ref)
+        |> Map.put(:prior_log_level, prior_log_level)
+        |> banner_events()
+        |> maybe_kick_git_diff()
 
-    schedule_tick()
+      schedule_tick()
 
-    {:ok, state}
-  end
+      {:ok, state}
+    end
 
-  @impl true
-  def render(%State{} = state, %Frame{} = frame), do: View.build_frame(state, frame)
+    @impl true
+    def render(%State{} = state, %Frame{} = frame), do: View.build_frame(state, frame)
 
-  # ── Keyboard handling ────────────────────────────────────────────────────
+    # ── Keyboard handling ────────────────────────────────────────────────────
 
-  @impl true
-  def handle_event(%Event.Key{kind: "press"} = key, %State{popup: nil} = state) do
-    handle_key(key, state)
-  end
+    @impl true
+    def handle_event(%Event.Key{kind: "press"} = key, %State{popup: nil} = state) do
+      handle_key(key, state)
+    end
 
-  def handle_event(%Event.Key{kind: "press"} = key, %State{popup: _} = state) do
-    handle_popup_key(key, state)
-  end
+    def handle_event(%Event.Key{kind: "press"} = key, %State{popup: _} = state) do
+      handle_popup_key(key, state)
+    end
 
-  # Mouse wheel: scroll the pane under the cursor by @wheel_step rows.
-  def handle_event(%ExRatatui.Event.Mouse{kind: "scroll_up", x: x, y: y}, state) do
-    {:noreply, scroll_pane_at(state, x, y, -@wheel_step)}
-  end
+    # Mouse wheel: scroll the pane under the cursor by @wheel_step rows.
+    def handle_event(%ExRatatui.Event.Mouse{kind: "scroll_up", x: x, y: y}, state) do
+      {:noreply, scroll_pane_at(state, x, y, -@wheel_step)}
+    end
 
-  def handle_event(%ExRatatui.Event.Mouse{kind: "scroll_down", x: x, y: y}, state) do
-    {:noreply, scroll_pane_at(state, x, y, +@wheel_step)}
-  end
+    def handle_event(%ExRatatui.Event.Mouse{kind: "scroll_down", x: x, y: y}, state) do
+      {:noreply, scroll_pane_at(state, x, y, +@wheel_step)}
+    end
 
-  # Left-click on a details tab title → switch tabs.
-  def handle_event(
-        %ExRatatui.Event.Mouse{kind: "down", button: "left", x: x, y: y},
+    # Left-click on a details tab title → switch tabs.
+    def handle_event(
+          %ExRatatui.Event.Mouse{kind: "down", button: "left", x: x, y: y},
+          state
+        ) do
+      {:noreply, maybe_click_tab(state, x, y)}
+    end
+
+    def handle_event(_event, state), do: {:noreply, state}
+
+    # ── Mouse helpers ────────────────────────────────────────────────────
+
+    defp scroll_pane_at(state, x, y, delta) do
+      layout = Process.get(:tui_layout, %{})
+
+      cond do
+        in_rect?(layout[:messages], x, y) -> State.scroll_messages(state, delta)
+        in_rect?(layout[:details], x, y) -> State.scroll_details(state, delta)
+        true -> state
+      end
+    end
+
+    defp maybe_click_tab(state, x, y) do
+      layout = Process.get(:tui_layout, %{})
+
+      if in_rect?(layout[:tabs], x, y) and is_list(layout[:tab_titles]) do
+        tabs = State.details_tabs()
+        # Approximate tab width: split available width evenly. ratatui's
+        # Tabs widget aligns left and uses a divider; this is a "good
+        # enough" hit-test that picks the closer tab.
+        tabs_rect = layout[:tabs]
+        offset = x - tabs_rect.x
+        slot_width = max(div(tabs_rect.width, length(tabs)), 1)
+        idx = min(div(offset, slot_width), length(tabs) - 1)
+        target = Enum.at(tabs, max(idx, 0))
+
+        State.set_details_tab(state, target)
+      else
         state
-      ) do
-    {:noreply, maybe_click_tab(state, x, y)}
-  end
-
-  def handle_event(_event, state), do: {:noreply, state}
-
-  # ── Mouse helpers ────────────────────────────────────────────────────
-
-  defp scroll_pane_at(state, x, y, delta) do
-    layout = Process.get(:tui_layout, %{})
-
-    cond do
-      in_rect?(layout[:messages], x, y) -> State.scroll_messages(state, delta)
-      in_rect?(layout[:details], x, y) -> State.scroll_details(state, delta)
-      true -> state
+      end
     end
-  end
 
-  defp maybe_click_tab(state, x, y) do
-    layout = Process.get(:tui_layout, %{})
+    defp in_rect?(nil, _x, _y), do: false
 
-    if in_rect?(layout[:tabs], x, y) and is_list(layout[:tab_titles]) do
-      tabs = State.details_tabs()
-      # Approximate tab width: split available width evenly. ratatui's
-      # Tabs widget aligns left and uses a divider; this is a "good
-      # enough" hit-test that picks the closer tab.
-      tabs_rect = layout[:tabs]
-      offset = x - tabs_rect.x
-      slot_width = max(div(tabs_rect.width, length(tabs)), 1)
-      idx = min(div(offset, slot_width), length(tabs) - 1)
-      target = Enum.at(tabs, max(idx, 0))
-
-      State.set_details_tab(state, target)
-    else
-      state
+    defp in_rect?(%{x: rx, y: ry, width: rw, height: rh}, x, y) do
+      x >= rx and x < rx + rw and y >= ry and y < ry + rh
     end
-  end
 
-  defp in_rect?(nil, _x, _y), do: false
+    defp handle_key(%Event.Key{code: "c", modifiers: mods} = key, state) do
+      if "ctrl" in mods do
+        {:stop, restore_logger(state)}
+      else
+        forward_to_textarea(key, state)
+      end
+    end
 
-  defp in_rect?(%{x: rx, y: ry, width: rw, height: rh}, x, y) do
-    x >= rx and x < rx + rw and y >= ry and y < ry + rh
-  end
+    # ── Autocomplete navigation (only when the popup is open) ─────────────
 
-  defp handle_key(%Event.Key{code: "c", modifiers: mods} = key, state) do
-    if "ctrl" in mods do
-      {:stop, restore_logger(state)}
-    else
+    defp handle_key(%Event.Key{code: "up"}, %State{autocomplete: %{}} = state) do
+      {:noreply, State.move_autocomplete(state, -1)}
+    end
+
+    defp handle_key(%Event.Key{code: "down"}, %State{autocomplete: %{}} = state) do
+      {:noreply, State.move_autocomplete(state, +1)}
+    end
+
+    defp handle_key(%Event.Key{code: "esc"}, %State{autocomplete: %{}} = state) do
+      {:noreply, State.close_autocomplete(state)}
+    end
+
+    # ── History navigation (Up/Down when no popup is open) ──────────────
+    # First Up snapshots the current input as `history_draft`. Subsequent
+    # Up steps further back; Down walks forward and ultimately restores
+    # the draft. Typing anything resets the cursor (see forward_to_textarea).
+    defp handle_key(%Event.Key{code: "up"}, state) do
+      current = read_textarea(state)
+
+      case State.history_prev(state, current) do
+        {state, nil} -> {:noreply, state}
+        {state, text} -> {:noreply, set_textarea(state, text)}
+      end
+    end
+
+    defp handle_key(%Event.Key{code: "down"}, state) do
+      case State.history_next(state) do
+        {state, nil} -> {:noreply, state}
+        {state, text} -> {:noreply, set_textarea(state, text)}
+      end
+    end
+
+    # Tab or Enter accepts the highlighted suggestion: replace the textarea
+    # contents with the selected verb (plus a trailing space so the user can
+    # immediately type arguments) and close the popup. Picking from the menu
+    # should complete the command text in the input box, not fire off the
+    # half-typed prefix as a chat message.
+    defp handle_key(%Event.Key{code: "tab"}, %State{autocomplete: %{}} = state) do
+      {:noreply, accept_autocomplete(state)}
+    end
+
+    defp handle_key(%Event.Key{code: "tab"}, state), do: {:noreply, state}
+
+    # ── Pane scrolling ────────────────────────────────────────────────────
+    # PgUp/PgDn scroll the messages pane (left). Add Shift to target the
+    # details pane (right). Home jumps to the very top; End returns to
+    # auto-bottom so new content follows again.
+
+    defp handle_key(%Event.Key{code: "pageup", modifiers: mods}, state) do
+      if "shift" in mods,
+        do: {:noreply, State.scroll_details(state, -@page_step)},
+        else: {:noreply, State.scroll_messages(state, -@page_step)}
+    end
+
+    defp handle_key(%Event.Key{code: "pagedown", modifiers: mods}, state) do
+      if "shift" in mods,
+        do: {:noreply, State.scroll_details(state, +@page_step)},
+        else: {:noreply, State.scroll_messages(state, +@page_step)}
+    end
+
+    defp handle_key(%Event.Key{code: "home", modifiers: mods}, state) do
+      if "shift" in mods,
+        do: {:noreply, State.scroll_details_top(state)},
+        else: {:noreply, State.scroll_messages_top(state)}
+    end
+
+    defp handle_key(%Event.Key{code: "end"}, state) do
+      {:noreply, State.reset_pane_scroll(state)}
+    end
+
+    defp handle_key(%Event.Key{code: "enter", modifiers: mods}, state) do
+      cond do
+        match?(%{}, state.autocomplete) and State.selected_autocomplete(state) != nil ->
+          # Enter while the autocomplete popup is open with a selection:
+          # accept the suggestion. User can press Enter again to submit.
+          {:noreply, accept_autocomplete(state)}
+
+        "shift" in mods ->
+          # Shift+Enter inserts a newline into the textarea instead of submitting.
+          if state.input_ref, do: ExRatatui.textarea_handle_key(state.input_ref, "enter", [])
+          {:noreply, state}
+
+        state.loading? ->
+          # Don't submit while a turn is in flight — drop the keystroke.
+          {:noreply, state}
+
+        true ->
+          state |> State.close_autocomplete() |> submit_input()
+      end
+    end
+
+    defp handle_key(%Event.Key{code: code} = key, state) when is_binary(code) do
       forward_to_textarea(key, state)
     end
-  end
 
-  # ── Autocomplete navigation (only when the popup is open) ─────────────
+    defp handle_key(_, state), do: {:noreply, state}
 
-  defp handle_key(%Event.Key{code: "up"}, %State{autocomplete: %{}} = state) do
-    {:noreply, State.move_autocomplete(state, -1)}
-  end
+    defp accept_autocomplete(state) do
+      case State.selected_autocomplete(state) do
+        nil ->
+          State.close_autocomplete(state)
 
-  defp handle_key(%Event.Key{code: "down"}, %State{autocomplete: %{}} = state) do
-    {:noreply, State.move_autocomplete(state, +1)}
-  end
+        verb ->
+          if state.input_ref do
+            ExRatatui.textarea_set_value(state.input_ref, verb <> " ")
+          end
 
-  defp handle_key(%Event.Key{code: "esc"}, %State{autocomplete: %{}} = state) do
-    {:noreply, State.close_autocomplete(state)}
-  end
-
-  # ── History navigation (Up/Down when no popup is open) ──────────────
-  # First Up snapshots the current input as `history_draft`. Subsequent
-  # Up steps further back; Down walks forward and ultimately restores
-  # the draft. Typing anything resets the cursor (see forward_to_textarea).
-  defp handle_key(%Event.Key{code: "up"}, state) do
-    current = read_textarea(state)
-
-    case State.history_prev(state, current) do
-      {state, nil} -> {:noreply, state}
-      {state, text} -> {:noreply, set_textarea(state, text)}
+          State.close_autocomplete(state)
+      end
     end
-  end
 
-  defp handle_key(%Event.Key{code: "down"}, state) do
-    case State.history_next(state) do
-      {state, nil} -> {:noreply, state}
-      {state, text} -> {:noreply, set_textarea(state, text)}
-    end
-  end
+    defp forward_to_textarea(%Event.Key{code: code, modifiers: mods}, state) do
+      if state.input_ref do
+        ExRatatui.textarea_handle_key(state.input_ref, code, mods)
+      end
 
-  # Tab or Enter accepts the highlighted suggestion: replace the textarea
-  # contents with the selected verb (plus a trailing space so the user can
-  # immediately type arguments) and close the popup. Picking from the menu
-  # should complete the command text in the input box, not fire off the
-  # half-typed prefix as a chat message.
-  defp handle_key(%Event.Key{code: "tab"}, %State{autocomplete: %{}} = state) do
-    {:noreply, accept_autocomplete(state)}
-  end
+      # After the textarea processes the key, re-read its value and refresh
+      # the autocomplete popup — opens it on `/`, filters it as the user
+      # types more, closes it once whitespace appears. Also cancels any
+      # in-progress history navigation (typing a fresh char means the user
+      # is composing, not browsing prior messages).
+      state =
+        case state.input_ref do
+          nil ->
+            state
 
-  defp handle_key(%Event.Key{code: "tab"}, state), do: {:noreply, state}
-
-  # ── Pane scrolling ────────────────────────────────────────────────────
-  # PgUp/PgDn scroll the messages pane (left). Add Shift to target the
-  # details pane (right). Home jumps to the very top; End returns to
-  # auto-bottom so new content follows again.
-
-  defp handle_key(%Event.Key{code: "pageup", modifiers: mods}, state) do
-    if "shift" in mods,
-      do: {:noreply, State.scroll_details(state, -@page_step)},
-      else: {:noreply, State.scroll_messages(state, -@page_step)}
-  end
-
-  defp handle_key(%Event.Key{code: "pagedown", modifiers: mods}, state) do
-    if "shift" in mods,
-      do: {:noreply, State.scroll_details(state, +@page_step)},
-      else: {:noreply, State.scroll_messages(state, +@page_step)}
-  end
-
-  defp handle_key(%Event.Key{code: "home", modifiers: mods}, state) do
-    if "shift" in mods,
-      do: {:noreply, State.scroll_details_top(state)},
-      else: {:noreply, State.scroll_messages_top(state)}
-  end
-
-  defp handle_key(%Event.Key{code: "end"}, state) do
-    {:noreply, State.reset_pane_scroll(state)}
-  end
-
-  defp handle_key(%Event.Key{code: "enter", modifiers: mods}, state) do
-    cond do
-      match?(%{}, state.autocomplete) and State.selected_autocomplete(state) != nil ->
-        # Enter while the autocomplete popup is open with a selection:
-        # accept the suggestion. User can press Enter again to submit.
-        {:noreply, accept_autocomplete(state)}
-
-      "shift" in mods ->
-        # Shift+Enter inserts a newline into the textarea instead of submitting.
-        if state.input_ref, do: ExRatatui.textarea_handle_key(state.input_ref, "enter", [])
-        {:noreply, state}
-
-      state.loading? ->
-        # Don't submit while a turn is in flight — drop the keystroke.
-        {:noreply, state}
-
-      true ->
-        state |> State.close_autocomplete() |> submit_input()
-    end
-  end
-
-  defp handle_key(%Event.Key{code: code} = key, state) when is_binary(code) do
-    forward_to_textarea(key, state)
-  end
-
-  defp handle_key(_, state), do: {:noreply, state}
-
-  defp accept_autocomplete(state) do
-    case State.selected_autocomplete(state) do
-      nil ->
-        State.close_autocomplete(state)
-
-      verb ->
-        if state.input_ref do
-          ExRatatui.textarea_set_value(state.input_ref, verb <> " ")
+          ref ->
+            state
+            |> State.update_autocomplete(ExRatatui.textarea_get_value(ref))
+            |> State.reset_history_nav()
         end
 
-        State.close_autocomplete(state)
-    end
-  end
-
-  defp forward_to_textarea(%Event.Key{code: code, modifiers: mods}, state) do
-    if state.input_ref do
-      ExRatatui.textarea_handle_key(state.input_ref, code, mods)
+      {:noreply, state}
     end
 
-    # After the textarea processes the key, re-read its value and refresh
-    # the autocomplete popup — opens it on `/`, filters it as the user
-    # types more, closes it once whitespace appears. Also cancels any
-    # in-progress history navigation (typing a fresh char means the user
-    # is composing, not browsing prior messages).
-    state =
-      case state.input_ref do
+    defp read_textarea(%State{input_ref: nil}), do: ""
+    defp read_textarea(%State{input_ref: ref}), do: ExRatatui.textarea_get_value(ref) || ""
+
+    defp set_textarea(%State{input_ref: nil} = state, _text), do: state
+
+    defp set_textarea(%State{input_ref: ref} = state, text) do
+      ExRatatui.textarea_set_value(ref, text || "")
+      state
+    end
+
+    defp handle_popup_key(%Event.Key{code: code}, state) when code in ["up", "k"] do
+      {:noreply, State.move_popup_selection(state, -1)}
+    end
+
+    defp handle_popup_key(%Event.Key{code: code}, state) when code in ["down", "j"] do
+      {:noreply, State.move_popup_selection(state, +1)}
+    end
+
+    defp handle_popup_key(%Event.Key{code: "esc"}, state) do
+      {:noreply, State.close_popup(state)}
+    end
+
+    defp handle_popup_key(%Event.Key{code: "enter"}, %State{popup: {:model, _, _}} = state) do
+      case State.current_popup_selection(state) do
         nil ->
-          state
+          {:noreply, State.close_popup(state)}
 
-        ref ->
+        model when is_binary(model) ->
           state
-          |> State.update_autocomplete(ExRatatui.textarea_get_value(ref))
-          |> State.reset_history_nav()
+          |> State.set_model(model)
+          |> State.close_popup()
+          |> State.append_event({:info, "Model → " <> model})
+          |> noreply()
+      end
+    end
+
+    defp handle_popup_key(%Event.Key{code: "enter"}, %State{popup: {:mode, _, _}} = state) do
+      case State.current_popup_selection(state) do
+        nil ->
+          {:noreply, State.close_popup(state)}
+
+        mode when is_atom(mode) ->
+          state
+          |> State.set_mode(mode)
+          |> State.close_popup()
+          |> State.append_event({:info, "Mode → " <> inspect(mode)})
+          |> noreply()
+      end
+    end
+
+    defp handle_popup_key(_, state), do: {:noreply, state}
+
+    # ── Process messages ─────────────────────────────────────────────────────
+
+    @impl true
+    def handle_info(:tick, %State{} = state) do
+      schedule_tick()
+      {:noreply, State.flush_stream(state)}
+    end
+
+    def handle_info({:athena_event, event}, %State{} = state) do
+      state = State.append_loop_event(state, event)
+
+      # Kick off a fresh `git diff` whenever a tool result lands — that's
+      # the point where the working tree may have changed. Bounded async,
+      # never blocks the UI.
+      state =
+        case event do
+          {:tool_result, _} -> maybe_kick_git_diff(state)
+          _ -> state
+        end
+
+      {:noreply, state}
+    end
+
+    def handle_info({:athena_done, result}, %State{} = state) do
+      new_state =
+        state
+        |> State.flush_stream()
+        |> State.apply_result(result)
+        |> State.set_loading(false)
+        |> Map.put(:run_task, nil)
+        |> append_status_row()
+        |> maybe_kick_git_diff()
+
+      {:noreply, new_state}
+    end
+
+    def handle_info({:git_diff, lines}, %State{} = state) when is_list(lines) do
+      {:noreply, State.set_git_diff(state, lines)}
+    end
+
+    def handle_info({:athena_error, reason}, %State{} = state) do
+      new_state =
+        state
+        |> State.flush_stream()
+        |> State.set_loading(false)
+        |> Map.put(:run_task, nil)
+        |> State.append_event({:error, "run error: " <> inspect(reason)})
+
+      {:noreply, new_state}
+    end
+
+    def handle_info(_msg, state), do: {:noreply, state}
+
+    # ── Submission + commands ────────────────────────────────────────────────
+
+    defp submit_input(%State{input_ref: nil} = state), do: {:noreply, state}
+
+    defp submit_input(%State{input_ref: ref} = state) do
+      raw = ExRatatui.textarea_get_value(ref)
+      ExRatatui.textarea_set_value(ref, "")
+
+      case Commands.parse(raw) do
+        :noop ->
+          {:noreply, state}
+
+        :exit ->
+          {:stop, restore_logger(state)}
+
+        {:message, text} ->
+          dispatch_message(text, state)
+
+        {:command, verb, args} ->
+          dispatch_command(verb, args, state)
+
+        {:unknown, verb} ->
+          append_and_noreply(state, {:warning, "Unknown command: /#{verb}. Try /help."})
+      end
+    end
+
+    defp dispatch_message(text, state) do
+      state =
+        state
+        |> State.append_event({:user, text})
+        |> State.set_loading(true)
+        |> State.reset_stream_state()
+        |> State.reset_pane_scroll()
+        |> State.reset_history_nav()
+        |> update_in_session(&Session.append_user(&1, text))
+
+      task_pid = Runner.start(state.session, self())
+      {:noreply, %{state | run_task: task_pid}}
+    end
+
+    defp dispatch_command(:help, _args, state) do
+      # Each event row renders as one line, so split the help text and append
+      # one :info row per line (otherwise only the first line is visible).
+      state =
+        Commands.help_text()
+        |> String.trim_trailing("\n")
+        |> String.split("\n")
+        |> Enum.reduce(state, fn line, s -> State.append_event(s, {:info, line}) end)
+
+      {:noreply, state}
+    end
+
+    defp dispatch_command(:clear, _args, state) do
+      {:noreply, State.clear_session(state)}
+    end
+
+    defp dispatch_command(:tools, _args, state) do
+      rows =
+        Tools.builtins()
+        |> Enum.map(fn mod -> {:info, "  - " <> inspect(mod)} end)
+
+      state = State.append_event(state, {:info, "Tools available:"})
+      state = Enum.reduce(rows, state, fn row, s -> State.append_event(s, row) end)
+      {:noreply, state}
+    end
+
+    defp dispatch_command(:mode, [], state) do
+      {:noreply, State.open_popup(state, {:mode, @modes})}
+    end
+
+    defp dispatch_command(:mode, [arg | _], state) do
+      case parse_mode_atom(arg) do
+        {:ok, mode} ->
+          state
+          |> State.set_mode(mode)
+          |> State.append_event({:info, "Mode → " <> inspect(mode)})
+          |> noreply()
+
+        :error ->
+          append_and_noreply(
+            state,
+            {:warning, "Unknown mode: " <> arg <> ". Try /mode with no args."}
+          )
+      end
+    end
+
+    defp dispatch_command(:model, [], state) do
+      case list_models_for(state.session) do
+        {:ok, []} ->
+          append_and_noreply(state, {:warning, no_models_message(state.session.provider)})
+
+        {:ok, models} ->
+          {:noreply, State.open_popup(state, {:model, models})}
+
+        {:error, reason} when reason in [:ollama_unreachable, :llamacpp_unreachable] ->
+          append_and_noreply(state, {:error, unreachable_message(state.session.provider)})
+
+        {:error, reason} ->
+          append_and_noreply(state, {:error, "Could not list models: " <> inspect(reason)})
+      end
+    end
+
+    defp dispatch_command(:model, [arg | _], state) when is_binary(arg) do
+      state
+      |> State.set_model(arg)
+      |> State.append_event({:info, "Model → " <> arg})
+      |> noreply()
+    end
+
+    defp dispatch_command(:tab, _args, state) do
+      state = State.cycle_details_tab(state)
+      label = state.details_tab |> Atom.to_string() |> String.capitalize()
+      state = maybe_kick_git_diff(state)
+
+      state
+      |> State.append_event({:info, "details tab → " <> label})
+      |> noreply()
+    end
+
+    defp dispatch_command(:mouse, args, state) do
+      requested =
+        case args |> Enum.map(&String.downcase/1) |> List.first() do
+          "on" -> true
+          "off" -> false
+          _ -> not state.mouse_enabled
+        end
+
+      if requested do
+        # X10 click reporting + SGR (extended coords) — same sequences
+        # Tui.start/1 writes on app startup.
+        write_to_tty("\e[?1000h\e[?1006h")
+      else
+        write_to_tty("\e[?1006l\e[?1000l")
       end
 
-    {:noreply, state}
-  end
+      label = if requested, do: "on", else: "off (terminal text selection restored)"
 
-  defp read_textarea(%State{input_ref: nil}), do: ""
-  defp read_textarea(%State{input_ref: ref}), do: ExRatatui.textarea_get_value(ref) || ""
-
-  defp set_textarea(%State{input_ref: nil} = state, _text), do: state
-
-  defp set_textarea(%State{input_ref: ref} = state, text) do
-    ExRatatui.textarea_set_value(ref, text || "")
-    state
-  end
-
-  defp handle_popup_key(%Event.Key{code: code}, state) when code in ["up", "k"] do
-    {:noreply, State.move_popup_selection(state, -1)}
-  end
-
-  defp handle_popup_key(%Event.Key{code: code}, state) when code in ["down", "j"] do
-    {:noreply, State.move_popup_selection(state, +1)}
-  end
-
-  defp handle_popup_key(%Event.Key{code: "esc"}, state) do
-    {:noreply, State.close_popup(state)}
-  end
-
-  defp handle_popup_key(%Event.Key{code: "enter"}, %State{popup: {:model, _, _}} = state) do
-    case State.current_popup_selection(state) do
-      nil ->
-        {:noreply, State.close_popup(state)}
-
-      model when is_binary(model) ->
-        state
-        |> State.set_model(model)
-        |> State.close_popup()
-        |> State.append_event({:info, "Model → " <> model})
-        |> noreply()
-    end
-  end
-
-  defp handle_popup_key(%Event.Key{code: "enter"}, %State{popup: {:mode, _, _}} = state) do
-    case State.current_popup_selection(state) do
-      nil ->
-        {:noreply, State.close_popup(state)}
-
-      mode when is_atom(mode) ->
-        state
-        |> State.set_mode(mode)
-        |> State.close_popup()
-        |> State.append_event({:info, "Mode → " <> inspect(mode)})
-        |> noreply()
-    end
-  end
-
-  defp handle_popup_key(_, state), do: {:noreply, state}
-
-  # ── Process messages ─────────────────────────────────────────────────────
-
-  @impl true
-  def handle_info(:tick, %State{} = state) do
-    schedule_tick()
-    {:noreply, State.flush_stream(state)}
-  end
-
-  def handle_info({:athena_event, event}, %State{} = state) do
-    state = State.append_loop_event(state, event)
-
-    # Kick off a fresh `git diff` whenever a tool result lands — that's
-    # the point where the working tree may have changed. Bounded async,
-    # never blocks the UI.
-    state =
-      case event do
-        {:tool_result, _} -> maybe_kick_git_diff(state)
-        _ -> state
-      end
-
-    {:noreply, state}
-  end
-
-  def handle_info({:athena_done, result}, %State{} = state) do
-    new_state =
       state
-      |> State.flush_stream()
-      |> State.apply_result(result)
-      |> State.set_loading(false)
-      |> Map.put(:run_task, nil)
-      |> append_status_row()
-      |> maybe_kick_git_diff()
-
-    {:noreply, new_state}
-  end
-
-  def handle_info({:git_diff, lines}, %State{} = state) when is_list(lines) do
-    {:noreply, State.set_git_diff(state, lines)}
-  end
-
-  def handle_info({:athena_error, reason}, %State{} = state) do
-    new_state =
-      state
-      |> State.flush_stream()
-      |> State.set_loading(false)
-      |> Map.put(:run_task, nil)
-      |> State.append_event({:error, "run error: " <> inspect(reason)})
-
-    {:noreply, new_state}
-  end
-
-  def handle_info(_msg, state), do: {:noreply, state}
-
-  # ── Submission + commands ────────────────────────────────────────────────
-
-  defp submit_input(%State{input_ref: nil} = state), do: {:noreply, state}
-
-  defp submit_input(%State{input_ref: ref} = state) do
-    raw = ExRatatui.textarea_get_value(ref)
-    ExRatatui.textarea_set_value(ref, "")
-
-    case Commands.parse(raw) do
-      :noop ->
-        {:noreply, state}
-
-      :exit ->
-        {:stop, restore_logger(state)}
-
-      {:message, text} ->
-        dispatch_message(text, state)
-
-      {:command, verb, args} ->
-        dispatch_command(verb, args, state)
-
-      {:unknown, verb} ->
-        append_and_noreply(state, {:warning, "Unknown command: /#{verb}. Try /help."})
+      |> State.set_mouse_enabled(requested)
+      |> State.append_event({:info, "mouse capture → " <> label})
+      |> noreply()
     end
-  end
 
-  defp dispatch_message(text, state) do
-    state =
-      state
-      |> State.append_event({:user, text})
-      |> State.set_loading(true)
-      |> State.reset_stream_state()
-      |> State.reset_pane_scroll()
-      |> State.reset_history_nav()
-      |> update_in_session(&Session.append_user(&1, text))
-
-    task_pid = Runner.start(state.session, self())
-    {:noreply, %{state | run_task: task_pid}}
-  end
-
-  defp dispatch_command(:help, _args, state) do
-    # Each event row renders as one line, so split the help text and append
-    # one :info row per line (otherwise only the first line is visible).
-    state =
-      Commands.help_text()
-      |> String.trim_trailing("\n")
-      |> String.split("\n")
-      |> Enum.reduce(state, fn line, s -> State.append_event(s, {:info, line}) end)
-
-    {:noreply, state}
-  end
-
-  defp dispatch_command(:clear, _args, state) do
-    {:noreply, State.clear_session(state)}
-  end
-
-  defp dispatch_command(:tools, _args, state) do
-    rows =
-      Tools.builtins()
-      |> Enum.map(fn mod -> {:info, "  - " <> inspect(mod)} end)
-
-    state = State.append_event(state, {:info, "Tools available:"})
-    state = Enum.reduce(rows, state, fn row, s -> State.append_event(s, row) end)
-    {:noreply, state}
-  end
-
-  defp dispatch_command(:mode, [], state) do
-    {:noreply, State.open_popup(state, {:mode, @modes})}
-  end
-
-  defp dispatch_command(:mode, [arg | _], state) do
-    case parse_mode_atom(arg) do
-      {:ok, mode} ->
-        state
-        |> State.set_mode(mode)
-        |> State.append_event({:info, "Mode → " <> inspect(mode)})
-        |> noreply()
-
-      :error ->
-        append_and_noreply(
-          state,
-          {:warning, "Unknown mode: " <> arg <> ". Try /mode with no args."}
-        )
-    end
-  end
-
-  defp dispatch_command(:model, [], state) do
-    case list_models_for(state.session) do
-      {:ok, []} ->
-        append_and_noreply(state, {:warning, no_models_message(state.session.provider)})
-
-      {:ok, models} ->
-        {:noreply, State.open_popup(state, {:model, models})}
-
-      {:error, reason} when reason in [:ollama_unreachable, :llamacpp_unreachable] ->
-        append_and_noreply(state, {:error, unreachable_message(state.session.provider)})
-
-      {:error, reason} ->
-        append_and_noreply(state, {:error, "Could not list models: " <> inspect(reason)})
-    end
-  end
-
-  defp dispatch_command(:model, [arg | _], state) when is_binary(arg) do
-    state
-    |> State.set_model(arg)
-    |> State.append_event({:info, "Model → " <> arg})
-    |> noreply()
-  end
-
-  defp dispatch_command(:tab, _args, state) do
-    state = State.cycle_details_tab(state)
-    label = state.details_tab |> Atom.to_string() |> String.capitalize()
-    state = maybe_kick_git_diff(state)
-
-    state
-    |> State.append_event({:info, "details tab → " <> label})
-    |> noreply()
-  end
-
-  defp dispatch_command(:mouse, args, state) do
-    requested =
+    defp dispatch_command(:diff, args, state) do
       case args |> Enum.map(&String.downcase/1) |> List.first() do
-        "on" -> true
-        "off" -> false
-        _ -> not state.mouse_enabled
-      end
-
-    if requested do
-      # X10 click reporting + SGR (extended coords) — same sequences
-      # Tui.start/1 writes on app startup.
-      write_to_tty("\e[?1000h\e[?1006h")
-    else
-      write_to_tty("\e[?1006l\e[?1000l")
-    end
-
-    label = if requested, do: "on", else: "off (terminal text selection restored)"
-
-    state
-    |> State.set_mouse_enabled(requested)
-    |> State.append_event({:info, "mouse capture → " <> label})
-    |> noreply()
-  end
-
-  defp dispatch_command(:diff, args, state) do
-    case args |> Enum.map(&String.downcase/1) |> List.first() do
-      mode when mode in ["side", "side-by-side", "split"] ->
-        state
-        |> State.set_diff_mode(:side_by_side)
-        |> State.set_details_tab(:changes)
-        |> State.append_event({:info, "diff layout → side-by-side"})
-        |> maybe_kick_git_diff()
-        |> noreply()
-
-      "inline" ->
-        state
-        |> State.set_diff_mode(:inline)
-        |> State.set_details_tab(:changes)
-        |> State.append_event({:info, "diff layout → inline"})
-        |> maybe_kick_git_diff()
-        |> noreply()
-
-      _ ->
-        state
-        |> State.set_details_tab(:changes)
-        |> State.append_event({:info, "details tab → Changes"})
-        |> maybe_kick_git_diff()
-        |> noreply()
-    end
-  end
-
-  defp dispatch_command(:timeline, _args, state) do
-    state
-    |> State.set_details_tab(:timeline)
-    |> State.append_event({:info, "details tab → Timeline"})
-    |> noreply()
-  end
-
-  defp dispatch_command(:cd, [], state) do
-    append_and_noreply(
-      state,
-      {:warning, "Usage: /cd PATH  (use /pwd to see the current directory)"}
-    )
-  end
-
-  defp dispatch_command(:cd, [path_arg | _], state) do
-    expanded = Path.expand(path_arg)
-
-    cond do
-      not File.exists?(expanded) ->
-        append_and_noreply(state, {:warning, "Path does not exist: " <> expanded})
-
-      not File.dir?(expanded) ->
-        append_and_noreply(state, {:warning, "Not a directory: " <> expanded})
-
-      true ->
-        state
-        |> update_in_session(&Session.set_cwd(&1, expanded))
-        |> State.append_event({:info, "cwd → " <> expanded})
-        |> maybe_kick_git_diff()
-        |> noreply()
-    end
-  end
-
-  defp dispatch_command(:pwd, _args, state) do
-    {path, source} =
-      case state.session.cwd do
-        nil ->
-          case File.cwd() do
-            {:ok, p} -> {p, " (default, process cwd — use /cd or -p to override)"}
-            _ -> {"?", " (unable to read process cwd)"}
-          end
-
-        p ->
-          {p, " (set via /cd or --path)"}
-      end
-
-    append_and_noreply(state, {:info, "cwd: " <> path <> source})
-  end
-
-  defp dispatch_command(:details, args, state) do
-    new_value =
-      case Enum.map(args, &String.downcase/1) do
-        ["on"] -> true
-        ["off"] -> false
-        _ -> not state.show_details
-      end
-
-    label = if new_value, do: "on", else: "off"
-
-    state
-    |> Map.put(:show_details, new_value)
-    |> State.append_event({:info, "Details pane → " <> label})
-    |> noreply()
-  end
-
-  defp dispatch_command(:expand, args, state) do
-    results = Session.tool_results(state.session)
-    total = length(results)
-    n = parse_expand_index(args)
-
-    case Enum.at(results, n - 1) do
-      nil ->
-        append_and_noreply(
-          state,
-          {:warning, "No tool result at position #{n} (total: #{total})."}
-        )
-
-      %ExAthena.Messages.ToolResult{content: content, is_error: is_error} ->
-        kind = if is_error, do: :tool_result_error, else: :tool_result
-        header_kind = if is_error, do: :error, else: :info
-
-        state =
+        mode when mode in ["side", "side-by-side", "split"] ->
           state
-          |> State.append_event({header_kind, "▼ tool result #{n}/#{total}"})
-          |> append_expanded_lines(kind, to_string(content))
-          |> State.append_event({:info, "▲ /expand"})
+          |> State.set_diff_mode(:side_by_side)
+          |> State.set_details_tab(:changes)
+          |> State.append_event({:info, "diff layout → side-by-side"})
+          |> maybe_kick_git_diff()
+          |> noreply()
 
-        {:noreply, state}
-    end
-  end
+        "inline" ->
+          state
+          |> State.set_diff_mode(:inline)
+          |> State.set_details_tab(:changes)
+          |> State.append_event({:info, "diff layout → inline"})
+          |> maybe_kick_git_diff()
+          |> noreply()
 
-  defp dispatch_command(_, _, state), do: {:noreply, state}
-
-  # ── Helpers ──────────────────────────────────────────────────────────────
-
-  defp schedule_tick, do: Process.send_after(self(), :tick, @tick_interval_ms)
-
-  defp append_status_row(%State{session: session} = state) do
-    State.append_event(state, {:status, View.status_line(session)})
-  end
-
-  defp banner_events(%State{session: session} = state) do
-    cwd_line =
-      case session.cwd do
-        nil ->
-          case File.cwd() do
-            {:ok, path} -> "cwd=" <> path <> "  (default — use /cd or -p to change)"
-            _ -> "cwd=(unknown)"
-          end
-
-        path ->
-          "cwd=" <> path
+        _ ->
+          state
+          |> State.set_details_tab(:changes)
+          |> State.append_event({:info, "details tab → Changes"})
+          |> maybe_kick_git_diff()
+          |> noreply()
       end
+    end
 
-    state
-    |> State.append_event({:info, "ExAthena chat  (/help for commands, /exit to quit)"})
-    |> State.append_event(
-      {:info,
-       "provider=#{session.provider}  model=#{session.model}  mode=#{inspect(session.mode)}"}
-    )
-    |> State.append_event({:info, cwd_line})
-  end
+    defp dispatch_command(:timeline, _args, state) do
+      state
+      |> State.set_details_tab(:timeline)
+      |> State.append_event({:info, "details tab → Timeline"})
+      |> noreply()
+    end
 
-  # ── Git diff (Changes tab) ────────────────────────────────────────────
+    defp dispatch_command(:cd, [], state) do
+      append_and_noreply(
+        state,
+        {:warning, "Usage: /cd PATH  (use /pwd to see the current directory)"}
+      )
+    end
 
-  # Spawn an unsupervised Task that shells out to `git diff HEAD` in the
-  # session's cwd and sends `{:git_diff, lines}` back to this process.
-  # Wrapped in try/rescue/catch per the CLAUDE.md Task.start guidance.
-  # Errors / non-git directories result in an empty diff (silently).
-  defp maybe_kick_git_diff(state) do
-    parent = self()
-    cwd = state.session.cwd || File.cwd!()
+    defp dispatch_command(:cd, [path_arg | _], state) do
+      expanded = Path.expand(path_arg)
 
-    Task.start(fn ->
-      try do
-        lines = fetch_git_diff(cwd)
-        send(parent, {:git_diff, lines})
-      rescue
-        _ -> send(parent, {:git_diff, []})
-      catch
-        _, _ -> send(parent, {:git_diff, []})
+      cond do
+        not File.exists?(expanded) ->
+          append_and_noreply(state, {:warning, "Path does not exist: " <> expanded})
+
+        not File.dir?(expanded) ->
+          append_and_noreply(state, {:warning, "Not a directory: " <> expanded})
+
+        true ->
+          state
+          |> update_in_session(&Session.set_cwd(&1, expanded))
+          |> State.append_event({:info, "cwd → " <> expanded})
+          |> maybe_kick_git_diff()
+          |> noreply()
       end
-    end)
-
-    state
-  end
-
-  # Per-file caps when synthesizing diffs for untracked files. Untracked
-  # files don't show up in `git diff HEAD`, so we generate a synthetic
-  # "new file" diff for each — but cap so a generated/binary blob doesn't
-  # flood the pane.
-  @max_untracked_lines 500
-  @max_untracked_bytes 100_000
-
-  defp fetch_git_diff(cwd) do
-    case System.cmd("git", ["rev-parse", "--show-toplevel"],
-           cd: cwd,
-           stderr_to_stdout: true
-         ) do
-      {_root, 0} ->
-        tracked = run_git_diff(cwd)
-        untracked = render_untracked_files(cwd)
-
-        case {tracked, untracked} do
-          {[], []} -> ["(no changes vs HEAD)", "cwd: #{cwd}"]
-          _ -> tracked ++ untracked
-        end
-
-      {output, _exit} ->
-        ["not a git repository (cwd: #{cwd})" | String.split(String.trim(output), "\n")]
     end
-  rescue
-    e in ErlangError ->
-      case e.original do
-        :enoent -> ["`git` executable not found on PATH"]
-        other -> ["git crashed: " <> inspect(other)]
-      end
 
-    e ->
-      ["git crashed: " <> Exception.message(e)]
-  end
-
-  defp run_git_diff(cwd) do
-    case System.cmd("git", ["diff", "HEAD", "--color=never"], cd: cwd, stderr_to_stdout: true) do
-      {output, 0} -> output |> String.trim_trailing("\n") |> String.split("\n", trim: true)
-      _ -> []
-    end
-  end
-
-  # `git ls-files --others --exclude-standard` lists files not tracked
-  # and not gitignored. For each, synthesize a `--- /dev/null` /
-  # `+++ b/<path>` diff so new files appear in the same Changes view.
-  defp render_untracked_files(cwd) do
-    case System.cmd("git", ["ls-files", "--others", "--exclude-standard"],
-           cd: cwd,
-           stderr_to_stdout: true
-         ) do
-      {output, 0} ->
-        output
-        |> String.trim()
-        |> String.split("\n", trim: true)
-        |> Enum.flat_map(&render_untracked_file(&1, cwd))
-
-      _ ->
-        []
-    end
-  end
-
-  defp render_untracked_file(rel, cwd) do
-    header_base = [
-      "diff --git a/#{rel} b/#{rel}",
-      "new file mode 100644",
-      "--- /dev/null",
-      "+++ b/#{rel}"
-    ]
-
-    path = Path.join(cwd, rel)
-
-    case File.stat(path) do
-      {:ok, %{type: :regular, size: size}} when size > @max_untracked_bytes ->
-        # Synthesize a 1-line hunk header so the structured diff parser
-        # counts the placeholder as part of the file rather than dropping
-        # bare `+` lines that have no enclosing hunk.
-        header_base ++
-          ["@@ -0,0 +1,1 @@", "+(file too large to show: #{size} bytes)"]
-
-      {:ok, %{type: :regular}} ->
-        case File.read(path) do
-          {:ok, content} ->
-            if binary_content?(content) do
-              header_base ++ ["@@ -0,0 +1,1 @@", "+(binary file)"]
-            else
-              lines = String.split(content, "\n")
-              total = length(lines)
-              visible = Enum.take(lines, @max_untracked_lines)
-              shown = length(visible)
-              diff_lines = Enum.map(visible, &("+" <> &1))
-
-              footer =
-                if total > shown,
-                  do: ["+… (#{total - shown} more lines)"],
-                  else: []
-
-              # `@@ -0,0 +1,N @@` — git's convention for a new file.
-              hunk_header = "@@ -0,0 +1,#{shown + length(footer)} @@"
-              header_base ++ [hunk_header] ++ diff_lines ++ footer
+    defp dispatch_command(:pwd, _args, state) do
+      {path, source} =
+        case state.session.cwd do
+          nil ->
+            case File.cwd() do
+              {:ok, p} -> {p, " (default, process cwd — use /cd or -p to override)"}
+              _ -> {"?", " (unable to read process cwd)"}
             end
 
-          _ ->
-            []
+          p ->
+            {p, " (set via /cd or --path)"}
         end
 
-      _ ->
-        []
+      append_and_noreply(state, {:info, "cwd: " <> path <> source})
     end
-  end
 
-  # Cheap binary heuristic: NUL byte in the first 1KB.
-  defp binary_content?(""), do: false
+    defp dispatch_command(:details, args, state) do
+      new_value =
+        case Enum.map(args, &String.downcase/1) do
+          ["on"] -> true
+          ["off"] -> false
+          _ -> not state.show_details
+        end
 
-  defp binary_content?(content) do
-    head_size = min(byte_size(content), 1024)
-    :binary.match(binary_part(content, 0, head_size), <<0>>) != :nomatch
-  end
+      label = if new_value, do: "on", else: "off"
 
-  defp restore_logger(%State{prior_log_level: level} = state) do
-    Logger.configure(level: level)
-    state
-  end
-
-  defp update_in_session(state, fun), do: %{state | session: fun.(state.session)}
-
-  defp noreply(state), do: {:noreply, state}
-
-  defp append_and_noreply(state, row), do: {:noreply, State.append_event(state, row)}
-
-  defp append_expanded_lines(state, kind, text) do
-    text
-    |> String.trim_trailing("\n")
-    |> String.split("\n")
-    |> Enum.reduce(state, fn line, s -> State.append_event(s, {kind, line}) end)
-  end
-
-  defp parse_mode_atom(arg) when is_binary(arg) do
-    candidate = String.to_existing_atom(arg)
-    if candidate in @modes, do: {:ok, candidate}, else: :error
-  rescue
-    ArgumentError -> :error
-  end
-
-  defp parse_expand_index([]), do: 1
-
-  defp parse_expand_index([arg | _]) when is_binary(arg) do
-    case Integer.parse(arg) do
-      {n, ""} when n > 0 -> n
-      _ -> 1
+      state
+      |> Map.put(:show_details, new_value)
+      |> State.append_event({:info, "Details pane → " <> label})
+      |> noreply()
     end
-  end
 
-  defp list_models_for(%{provider: :llamacpp}), do: LlamaCpp.list_models([])
-  defp list_models_for(_session), do: Ollama.list_models([])
+    defp dispatch_command(:expand, args, state) do
+      results = Session.tool_results(state.session)
+      total = length(results)
+      n = parse_expand_index(args)
 
-  defp no_models_message(:llamacpp),
-    do: "No models loaded. Start one with: llama-server --model path/to/model.gguf"
+      case Enum.at(results, n - 1) do
+        nil ->
+          append_and_noreply(
+            state,
+            {:warning, "No tool result at position #{n} (total: #{total})."}
+          )
 
-  defp no_models_message(_),
-    do: "No models installed. Pull one with: ollama pull llama3.1"
+        %ExAthena.Messages.ToolResult{content: content, is_error: is_error} ->
+          kind = if is_error, do: :tool_result_error, else: :tool_result
+          header_kind = if is_error, do: :error, else: :info
 
-  defp unreachable_message(:llamacpp),
-    do: "llama.cpp server not running. Start it with: llama-server --model path/to/model.gguf"
+          state =
+            state
+            |> State.append_event({header_kind, "▼ tool result #{n}/#{total}"})
+            |> append_expanded_lines(kind, to_string(content))
+            |> State.append_event({:info, "▲ /expand"})
 
-  defp unreachable_message(_),
-    do: "Ollama not running. Start it with: ollama serve"
-
-  # Reconcile the configured model against what the local provider has
-  # available; surface diagnostics as banner rows but don't block startup.
-  defp reconcile_initial_session(%Session{provider: :ollama} = session) do
-    case Runner.select_initial_model(session.model, Ollama.list_models([])) do
-      {:ok, _} -> session
-      {:fallback, model} -> Session.set_model(session, model)
-      {:error, _} -> session
+          {:noreply, state}
+      end
     end
-  end
 
-  defp reconcile_initial_session(%Session{provider: :llamacpp} = session) do
-    case Runner.select_initial_model(session.model, LlamaCpp.list_models([])) do
-      {:ok, _} -> session
-      {:fallback, model} -> Session.set_model(session, model)
-      {:error, _} -> session
+    defp dispatch_command(_, _, state), do: {:noreply, state}
+
+    # ── Helpers ──────────────────────────────────────────────────────────────
+
+    defp schedule_tick, do: Process.send_after(self(), :tick, @tick_interval_ms)
+
+    defp append_status_row(%State{session: session} = state) do
+      State.append_event(state, {:status, View.status_line(session)})
     end
-  end
 
-  defp reconcile_initial_session(session), do: session
-end
+    defp banner_events(%State{session: session} = state) do
+      cwd_line =
+        case session.cwd do
+          nil ->
+            case File.cwd() do
+              {:ok, path} -> "cwd=" <> path <> "  (default — use /cd or -p to change)"
+              _ -> "cwd=(unknown)"
+            end
+
+          path ->
+            "cwd=" <> path
+        end
+
+      state
+      |> State.append_event({:info, "ExAthena chat  (/help for commands, /exit to quit)"})
+      |> State.append_event(
+        {:info,
+         "provider=#{session.provider}  model=#{session.model}  mode=#{inspect(session.mode)}"}
+      )
+      |> State.append_event({:info, cwd_line})
+    end
+
+    # ── Git diff (Changes tab) ────────────────────────────────────────────
+
+    # Spawn an unsupervised Task that shells out to `git diff HEAD` in the
+    # session's cwd and sends `{:git_diff, lines}` back to this process.
+    # Wrapped in try/rescue/catch per the CLAUDE.md Task.start guidance.
+    # Errors / non-git directories result in an empty diff (silently).
+    defp maybe_kick_git_diff(state) do
+      parent = self()
+      cwd = state.session.cwd || File.cwd!()
+
+      Task.start(fn ->
+        try do
+          lines = fetch_git_diff(cwd)
+          send(parent, {:git_diff, lines})
+        rescue
+          _ -> send(parent, {:git_diff, []})
+        catch
+          _, _ -> send(parent, {:git_diff, []})
+        end
+      end)
+
+      state
+    end
+
+    # Per-file caps when synthesizing diffs for untracked files. Untracked
+    # files don't show up in `git diff HEAD`, so we generate a synthetic
+    # "new file" diff for each — but cap so a generated/binary blob doesn't
+    # flood the pane.
+    @max_untracked_lines 500
+    @max_untracked_bytes 100_000
+
+    defp fetch_git_diff(cwd) do
+      case System.cmd("git", ["rev-parse", "--show-toplevel"],
+             cd: cwd,
+             stderr_to_stdout: true
+           ) do
+        {_root, 0} ->
+          tracked = run_git_diff(cwd)
+          untracked = render_untracked_files(cwd)
+
+          case {tracked, untracked} do
+            {[], []} -> ["(no changes vs HEAD)", "cwd: #{cwd}"]
+            _ -> tracked ++ untracked
+          end
+
+        {output, _exit} ->
+          ["not a git repository (cwd: #{cwd})" | String.split(String.trim(output), "\n")]
+      end
+    rescue
+      e in ErlangError ->
+        case e.original do
+          :enoent -> ["`git` executable not found on PATH"]
+          other -> ["git crashed: " <> inspect(other)]
+        end
+
+      e ->
+        ["git crashed: " <> Exception.message(e)]
+    end
+
+    defp run_git_diff(cwd) do
+      case System.cmd("git", ["diff", "HEAD", "--color=never"], cd: cwd, stderr_to_stdout: true) do
+        {output, 0} -> output |> String.trim_trailing("\n") |> String.split("\n", trim: true)
+        _ -> []
+      end
+    end
+
+    # `git ls-files --others --exclude-standard` lists files not tracked
+    # and not gitignored. For each, synthesize a `--- /dev/null` /
+    # `+++ b/<path>` diff so new files appear in the same Changes view.
+    defp render_untracked_files(cwd) do
+      case System.cmd("git", ["ls-files", "--others", "--exclude-standard"],
+             cd: cwd,
+             stderr_to_stdout: true
+           ) do
+        {output, 0} ->
+          output
+          |> String.trim()
+          |> String.split("\n", trim: true)
+          |> Enum.flat_map(&render_untracked_file(&1, cwd))
+
+        _ ->
+          []
+      end
+    end
+
+    defp render_untracked_file(rel, cwd) do
+      header_base = [
+        "diff --git a/#{rel} b/#{rel}",
+        "new file mode 100644",
+        "--- /dev/null",
+        "+++ b/#{rel}"
+      ]
+
+      path = Path.join(cwd, rel)
+
+      case File.stat(path) do
+        {:ok, %{type: :regular, size: size}} when size > @max_untracked_bytes ->
+          # Synthesize a 1-line hunk header so the structured diff parser
+          # counts the placeholder as part of the file rather than dropping
+          # bare `+` lines that have no enclosing hunk.
+          header_base ++
+            ["@@ -0,0 +1,1 @@", "+(file too large to show: #{size} bytes)"]
+
+        {:ok, %{type: :regular}} ->
+          case File.read(path) do
+            {:ok, content} ->
+              if binary_content?(content) do
+                header_base ++ ["@@ -0,0 +1,1 @@", "+(binary file)"]
+              else
+                lines = String.split(content, "\n")
+                total = length(lines)
+                visible = Enum.take(lines, @max_untracked_lines)
+                shown = length(visible)
+                diff_lines = Enum.map(visible, &("+" <> &1))
+
+                footer =
+                  if total > shown,
+                    do: ["+… (#{total - shown} more lines)"],
+                    else: []
+
+                # `@@ -0,0 +1,N @@` — git's convention for a new file.
+                hunk_header = "@@ -0,0 +1,#{shown + length(footer)} @@"
+                header_base ++ [hunk_header] ++ diff_lines ++ footer
+              end
+
+            _ ->
+              []
+          end
+
+        _ ->
+          []
+      end
+    end
+
+    # Cheap binary heuristic: NUL byte in the first 1KB.
+    defp binary_content?(""), do: false
+
+    defp binary_content?(content) do
+      head_size = min(byte_size(content), 1024)
+      :binary.match(binary_part(content, 0, head_size), <<0>>) != :nomatch
+    end
+
+    defp restore_logger(%State{prior_log_level: level} = state) do
+      Logger.configure(level: level)
+      state
+    end
+
+    defp update_in_session(state, fun), do: %{state | session: fun.(state.session)}
+
+    defp noreply(state), do: {:noreply, state}
+
+    defp append_and_noreply(state, row), do: {:noreply, State.append_event(state, row)}
+
+    defp append_expanded_lines(state, kind, text) do
+      text
+      |> String.trim_trailing("\n")
+      |> String.split("\n")
+      |> Enum.reduce(state, fn line, s -> State.append_event(s, {kind, line}) end)
+    end
+
+    defp parse_mode_atom(arg) when is_binary(arg) do
+      candidate = String.to_existing_atom(arg)
+      if candidate in @modes, do: {:ok, candidate}, else: :error
+    rescue
+      ArgumentError -> :error
+    end
+
+    defp parse_expand_index([]), do: 1
+
+    defp parse_expand_index([arg | _]) when is_binary(arg) do
+      case Integer.parse(arg) do
+        {n, ""} when n > 0 -> n
+        _ -> 1
+      end
+    end
+
+    defp list_models_for(%{provider: :llamacpp}), do: LlamaCpp.list_models([])
+    defp list_models_for(_session), do: Ollama.list_models([])
+
+    defp no_models_message(:llamacpp),
+      do: "No models loaded. Start one with: llama-server --model path/to/model.gguf"
+
+    defp no_models_message(_),
+      do: "No models installed. Pull one with: ollama pull llama3.1"
+
+    defp unreachable_message(:llamacpp),
+      do: "llama.cpp server not running. Start it with: llama-server --model path/to/model.gguf"
+
+    defp unreachable_message(_),
+      do: "Ollama not running. Start it with: ollama serve"
+
+    # Reconcile the configured model against what the local provider has
+    # available; surface diagnostics as banner rows but don't block startup.
+    defp reconcile_initial_session(%Session{provider: :ollama} = session) do
+      case Runner.select_initial_model(session.model, Ollama.list_models([])) do
+        {:ok, _} -> session
+        {:fallback, model} -> Session.set_model(session, model)
+        {:error, _} -> session
+      end
+    end
+
+    defp reconcile_initial_session(%Session{provider: :llamacpp} = session) do
+      case Runner.select_initial_model(session.model, LlamaCpp.list_models([])) do
+        {:ok, _} -> session
+        {:fallback, model} -> Session.set_model(session, model)
+        {:error, _} -> session
+      end
+    end
+
+    defp reconcile_initial_session(session), do: session
+  end
 end

--- a/lib/ex_athena/chat/tui/view.ex
+++ b/lib/ex_athena/chat/tui/view.ex
@@ -2,1029 +2,1030 @@
 # widget structs at compile time (e.g. `%ExRatatui.Widgets.Tabs{}`), so it
 # can't compile for consumers that don't pull ex_ratatui. See ExAthena.Chat.Tui.
 if Code.ensure_loaded?(ExRatatui.App) do
-defmodule ExAthena.Chat.Tui.View do
-  @moduledoc """
-  Pure view function for `ExAthena.Chat.Tui`. Turns a `%State{}` into the
-  list of `{widget, %Rect{}}` tuples the ex_ratatui runtime needs.
+  defmodule ExAthena.Chat.Tui.View do
+    @moduledoc """
+    Pure view function for `ExAthena.Chat.Tui`. Turns a `%State{}` into the
+    list of `{widget, %Rect{}}` tuples the ex_ratatui runtime needs.
 
-  Layout (top-to-bottom):
+    Layout (top-to-bottom):
 
-    1. Header (1 row) — `provider · model · mode · iter=N · in/out tok · $cost`.
-    2. Body (flex) — split horizontally 50/50 into:
-         * Left  — `messages` WidgetList (one `{Paragraph, 1}` per event row).
-           If `state.loading? == true`, a `Throbber` is appended.
-         * Right — `details` WidgetList: full args, full tool results, thinking,
-           tool UI payloads, and every loop event. Wrapped in a titled `Block`
-           with a left border.
-    3. Input (3 rows) — `Textarea` bound to `state.input_ref` inside a
-       titled `Block`.
-    4. Footer (1 row) — shortcut hints (changes when a popup is open).
+      1. Header (1 row) — `provider · model · mode · iter=N · in/out tok · $cost`.
+      2. Body (flex) — split horizontally 50/50 into:
+           * Left  — `messages` WidgetList (one `{Paragraph, 1}` per event row).
+             If `state.loading? == true`, a `Throbber` is appended.
+           * Right — `details` WidgetList: full args, full tool results, thinking,
+             tool UI payloads, and every loop event. Wrapped in a titled `Block`
+             with a left border.
+      3. Input (3 rows) — `Textarea` bound to `state.input_ref` inside a
+         titled `Block`.
+      4. Footer (1 row) — shortcut hints (changes when a popup is open).
 
-  When `state.popup != nil`, a `Popup` widget overlays the messages
-  rect with a centered `List`.
-  """
+    When `state.popup != nil`, a `Popup` widget overlays the messages
+    rect with a centered `List`.
+    """
 
-  alias ExAthena.Chat.{Commands, Session, Tui.State}
-  alias ExRatatui.Frame
-  alias ExRatatui.Layout
-  alias ExRatatui.Layout.Rect
-  alias ExRatatui.Style
-  alias ExRatatui.Text.{Line, Span}
-  alias ExRatatui.Widgets.{Block, Clear, List, Paragraph, Popup, Textarea, Throbber, WidgetList}
+    alias ExAthena.Chat.{Commands, Session, Tui.State}
+    alias ExRatatui.Frame
+    alias ExRatatui.Layout
+    alias ExRatatui.Layout.Rect
+    alias ExRatatui.Style
+    alias ExRatatui.Text.{Line, Span}
+    alias ExRatatui.Widgets.{Block, Clear, List, Paragraph, Popup, Textarea, Throbber, WidgetList}
 
-  @input_height 3
-  @footer_height 1
+    @input_height 3
+    @footer_height 1
 
-  @input_block %Block{
-    title: " me ▸ ",
-    borders: [:all],
-    border_type: :rounded
-  }
+    @input_block %Block{
+      title: " me ▸ ",
+      borders: [:all],
+      border_type: :rounded
+    }
 
-  @doc """
-  Build the per-frame widget list for the given state and frame.
-  """
-  @spec build_frame(State.t(), Frame.t()) :: [{struct(), Rect.t()}]
-  def build_frame(%State{} = state, %Frame{width: w, height: h}) do
-    area = %Rect{x: 0, y: 0, width: w, height: h}
+    @doc """
+    Build the per-frame widget list for the given state and frame.
+    """
+    @spec build_frame(State.t(), Frame.t()) :: [{struct(), Rect.t()}]
+    def build_frame(%State{} = state, %Frame{width: w, height: h}) do
+      area = %Rect{x: 0, y: 0, width: w, height: h}
 
-    [header_rect, body_rect, input_rect, footer_rect] =
-      Layout.split(area, :vertical, [
-        {:length, 1},
-        {:min, 0},
-        {:length, @input_height},
-        {:length, @footer_height}
-      ])
+      [header_rect, body_rect, input_rect, footer_rect] =
+        Layout.split(area, :vertical, [
+          {:length, 1},
+          {:min, 0},
+          {:length, @input_height},
+          {:length, @footer_height}
+        ])
 
-    {messages_rect, details_rect} = split_body(body_rect, state)
+      {messages_rect, details_rect} = split_body(body_rect, state)
 
-    # Stash the layout rects so the App's mouse-event handler can route
-    # clicks and wheel scrolls without recomputing the layout. Process
-    # dict is per-process and is the same process the App callbacks run
-    # in, so this is safe and cheap.
-    tabs_rect = details_rect && %Rect{details_rect | height: 1}
+      # Stash the layout rects so the App's mouse-event handler can route
+      # clicks and wheel scrolls without recomputing the layout. Process
+      # dict is per-process and is the same process the App callbacks run
+      # in, so this is safe and cheap.
+      tabs_rect = details_rect && %Rect{details_rect | height: 1}
 
-    Process.put(:tui_layout, %{
-      messages: messages_rect,
-      details: details_rect,
-      tabs: tabs_rect,
-      tab_titles: details_tab_titles(state)
-    })
+      Process.put(:tui_layout, %{
+        messages: messages_rect,
+        details: details_rect,
+        tabs: tabs_rect,
+        tab_titles: details_tab_titles(state)
+      })
 
-    widgets =
+      widgets =
+        [
+          {header(state), header_rect},
+          {messages(state, messages_rect.width, messages_rect.height), messages_rect},
+          {input(state), input_rect},
+          {footer(state), footer_rect}
+        ] ++ details_widget(state, details_rect) ++ autocomplete_widget(state, input_rect)
+
+      case popup(state, messages_rect) do
+        nil -> widgets
+        popup_tuple -> widgets ++ [popup_tuple]
+      end
+    end
+
+    defp details_tab_titles(state) do
+      tabs = State.details_tabs()
+      Enum.map(tabs, &{&1, tab_title(&1, state)})
+    end
+
+    defp split_body(body_rect, %State{show_details: false}), do: {body_rect, nil}
+
+    defp split_body(body_rect, _state) do
+      [m, d] = Layout.split(body_rect, :horizontal, [{:percentage, 50}, {:percentage, 50}])
+      {m, d}
+    end
+
+    defp details_widget(_state, nil), do: []
+
+    defp details_widget(state, details_rect) do
+      [tabs_rect, content_rect] =
+        Layout.split(details_rect, :vertical, [{:length, 1}, {:min, 0}])
+
+      # The content Block draws borders on all four sides, so the interior
+      # is two cells narrower AND two cells shorter than the outer rect.
+      inner_w = max(content_rect.width - 2, 1)
+      inner_h = max(content_rect.height - 2, 1)
+
+      content_widget =
+        case state.details_tab do
+          :timeline -> details(state, inner_w, inner_h)
+          :changes -> changes(state, inner_w, inner_h)
+        end
+
       [
-        {header(state), header_rect},
-        {messages(state, messages_rect.width, messages_rect.height), messages_rect},
-        {input(state), input_rect},
-        {footer(state), footer_rect}
-      ] ++ details_widget(state, details_rect) ++ autocomplete_widget(state, input_rect)
-
-    case popup(state, messages_rect) do
-      nil -> widgets
-      popup_tuple -> widgets ++ [popup_tuple]
-    end
-  end
-
-  defp details_tab_titles(state) do
-    tabs = State.details_tabs()
-    Enum.map(tabs, &{&1, tab_title(&1, state)})
-  end
-
-  defp split_body(body_rect, %State{show_details: false}), do: {body_rect, nil}
-
-  defp split_body(body_rect, _state) do
-    [m, d] = Layout.split(body_rect, :horizontal, [{:percentage, 50}, {:percentage, 50}])
-    {m, d}
-  end
-
-  defp details_widget(_state, nil), do: []
-
-  defp details_widget(state, details_rect) do
-    [tabs_rect, content_rect] =
-      Layout.split(details_rect, :vertical, [{:length, 1}, {:min, 0}])
-
-    # The content Block draws borders on all four sides, so the interior
-    # is two cells narrower AND two cells shorter than the outer rect.
-    inner_w = max(content_rect.width - 2, 1)
-    inner_h = max(content_rect.height - 2, 1)
-
-    content_widget =
-      case state.details_tab do
-        :timeline -> details(state, inner_w, inner_h)
-        :changes -> changes(state, inner_w, inner_h)
-      end
-
-    [
-      {details_tabs_widget(state), tabs_rect},
-      {content_widget, content_rect}
-    ]
-  end
-
-  defp details_tabs_widget(%State{details_tab: tab} = state) do
-    tabs = State.details_tabs()
-    titles = Enum.map(tabs, &tab_title(&1, state))
-    selected = Enum.find_index(tabs, &(&1 == tab)) || 0
-
-    %ExRatatui.Widgets.Tabs{
-      titles: titles,
-      selected: selected,
-      style: %Style{fg: :dark_gray},
-      highlight_style: %Style{fg: :light_blue, modifiers: [:bold]},
-      divider: " │ "
-    }
-  end
-
-  defp tab_title(:timeline, _state), do: " Timeline "
-
-  defp tab_title(:changes, %State{git_diff_lines: lines}) do
-    case changed_files_count(lines) do
-      0 -> " Changes "
-      n -> " Changes (#{n} file#{if n == 1, do: "", else: "s"}) "
-    end
-  end
-
-  defp tab_title(other, _state), do: " #{other} "
-
-  # Quick count of `diff --git` headers — one per modified file.
-  defp changed_files_count(lines) do
-    Enum.count(lines, &String.starts_with?(&1, "diff --git "))
-  end
-
-  # ─ Autocomplete (slash command suggestions) ───────────────────────────────
-
-  @ac_max_rows 10
-  @ac_block %Block{
-    title: " commands · Tab to accept · Esc to close ",
-    borders: [:all],
-    border_type: :rounded,
-    border_style: %Style{fg: :light_blue}
-  }
-
-  defp autocomplete_widget(%State{autocomplete: nil}, _input_rect), do: []
-
-  defp autocomplete_widget(%State{autocomplete: %{items: items, idx: idx}}, input_rect) do
-    descs = Commands.descriptions()
-    label_width = items |> Enum.map(&String.length/1) |> Enum.max(fn -> 8 end)
-
-    labels =
-      Enum.map(items, fn cmd ->
-        desc = Map.get(descs, cmd, "")
-        pad = max(0, label_width - String.length(cmd))
-        cmd <> String.duplicate(" ", pad) <> "  " <> desc
-      end)
-
-    body_height = min(length(labels), @ac_max_rows)
-    # +2 for the block's top/bottom borders.
-    height = body_height + 2
-
-    inner_width = labels |> Enum.map(&String.length/1) |> Enum.max(fn -> 20 end)
-    width = min(inner_width + 4, input_rect.width)
-
-    rect = %Rect{
-      x: input_rect.x,
-      y: max(input_rect.y - height, 0),
-      width: width,
-      height: height
-    }
-
-    list = %List{
-      items: labels,
-      selected: idx,
-      block: @ac_block,
-      highlight_style: %Style{fg: :black, bg: :light_blue, modifiers: [:bold]},
-      highlight_symbol: "▸ "
-    }
-
-    # Clear the underlying messages area first so the popup is opaque.
-    [{%Clear{}, rect}, {list, rect}]
-  end
-
-  @doc "Build the header status string from a session."
-  @spec status_line(Session.t()) :: String.t()
-  def status_line(%Session{} = s) do
-    cwd = s.cwd || effective_cwd()
-
-    IO.iodata_to_binary([
-      to_string(s.model),
-      " · ",
-      inspect(s.mode),
-      " · iter=",
-      Integer.to_string(s.iteration),
-      " · ",
-      Integer.to_string(Map.get(s.usage, :input_tokens, 0)),
-      "/",
-      Integer.to_string(Map.get(s.usage, :output_tokens, 0)),
-      " tok · $",
-      :erlang.float_to_binary(s.cost_usd / 1.0, decimals: 4),
-      " · cwd=",
-      Path.basename(cwd)
-    ])
-  end
-
-  defp effective_cwd do
-    case File.cwd() do
-      {:ok, path} -> path
-      _ -> "?"
-    end
-  end
-
-  defp header(%State{session: session}) do
-    %Paragraph{
-      text: status_line(session),
-      style: %Style{fg: :light_blue},
-      alignment: :left
-    }
-  end
-
-  defp messages(
-         %State{
-           events: events,
-           loading?: loading?,
-           session: session,
-           messages_scroll: above_bottom,
-           tool_blocks: tool_blocks
-         },
-         width,
-         height
-       ) do
-    items =
-      events
-      |> Enum.flat_map(&event_to_widgets(&1, session.model, width, tool_blocks))
-      |> append_throbber(loading?)
-
-    %WidgetList{items: items, scroll_offset: scroll_offset(items, height, above_bottom)}
-  end
-
-  # One event can produce multiple widget rows — a tool block expands
-  # into a header + indented preview lines + truncation hint, etc.
-  defp event_to_widgets({:tool_block, id}, _model, width, tool_blocks) do
-    case Map.get(tool_blocks, id) do
-      nil -> [{%Paragraph{text: "● (missing tool block)", style: %Style{fg: :dark_gray}}, 1}]
-      block -> render_tool_block(block, width)
-    end
-  end
-
-  defp event_to_widgets(row, model, width, _tool_blocks),
-    do: [row_widget(row, model, width)]
-
-  @details_block %Block{
-    title: " details ",
-    borders: [:left, :top, :bottom, :right],
-    border_type: :rounded,
-    border_style: %Style{fg: :dark_gray}
-  }
-
-  defp details(%State{details: details, details_scroll: above_bottom}, width, height) do
-    items = Enum.map(details, &detail_row_widget(&1, width))
-
-    %WidgetList{
-      items: items,
-      scroll_offset: scroll_offset(items, height, above_bottom),
-      block: @details_block
-    }
-  end
-
-  @changes_block %Block{
-    title: " changes · git diff HEAD ",
-    borders: [:left, :top, :bottom, :right],
-    border_type: :rounded,
-    border_style: %Style{fg: :dark_gray}
-  }
-
-  defp changes(%State{git_diff_lines: []}, _width, _height) do
-    %WidgetList{
-      items: [
-        {%Paragraph{
-           text: "Fetching `git diff` … (run /diff to refresh)",
-           style: %Style{fg: :dark_gray}
-         }, 1}
-      ],
-      block: @changes_block
-    }
-  end
-
-  defp changes(
-         %State{git_diff_lines: lines, details_scroll: above_bottom, diff_mode: mode},
-         width,
-         height
-       ) do
-    {files, leading} = parse_git_diff(lines)
-
-    items =
-      cond do
-        files == [] and leading == [] -> []
-        files == [] -> Enum.map(leading, &noise_row(&1, width))
-        true -> render_diff_files(files, leading, mode, width)
-      end
-
-    %WidgetList{
-      items: items,
-      scroll_offset: scroll_offset(items, height, above_bottom),
-      block: @changes_block
-    }
-  end
-
-  defp noise_row(line, width) do
-    style =
-      cond do
-        String.starts_with?(line, "(no changes vs HEAD)") ->
-          %Style{fg: :dark_gray, modifiers: [:italic]}
-
-        String.starts_with?(line, "cwd: ") ->
-          %Style{fg: :dark_gray, modifiers: [:italic]}
-
-        String.starts_with?(line, "git diff failed") or
-          String.starts_with?(line, "git diff crashed") or
-            String.starts_with?(line, "`git` executable") ->
-          %Style{fg: :red, modifiers: [:bold]}
-
-        true ->
-          %Style{fg: :dark_gray}
-      end
-
-    {%Paragraph{text: line, style: style, wrap: true}, wrapped_height(line, width)}
-  end
-
-  # ── Diff parser ──
-
-  # Walks `git_diff_lines` and groups into per-file records.
-  # Returns `{files, leading_lines}` where `leading_lines` is any
-  # non-diff content before the first `diff --git` (status / error
-  # messages from fetch_git_diff).
-  defp parse_git_diff(lines) do
-    {files, leading, _state} =
-      Enum.reduce(lines, {[], [], :preamble}, &parse_line/2)
-
-    {Enum.reverse(files) |> Enum.map(&finalize_file/1), Enum.reverse(leading)}
-  end
-
-  defp parse_line("diff --git " <> rest, {files, leading, state}) do
-    files =
-      case state do
-        :preamble -> files
-        _ -> finalize_state(files, state)
-      end
-
-    path = extract_diff_path(rest)
-    {files, leading, {:file, %{path: path, additions: 0, deletions: 0, hunks: [], hunk: nil}}}
-  end
-
-  defp parse_line(line, {files, leading, :preamble}) do
-    {files, [line | leading], :preamble}
-  end
-
-  defp parse_line("index " <> _, acc), do: acc
-
-  defp parse_line("new file" <> _, {files, leading, {:file, f}}) do
-    {files, leading, {:file, Map.put(f, :kind, :added)}}
-  end
-
-  defp parse_line("deleted file" <> _, {files, leading, {:file, f}}) do
-    {files, leading, {:file, Map.put(f, :kind, :deleted)}}
-  end
-
-  defp parse_line("--- " <> _, acc), do: acc
-  defp parse_line("+++ " <> _, acc), do: acc
-
-  defp parse_line("@@" <> _ = header, {files, leading, {:file, f}}) do
-    f = flush_hunk(f)
-    {files, leading, {:file, Map.put(f, :hunk, %{header: header, lines: []})}}
-  end
-
-  defp parse_line("+" <> tail, {files, leading, {:file, %{hunk: h} = f}}) when not is_nil(h) do
-    f = %{
-      f
-      | hunk: %{h | lines: h.lines ++ [{:added, tail}]},
-        additions: f.additions + 1
-    }
-
-    {files, leading, {:file, f}}
-  end
-
-  defp parse_line("-" <> tail, {files, leading, {:file, %{hunk: h} = f}}) when not is_nil(h) do
-    f = %{
-      f
-      | hunk: %{h | lines: h.lines ++ [{:removed, tail}]},
-        deletions: f.deletions + 1
-    }
-
-    {files, leading, {:file, f}}
-  end
-
-  defp parse_line(" " <> tail, {files, leading, {:file, %{hunk: h} = f}}) when not is_nil(h) do
-    f = %{f | hunk: %{h | lines: h.lines ++ [{:context, tail}]}}
-    {files, leading, {:file, f}}
-  end
-
-  defp parse_line("\\ " <> _, acc), do: acc
-
-  defp parse_line(_line, acc), do: acc
-
-  defp flush_hunk(%{hunk: nil} = f), do: f
-
-  defp flush_hunk(%{hunk: h, hunks: hunks} = f),
-    do: %{f | hunks: hunks ++ [h], hunk: nil}
-
-  defp finalize_file(f), do: flush_hunk(f) |> Map.drop([:hunk])
-
-  defp finalize_state(files, {:file, f}), do: [f | files]
-  defp finalize_state(files, _), do: files
-
-  defp extract_diff_path(rest) do
-    # rest is like "a/path b/path"; take the `b/` path (the post-image).
-    case Regex.run(~r{ b/(.+)$}, rest) do
-      [_, path] -> path
-      _ -> String.trim(rest)
-    end
-  end
-
-  # ── Per-file rendering ──
-
-  defp render_diff_files(files, leading, mode, width) do
-    leading_rows = Enum.map(leading, &noise_row(&1, width))
-    body = Enum.flat_map(files, &render_file(&1, mode, width))
-    leading_rows ++ body
-  end
-
-  defp render_file(file, mode, width) do
-    header_text = file_header_text(file)
-
-    header = {
-      %Paragraph{
-        text: header_text,
-        style: %Style{fg: :light_yellow, modifiers: [:bold]},
-        wrap: true
-      },
-      wrapped_height(header_text, width)
-    }
-
-    hunks = Enum.flat_map(file.hunks, &render_hunk(&1, mode, width))
-
-    [header | hunks] ++ [{%Paragraph{text: " ", style: %Style{}}, 1}]
-  end
-
-  defp file_header_text(%{path: path} = f) do
-    kind_label =
-      case Map.get(f, :kind) do
-        :added -> "new"
-        :deleted -> "deleted"
-        _ -> "modified"
-      end
-
-    stats =
-      cond do
-        f.additions > 0 and f.deletions > 0 -> " (+#{f.additions} -#{f.deletions})"
-        f.additions > 0 -> " (+#{f.additions})"
-        f.deletions > 0 -> " (-#{f.deletions})"
-        true -> ""
-      end
-
-    "▸ #{path}  [#{kind_label}]#{stats}"
-  end
-
-  defp render_hunk(%{header: header, lines: lines}, :inline, _width) do
-    header_row = {
-      %Paragraph{text: "  " <> header, style: %Style{fg: :cyan}, wrap: false},
-      1
-    }
-
-    body =
-      Enum.map(lines, fn {kind, text} ->
-        {prefix, style} =
-          case kind do
-            :added -> {"+ ", %Style{fg: :green}}
-            :removed -> {"- ", %Style{fg: :red}}
-            :context -> {"  ", %Style{fg: :dark_gray}}
-          end
-
-        full = "  " <> prefix <> text
-        {%Paragraph{text: full, style: style, wrap: false}, 1}
-      end)
-
-    [header_row | body]
-  end
-
-  defp render_hunk(%{header: header, lines: lines}, :side_by_side, width) do
-    header_row = {
-      %Paragraph{text: "  " <> header, style: %Style{fg: :cyan}, wrap: false},
-      1
-    }
-
-    col_width = max(div(width - 5, 2), 8)
-
-    pair_rows =
-      lines
-      |> pair_hunk_lines()
-      |> Enum.map(&render_side_by_side_pair(&1, col_width))
-
-    [header_row | pair_rows]
-  end
-
-  # Pair `-` runs with the following `+` runs so they sit side by side.
-  defp pair_hunk_lines(lines) do
-    lines
-    |> Enum.chunk_by(fn {kind, _} -> kind end)
-    |> fold_runs([])
-    |> Enum.reverse()
-  end
-
-  defp fold_runs([], acc), do: acc
-
-  defp fold_runs([[{:context, _} | _] = run | rest], acc) do
-    pairs = Enum.map(run, fn {:context, t} -> {{:context, t}, {:context, t}} end)
-    fold_runs(rest, Enum.reverse(pairs) ++ acc)
-  end
-
-  defp fold_runs([[{:removed, _} | _] = lefts, [{:added, _} | _] = rights | rest], acc) do
-    left_texts = Enum.map(lefts, fn {:removed, t} -> t end)
-    right_texts = Enum.map(rights, fn {:added, t} -> t end)
-
-    pairs =
-      zip_pad(left_texts, right_texts)
-      |> Enum.map(fn
-        {nil, r} -> {{:none, ""}, {:added, r}}
-        {l, nil} -> {{:removed, l}, {:none, ""}}
-        {l, r} -> {{:removed, l}, {:added, r}}
-      end)
-
-    fold_runs(rest, Enum.reverse(pairs) ++ acc)
-  end
-
-  defp fold_runs([[{:removed, _} | _] = run | rest], acc) do
-    pairs = Enum.map(run, fn {:removed, t} -> {{:removed, t}, {:none, ""}} end)
-    fold_runs(rest, Enum.reverse(pairs) ++ acc)
-  end
-
-  defp fold_runs([[{:added, _} | _] = run | rest], acc) do
-    pairs = Enum.map(run, fn {:added, t} -> {{:none, ""}, {:added, t}} end)
-    fold_runs(rest, Enum.reverse(pairs) ++ acc)
-  end
-
-  defp fold_runs([_other | rest], acc), do: fold_runs(rest, acc)
-
-  defp zip_pad([], []), do: []
-  defp zip_pad([], [r | rs]), do: [{nil, r} | zip_pad([], rs)]
-  defp zip_pad([l | ls], []), do: [{l, nil} | zip_pad(ls, [])]
-  defp zip_pad([l | ls], [r | rs]), do: [{l, r} | zip_pad(ls, rs)]
-
-  defp render_side_by_side_pair({left, right}, col_width) do
-    line =
-      Line.new([
-        Span.new(side_text(left, col_width), style: side_style(left)),
-        Span.new(" │ ", style: %Style{fg: :dark_gray}),
-        Span.new(side_text(right, col_width), style: side_style(right))
-      ])
-
-    {%Paragraph{text: [line], wrap: false}, 1}
-  end
-
-  defp side_text({:none, _}, col_width), do: String.duplicate(" ", col_width)
-
-  defp side_text({kind, text}, col_width) do
-    prefix =
-      case kind do
-        :added -> "+ "
-        :removed -> "- "
-        :context -> "  "
-      end
-
-    body = prefix <> text
-    cur = String.length(body)
-
-    cond do
-      cur > col_width -> String.slice(body, 0, col_width - 1) <> "…"
-      true -> body <> String.duplicate(" ", col_width - cur)
-    end
-  end
-
-  defp side_style({:added, _}), do: %Style{fg: :green}
-  defp side_style({:removed, _}), do: %Style{fg: :red}
-  defp side_style({:context, _}), do: %Style{fg: :dark_gray}
-  defp side_style({:none, _}), do: %Style{}
-
-  # Compute a scroll_offset for a WidgetList. `above_bottom` is the user's
-  # manual scroll position (in rows above the natural bottom); nil = "at
-  # the bottom" (auto-pin to newest content). When the user has scrolled
-  # up, we step back from the auto-bottom by `above_bottom` rows, clamped
-  # to [0, max_offset] so it never escapes the content.
-  defp scroll_offset(items, height, above_bottom)
-       when is_integer(height) and height > 0 do
-    total = items |> Enum.map(fn {_w, h} -> h end) |> Enum.sum()
-    auto = max(total - height, 0)
-
-    case above_bottom do
-      nil -> auto
-      n when is_integer(n) -> auto |> Kernel.-(n) |> max(0)
-    end
-  end
-
-  defp scroll_offset(_items, _height, _above_bottom), do: 0
-
-  # Estimate the number of rows a string occupies once it's wrapped at
-  # `width` columns. Counts each explicit `\n` as a line break and uses
-  # `String.length/1` to approximate display columns (good enough for
-  # ASCII / European text; emoji and CJK may be off by one). The Paragraph
-  # widget does the actual wrapping; this just sizes the row in the
-  # surrounding WidgetList so wrapped content isn't clipped.
-  defp wrapped_height(text, width) when is_binary(text) and is_integer(width) and width > 0 do
-    text
-    |> String.split("\n")
-    |> Enum.map(fn line ->
-      case String.length(line) do
-        0 -> 1
-        n -> div(n - 1, width) + 1
-      end
-    end)
-    |> Enum.sum()
-    |> max(1)
-  end
-
-  defp wrapped_height(_text, _width), do: 1
-
-  defp detail_row_widget({:detail_header, text}, width) do
-    {%Paragraph{
-       text: text,
-       style: %Style{fg: :light_yellow, modifiers: [:bold]},
-       wrap: true
-     }, wrapped_height(text, width)}
-  end
-
-  defp detail_row_widget({:thinking, text}, width) do
-    {%Paragraph{
-       text: text,
-       style: %Style{fg: :magenta, modifiers: [:italic]},
-       wrap: true
-     }, wrapped_height(text, width)}
-  end
-
-  defp detail_row_widget({:assistant, text}, width) do
-    {%Paragraph{text: text, style: %Style{fg: :white}, wrap: true}, wrapped_height(text, width)}
-  end
-
-  defp detail_row_widget({:tool_call, text}, width) do
-    {%Paragraph{text: text, style: %Style{fg: :cyan}, wrap: true}, wrapped_height(text, width)}
-  end
-
-  defp detail_row_widget({:tool_result, text}, width) do
-    {%Paragraph{text: text, style: %Style{fg: :dark_gray}, wrap: true},
-     wrapped_height(text, width)}
-  end
-
-  defp detail_row_widget({:tool_result_error, text}, width) do
-    {%Paragraph{text: text, style: %Style{fg: :red}, wrap: true}, wrapped_height(text, width)}
-  end
-
-  defp detail_row_widget({:error, text}, width) do
-    {%Paragraph{text: text, style: %Style{fg: :red, modifiers: [:bold]}, wrap: true},
-     wrapped_height(text, width)}
-  end
-
-  defp detail_row_widget({:info, text}, width) do
-    {%Paragraph{text: text, style: %Style{fg: :dark_gray}, wrap: true},
-     wrapped_height(text, width)}
-  end
-
-  defp detail_row_widget({_kind, text}, width) do
-    {%Paragraph{text: text, style: %Style{fg: :dark_gray}, wrap: true},
-     wrapped_height(text, width)}
-  end
-
-  # ── Tool block (Claude-Code style: `● Tool(args)` + indented preview) ──
-
-  defp render_tool_block(%{todos: todos} = block, width) when is_list(todos) do
-    # Todo list: header + one row per item with a checkbox.
-    bullet = status_bullet(block.status)
-
-    header_text =
-      "#{bullet} TodoWrite (#{length(todos)} item#{if length(todos) == 1, do: "", else: "s"})"
-
-    header = {
-      %Paragraph{
-        text: header_text,
-        style: %Style{fg: bullet_color(block.status), modifiers: [:bold]},
-        wrap: true
-      },
-      wrapped_height(header_text, width)
-    }
-
-    {pending_and_active, completed} =
-      Enum.split_with(todos, &(get_todo_status(&1) != "completed"))
-
-    visible_rows =
-      pending_and_active
-      |> Enum.map(&todo_row_widget(&1, width))
-      |> Kernel.++(maybe_collapsed_completed_row(completed, width))
-
-    [header | visible_rows]
-  end
-
-  defp render_tool_block(block, width) do
-    color = bullet_color(block.status)
-    header_text = tool_header_text(block)
-
-    header = {
-      %Paragraph{
-        text: header_text,
-        style: %Style{fg: color, modifiers: [:bold]},
-        wrap: true
-      },
-      wrapped_height(header_text, width)
-    }
-
-    preview_rows = preview_widget_rows(block, width)
-
-    [header | preview_rows]
-  end
-
-  # ── Status bullet helpers ──
-
-  defp status_bullet(:pending), do: "●"
-  defp status_bullet(:success), do: "●"
-  defp status_bullet(:error), do: "●"
-  defp status_bullet(_), do: "●"
-
-  defp bullet_color(:pending), do: :light_blue
-  defp bullet_color(:success), do: :green
-  defp bullet_color(:error), do: :red
-  defp bullet_color(_), do: :dark_gray
-
-  # ── Header rendering: `● Tool(args)` ──
-
-  defp tool_header_text(%{name: name, ui: %{kind: :diff, payload: %{path: path}}})
-       when name in ["edit", "write", "apply_patch"] do
-    "#{status_bullet(:success)} #{verb_for(name)}(#{Path.relative_to_cwd(path)})"
-  end
-
-  defp tool_header_text(%{name: name, args: args}) do
-    "#{status_bullet(:success)} #{tool_display_name(name)}(#{args_summary(name, args)})"
-  end
-
-  defp tool_display_name(name) do
-    name
-    |> String.split("_")
-    |> Enum.map(&String.capitalize/1)
-    |> Enum.join("")
-  end
-
-  defp verb_for("write"), do: "Create"
-  defp verb_for("apply_patch"), do: "Patch"
-  defp verb_for(_), do: "Update"
-
-  defp args_summary("bash", %{"command" => cmd}) when is_binary(cmd), do: truncate(cmd, 100)
-  defp args_summary("bash", %{command: cmd}) when is_binary(cmd), do: truncate(cmd, 100)
-  defp args_summary("read", args), do: get_arg(args, "path") |> Path.relative_to_cwd()
-  defp args_summary("edit", args), do: get_arg(args, "path") |> Path.relative_to_cwd()
-  defp args_summary("write", args), do: get_arg(args, "path") |> Path.relative_to_cwd()
-  defp args_summary("grep", args), do: get_arg(args, "pattern")
-  defp args_summary("glob", args), do: get_arg(args, "pattern")
-  defp args_summary("web_fetch", args), do: args |> get_arg("url") |> truncate(80)
-  defp args_summary(_name, args) when args == %{} or is_nil(args), do: ""
-  defp args_summary(_name, args), do: args |> compact_args() |> truncate(80)
-
-  defp get_arg(args, key) when is_map(args) do
-    Map.get(args, key) || Map.get(args, String.to_atom(key)) || ""
-  end
-
-  defp get_arg(_args, _key), do: ""
-
-  defp compact_args(args) when is_map(args) do
-    Enum.map_join(args, ", ", fn {k, v} -> "#{k}: #{inspect(v)}" end)
-  end
-
-  defp compact_args(other), do: inspect(other)
-
-  # ── Indented preview rows ──
-
-  defp preview_widget_rows(%{ui: %{kind: :diff, payload: payload}} = _block, width) do
-    diff_preview_rows(payload, width)
-  end
-
-  defp preview_widget_rows(%{output_preview: nil}, _width), do: []
-
-  defp preview_widget_rows(%{output_preview: [], total_lines: _}, _width), do: []
-
-  defp preview_widget_rows(%{output_preview: lines, total_lines: total}, width) do
-    visible_count = length(lines)
-    preview_color = %Style{fg: :dark_gray}
-
-    visible =
-      lines
-      |> Enum.with_index()
-      |> Enum.map(fn {line, idx} ->
-        text = if idx == 0, do: "  └ #{line}", else: "    #{line}"
-        {%Paragraph{text: text, style: preview_color, wrap: true}, wrapped_height(text, width)}
-      end)
-
-    if total > visible_count do
-      remaining = total - visible_count
-
-      hint =
-        "    … +#{remaining} line#{if remaining == 1, do: "", else: "s"} (/expand 1 for full)"
-
-      visible ++
-        [{%Paragraph{text: hint, style: %Style{fg: :dark_gray, modifiers: [:italic]}}, 1}]
-    else
-      visible
-    end
-  end
-
-  # Edit / Write / apply_patch tool UI payloads carry the raw `before`
-  # and `after` strings — not a pre-diffed line list — so we compute the
-  # Myers diff inline. Same logic as ChatLive's `build_ui_entry(:diff)`
-  # in the web LiveView (chat_live.ex:1568).
-  defp diff_preview_rows(%{before: before, after: aft}, width) do
-    before_lines = String.split(to_string(before), "\n")
-    after_lines = String.split(to_string(aft), "\n")
-
-    all_lines =
-      Elixir.List.myers_difference(before_lines, after_lines)
-      |> Enum.flat_map(fn
-        {:eq, ls} -> Enum.map(ls, &{:eq, &1})
-        {:ins, ls} -> Enum.map(ls, &{:ins, &1})
-        {:del, ls} -> Enum.map(ls, &{:del, &1})
-      end)
-
-    added = Enum.count(all_lines, fn {k, _} -> k == :ins end)
-    removed = Enum.count(all_lines, fn {k, _} -> k == :del end)
-
-    stat_text =
-      cond do
-        added > 0 and removed > 0 -> "  └ +#{added} −#{removed} lines"
-        added > 0 -> "  └ Added #{added} line#{if added == 1, do: "", else: "s"}"
-        removed > 0 -> "  └ Removed #{removed} line#{if removed == 1, do: "", else: "s"}"
-        true -> "  └ no net change"
-      end
-
-    stat_row =
-      {%Paragraph{text: stat_text, style: %Style{fg: :dark_gray}, wrap: true},
-       wrapped_height(stat_text, width)}
-
-    snippet_rows =
-      all_lines
-      |> Enum.reject(fn {kind, _} -> kind == :eq end)
-      |> Enum.take(6)
-      |> Enum.map(fn {kind, line} ->
-        {prefix, style} =
-          case kind do
-            :ins -> {"    + ", %Style{fg: :green}}
-            :del -> {"    - ", %Style{fg: :red}}
-            _ -> {"      ", %Style{fg: :dark_gray}}
-          end
-
-        text = prefix <> truncate(line, max(width - 6, 20))
-        {%Paragraph{text: text, style: style, wrap: false}, 1}
-      end)
-
-    [stat_row | snippet_rows]
-  end
-
-  defp diff_preview_rows(_payload, _width), do: []
-
-  # ── Todo list rendering ──
-
-  defp todo_row_widget(todo, width) do
-    {marker, color} = todo_marker(get_todo_status(todo))
-    content = get_todo_field(todo, "content") || ""
-    text = "  #{marker} #{content}"
-    {%Paragraph{text: text, style: %Style{fg: color}, wrap: true}, wrapped_height(text, width)}
-  end
-
-  defp maybe_collapsed_completed_row([], _width), do: []
-
-  defp maybe_collapsed_completed_row(completed, width) do
-    n = length(completed)
-    text = "    … +#{n} completed"
-
-    [
-      {%Paragraph{text: text, style: %Style{fg: :dark_gray, modifiers: [:italic]}, wrap: true},
-       wrapped_height(text, width)}
-    ]
-  end
-
-  defp todo_marker("completed"), do: {"✓", :green}
-  defp todo_marker("in_progress"), do: {"◐", :light_blue}
-  defp todo_marker(_), do: {"□", :dark_gray}
-
-  defp get_todo_status(todo), do: get_todo_field(todo, "status") || "pending"
-
-  defp get_todo_field(todo, key) when is_map(todo) do
-    Map.get(todo, key) || Map.get(todo, String.to_atom(key))
-  end
-
-  defp get_todo_field(_, _), do: nil
-
-  defp truncate(text, max) when is_binary(text) and is_integer(max) do
-    if String.length(text) <= max, do: text, else: String.slice(text, 0, max - 1) <> "…"
-  end
-
-  defp truncate(other, max), do: other |> to_string() |> truncate(max)
-
-  defp row_widget({:user, text}, _model, width) do
-    full = "me ▸ " <> text
-
-    {%Paragraph{text: full, style: %Style{fg: :green, modifiers: [:bold]}, wrap: true},
-     wrapped_height(full, width)}
-  end
-
-  defp row_widget({:assistant, text}, model, width) do
-    full = model <> " ▸ " <> text
-
-    {%Paragraph{text: full, style: %Style{fg: :cyan, modifiers: [:bold]}, wrap: true},
-     wrapped_height(full, width)}
-  end
-
-  defp row_widget({:tool_call, text}, _model, width) do
-    {%Paragraph{text: text, style: %Style{fg: :cyan}, wrap: true}, wrapped_height(text, width)}
-  end
-
-  defp row_widget({:tool_result, text}, _model, width) do
-    {%Paragraph{text: text, style: %Style{fg: :dark_gray}, wrap: true},
-     wrapped_height(text, width)}
-  end
-
-  defp row_widget({:tool_result_error, text}, _model, width) do
-    {%Paragraph{text: text, style: %Style{fg: :red}, wrap: true}, wrapped_height(text, width)}
-  end
-
-  defp row_widget({:warning, text}, _model, width) do
-    {%Paragraph{text: text, style: %Style{fg: :yellow}, wrap: true}, wrapped_height(text, width)}
-  end
-
-  defp row_widget({:error, text}, _model, width) do
-    {%Paragraph{text: text, style: %Style{fg: :red, modifiers: [:bold]}, wrap: true},
-     wrapped_height(text, width)}
-  end
-
-  defp row_widget({:info, text}, _model, width) do
-    {%Paragraph{text: text, style: %Style{fg: :dark_gray}, wrap: true},
-     wrapped_height(text, width)}
-  end
-
-  defp row_widget({:status, text}, _model, width) do
-    {%Paragraph{text: text, style: %Style{fg: :dark_gray}, wrap: true},
-     wrapped_height(text, width)}
-  end
-
-  defp append_throbber(items, false), do: items
-
-  defp append_throbber(items, true) do
-    items ++
-      [
-        {%Throbber{
-           label: " thinking…",
-           throbber_set: :braille,
-           style: %Style{fg: :dark_gray}
-         }, 1}
+        {details_tabs_widget(state), tabs_rect},
+        {content_widget, content_rect}
       ]
-  end
+    end
 
-  defp input(%State{input_ref: ref}) do
-    %Textarea{
-      state: ref,
-      placeholder: "Type a message and press Enter to send. /help for commands.",
-      placeholder_style: %Style{fg: :dark_gray},
-      block: @input_block
-    }
-  end
+    defp details_tabs_widget(%State{details_tab: tab} = state) do
+      tabs = State.details_tabs()
+      titles = Enum.map(tabs, &tab_title(&1, state))
+      selected = Enum.find_index(tabs, &(&1 == tab)) || 0
 
-  defp footer(%State{popup: nil}) do
-    %Paragraph{
-      text: "Enter: send  Ctrl+C: quit  /help",
-      style: %Style{fg: :dark_gray}
-    }
-  end
+      %ExRatatui.Widgets.Tabs{
+        titles: titles,
+        selected: selected,
+        style: %Style{fg: :dark_gray},
+        highlight_style: %Style{fg: :light_blue, modifiers: [:bold]},
+        divider: " │ "
+      }
+    end
 
-  defp footer(%State{popup: _}) do
-    %Paragraph{
-      text: "↑↓ navigate  Enter select  Esc cancel",
-      style: %Style{fg: :dark_gray}
-    }
-  end
+    defp tab_title(:timeline, _state), do: " Timeline "
 
-  defp popup(%State{popup: nil}, _rect), do: nil
-
-  defp popup(%State{popup: {kind, items, idx}}, messages_rect) do
-    {title, list_items} =
-      case kind do
-        :model -> {" Pick a model ", items}
-        :mode -> {" Pick a mode ", Enum.map(items, &inspect/1)}
+    defp tab_title(:changes, %State{git_diff_lines: lines}) do
+      case changed_files_count(lines) do
+        0 -> " Changes "
+        n -> " Changes (#{n} file#{if n == 1, do: "", else: "s"}) "
       end
+    end
 
-    list = %List{
-      items: list_items,
-      selected: idx,
-      highlight_style: %Style{fg: :black, bg: :white, modifiers: [:bold]},
-      highlight_symbol: "> "
+    defp tab_title(other, _state), do: " #{other} "
+
+    # Quick count of `diff --git` headers — one per modified file.
+    defp changed_files_count(lines) do
+      Enum.count(lines, &String.starts_with?(&1, "diff --git "))
+    end
+
+    # ─ Autocomplete (slash command suggestions) ───────────────────────────────
+
+    @ac_max_rows 10
+    @ac_block %Block{
+      title: " commands · Tab to accept · Esc to close ",
+      borders: [:all],
+      border_type: :rounded,
+      border_style: %Style{fg: :light_blue}
     }
 
-    popup_widget = %Popup{
-      content: list,
-      block: %Block{title: title, borders: [:all], border_type: :rounded},
-      percent_width: 50,
-      percent_height: 60
+    defp autocomplete_widget(%State{autocomplete: nil}, _input_rect), do: []
+
+    defp autocomplete_widget(%State{autocomplete: %{items: items, idx: idx}}, input_rect) do
+      descs = Commands.descriptions()
+      label_width = items |> Enum.map(&String.length/1) |> Enum.max(fn -> 8 end)
+
+      labels =
+        Enum.map(items, fn cmd ->
+          desc = Map.get(descs, cmd, "")
+          pad = max(0, label_width - String.length(cmd))
+          cmd <> String.duplicate(" ", pad) <> "  " <> desc
+        end)
+
+      body_height = min(length(labels), @ac_max_rows)
+      # +2 for the block's top/bottom borders.
+      height = body_height + 2
+
+      inner_width = labels |> Enum.map(&String.length/1) |> Enum.max(fn -> 20 end)
+      width = min(inner_width + 4, input_rect.width)
+
+      rect = %Rect{
+        x: input_rect.x,
+        y: max(input_rect.y - height, 0),
+        width: width,
+        height: height
+      }
+
+      list = %List{
+        items: labels,
+        selected: idx,
+        block: @ac_block,
+        highlight_style: %Style{fg: :black, bg: :light_blue, modifiers: [:bold]},
+        highlight_symbol: "▸ "
+      }
+
+      # Clear the underlying messages area first so the popup is opaque.
+      [{%Clear{}, rect}, {list, rect}]
+    end
+
+    @doc "Build the header status string from a session."
+    @spec status_line(Session.t()) :: String.t()
+    def status_line(%Session{} = s) do
+      cwd = s.cwd || effective_cwd()
+
+      IO.iodata_to_binary([
+        to_string(s.model),
+        " · ",
+        inspect(s.mode),
+        " · iter=",
+        Integer.to_string(s.iteration),
+        " · ",
+        Integer.to_string(Map.get(s.usage, :input_tokens, 0)),
+        "/",
+        Integer.to_string(Map.get(s.usage, :output_tokens, 0)),
+        " tok · $",
+        :erlang.float_to_binary(s.cost_usd / 1.0, decimals: 4),
+        " · cwd=",
+        Path.basename(cwd)
+      ])
+    end
+
+    defp effective_cwd do
+      case File.cwd() do
+        {:ok, path} -> path
+        _ -> "?"
+      end
+    end
+
+    defp header(%State{session: session}) do
+      %Paragraph{
+        text: status_line(session),
+        style: %Style{fg: :light_blue},
+        alignment: :left
+      }
+    end
+
+    defp messages(
+           %State{
+             events: events,
+             loading?: loading?,
+             session: session,
+             messages_scroll: above_bottom,
+             tool_blocks: tool_blocks
+           },
+           width,
+           height
+         ) do
+      items =
+        events
+        |> Enum.flat_map(&event_to_widgets(&1, session.model, width, tool_blocks))
+        |> append_throbber(loading?)
+
+      %WidgetList{items: items, scroll_offset: scroll_offset(items, height, above_bottom)}
+    end
+
+    # One event can produce multiple widget rows — a tool block expands
+    # into a header + indented preview lines + truncation hint, etc.
+    defp event_to_widgets({:tool_block, id}, _model, width, tool_blocks) do
+      case Map.get(tool_blocks, id) do
+        nil -> [{%Paragraph{text: "● (missing tool block)", style: %Style{fg: :dark_gray}}, 1}]
+        block -> render_tool_block(block, width)
+      end
+    end
+
+    defp event_to_widgets(row, model, width, _tool_blocks),
+      do: [row_widget(row, model, width)]
+
+    @details_block %Block{
+      title: " details ",
+      borders: [:left, :top, :bottom, :right],
+      border_type: :rounded,
+      border_style: %Style{fg: :dark_gray}
     }
 
-    {popup_widget, messages_rect}
+    defp details(%State{details: details, details_scroll: above_bottom}, width, height) do
+      items = Enum.map(details, &detail_row_widget(&1, width))
+
+      %WidgetList{
+        items: items,
+        scroll_offset: scroll_offset(items, height, above_bottom),
+        block: @details_block
+      }
+    end
+
+    @changes_block %Block{
+      title: " changes · git diff HEAD ",
+      borders: [:left, :top, :bottom, :right],
+      border_type: :rounded,
+      border_style: %Style{fg: :dark_gray}
+    }
+
+    defp changes(%State{git_diff_lines: []}, _width, _height) do
+      %WidgetList{
+        items: [
+          {%Paragraph{
+             text: "Fetching `git diff` … (run /diff to refresh)",
+             style: %Style{fg: :dark_gray}
+           }, 1}
+        ],
+        block: @changes_block
+      }
+    end
+
+    defp changes(
+           %State{git_diff_lines: lines, details_scroll: above_bottom, diff_mode: mode},
+           width,
+           height
+         ) do
+      {files, leading} = parse_git_diff(lines)
+
+      items =
+        cond do
+          files == [] and leading == [] -> []
+          files == [] -> Enum.map(leading, &noise_row(&1, width))
+          true -> render_diff_files(files, leading, mode, width)
+        end
+
+      %WidgetList{
+        items: items,
+        scroll_offset: scroll_offset(items, height, above_bottom),
+        block: @changes_block
+      }
+    end
+
+    defp noise_row(line, width) do
+      style =
+        cond do
+          String.starts_with?(line, "(no changes vs HEAD)") ->
+            %Style{fg: :dark_gray, modifiers: [:italic]}
+
+          String.starts_with?(line, "cwd: ") ->
+            %Style{fg: :dark_gray, modifiers: [:italic]}
+
+          String.starts_with?(line, "git diff failed") or
+            String.starts_with?(line, "git diff crashed") or
+              String.starts_with?(line, "`git` executable") ->
+            %Style{fg: :red, modifiers: [:bold]}
+
+          true ->
+            %Style{fg: :dark_gray}
+        end
+
+      {%Paragraph{text: line, style: style, wrap: true}, wrapped_height(line, width)}
+    end
+
+    # ── Diff parser ──
+
+    # Walks `git_diff_lines` and groups into per-file records.
+    # Returns `{files, leading_lines}` where `leading_lines` is any
+    # non-diff content before the first `diff --git` (status / error
+    # messages from fetch_git_diff).
+    defp parse_git_diff(lines) do
+      {files, leading, _state} =
+        Enum.reduce(lines, {[], [], :preamble}, &parse_line/2)
+
+      {Enum.reverse(files) |> Enum.map(&finalize_file/1), Enum.reverse(leading)}
+    end
+
+    defp parse_line("diff --git " <> rest, {files, leading, state}) do
+      files =
+        case state do
+          :preamble -> files
+          _ -> finalize_state(files, state)
+        end
+
+      path = extract_diff_path(rest)
+      {files, leading, {:file, %{path: path, additions: 0, deletions: 0, hunks: [], hunk: nil}}}
+    end
+
+    defp parse_line(line, {files, leading, :preamble}) do
+      {files, [line | leading], :preamble}
+    end
+
+    defp parse_line("index " <> _, acc), do: acc
+
+    defp parse_line("new file" <> _, {files, leading, {:file, f}}) do
+      {files, leading, {:file, Map.put(f, :kind, :added)}}
+    end
+
+    defp parse_line("deleted file" <> _, {files, leading, {:file, f}}) do
+      {files, leading, {:file, Map.put(f, :kind, :deleted)}}
+    end
+
+    defp parse_line("--- " <> _, acc), do: acc
+    defp parse_line("+++ " <> _, acc), do: acc
+
+    defp parse_line("@@" <> _ = header, {files, leading, {:file, f}}) do
+      f = flush_hunk(f)
+      {files, leading, {:file, Map.put(f, :hunk, %{header: header, lines: []})}}
+    end
+
+    defp parse_line("+" <> tail, {files, leading, {:file, %{hunk: h} = f}}) when not is_nil(h) do
+      f = %{
+        f
+        | hunk: %{h | lines: h.lines ++ [{:added, tail}]},
+          additions: f.additions + 1
+      }
+
+      {files, leading, {:file, f}}
+    end
+
+    defp parse_line("-" <> tail, {files, leading, {:file, %{hunk: h} = f}}) when not is_nil(h) do
+      f = %{
+        f
+        | hunk: %{h | lines: h.lines ++ [{:removed, tail}]},
+          deletions: f.deletions + 1
+      }
+
+      {files, leading, {:file, f}}
+    end
+
+    defp parse_line(" " <> tail, {files, leading, {:file, %{hunk: h} = f}}) when not is_nil(h) do
+      f = %{f | hunk: %{h | lines: h.lines ++ [{:context, tail}]}}
+      {files, leading, {:file, f}}
+    end
+
+    defp parse_line("\\ " <> _, acc), do: acc
+
+    defp parse_line(_line, acc), do: acc
+
+    defp flush_hunk(%{hunk: nil} = f), do: f
+
+    defp flush_hunk(%{hunk: h, hunks: hunks} = f),
+      do: %{f | hunks: hunks ++ [h], hunk: nil}
+
+    defp finalize_file(f), do: flush_hunk(f) |> Map.drop([:hunk])
+
+    defp finalize_state(files, {:file, f}), do: [f | files]
+    defp finalize_state(files, _), do: files
+
+    defp extract_diff_path(rest) do
+      # rest is like "a/path b/path"; take the `b/` path (the post-image).
+      case Regex.run(~r{ b/(.+)$}, rest) do
+        [_, path] -> path
+        _ -> String.trim(rest)
+      end
+    end
+
+    # ── Per-file rendering ──
+
+    defp render_diff_files(files, leading, mode, width) do
+      leading_rows = Enum.map(leading, &noise_row(&1, width))
+      body = Enum.flat_map(files, &render_file(&1, mode, width))
+      leading_rows ++ body
+    end
+
+    defp render_file(file, mode, width) do
+      header_text = file_header_text(file)
+
+      header = {
+        %Paragraph{
+          text: header_text,
+          style: %Style{fg: :light_yellow, modifiers: [:bold]},
+          wrap: true
+        },
+        wrapped_height(header_text, width)
+      }
+
+      hunks = Enum.flat_map(file.hunks, &render_hunk(&1, mode, width))
+
+      [header | hunks] ++ [{%Paragraph{text: " ", style: %Style{}}, 1}]
+    end
+
+    defp file_header_text(%{path: path} = f) do
+      kind_label =
+        case Map.get(f, :kind) do
+          :added -> "new"
+          :deleted -> "deleted"
+          _ -> "modified"
+        end
+
+      stats =
+        cond do
+          f.additions > 0 and f.deletions > 0 -> " (+#{f.additions} -#{f.deletions})"
+          f.additions > 0 -> " (+#{f.additions})"
+          f.deletions > 0 -> " (-#{f.deletions})"
+          true -> ""
+        end
+
+      "▸ #{path}  [#{kind_label}]#{stats}"
+    end
+
+    defp render_hunk(%{header: header, lines: lines}, :inline, _width) do
+      header_row = {
+        %Paragraph{text: "  " <> header, style: %Style{fg: :cyan}, wrap: false},
+        1
+      }
+
+      body =
+        Enum.map(lines, fn {kind, text} ->
+          {prefix, style} =
+            case kind do
+              :added -> {"+ ", %Style{fg: :green}}
+              :removed -> {"- ", %Style{fg: :red}}
+              :context -> {"  ", %Style{fg: :dark_gray}}
+            end
+
+          full = "  " <> prefix <> text
+          {%Paragraph{text: full, style: style, wrap: false}, 1}
+        end)
+
+      [header_row | body]
+    end
+
+    defp render_hunk(%{header: header, lines: lines}, :side_by_side, width) do
+      header_row = {
+        %Paragraph{text: "  " <> header, style: %Style{fg: :cyan}, wrap: false},
+        1
+      }
+
+      col_width = max(div(width - 5, 2), 8)
+
+      pair_rows =
+        lines
+        |> pair_hunk_lines()
+        |> Enum.map(&render_side_by_side_pair(&1, col_width))
+
+      [header_row | pair_rows]
+    end
+
+    # Pair `-` runs with the following `+` runs so they sit side by side.
+    defp pair_hunk_lines(lines) do
+      lines
+      |> Enum.chunk_by(fn {kind, _} -> kind end)
+      |> fold_runs([])
+      |> Enum.reverse()
+    end
+
+    defp fold_runs([], acc), do: acc
+
+    defp fold_runs([[{:context, _} | _] = run | rest], acc) do
+      pairs = Enum.map(run, fn {:context, t} -> {{:context, t}, {:context, t}} end)
+      fold_runs(rest, Enum.reverse(pairs) ++ acc)
+    end
+
+    defp fold_runs([[{:removed, _} | _] = lefts, [{:added, _} | _] = rights | rest], acc) do
+      left_texts = Enum.map(lefts, fn {:removed, t} -> t end)
+      right_texts = Enum.map(rights, fn {:added, t} -> t end)
+
+      pairs =
+        zip_pad(left_texts, right_texts)
+        |> Enum.map(fn
+          {nil, r} -> {{:none, ""}, {:added, r}}
+          {l, nil} -> {{:removed, l}, {:none, ""}}
+          {l, r} -> {{:removed, l}, {:added, r}}
+        end)
+
+      fold_runs(rest, Enum.reverse(pairs) ++ acc)
+    end
+
+    defp fold_runs([[{:removed, _} | _] = run | rest], acc) do
+      pairs = Enum.map(run, fn {:removed, t} -> {{:removed, t}, {:none, ""}} end)
+      fold_runs(rest, Enum.reverse(pairs) ++ acc)
+    end
+
+    defp fold_runs([[{:added, _} | _] = run | rest], acc) do
+      pairs = Enum.map(run, fn {:added, t} -> {{:none, ""}, {:added, t}} end)
+      fold_runs(rest, Enum.reverse(pairs) ++ acc)
+    end
+
+    defp fold_runs([_other | rest], acc), do: fold_runs(rest, acc)
+
+    defp zip_pad([], []), do: []
+    defp zip_pad([], [r | rs]), do: [{nil, r} | zip_pad([], rs)]
+    defp zip_pad([l | ls], []), do: [{l, nil} | zip_pad(ls, [])]
+    defp zip_pad([l | ls], [r | rs]), do: [{l, r} | zip_pad(ls, rs)]
+
+    defp render_side_by_side_pair({left, right}, col_width) do
+      line =
+        Line.new([
+          Span.new(side_text(left, col_width), style: side_style(left)),
+          Span.new(" │ ", style: %Style{fg: :dark_gray}),
+          Span.new(side_text(right, col_width), style: side_style(right))
+        ])
+
+      {%Paragraph{text: [line], wrap: false}, 1}
+    end
+
+    defp side_text({:none, _}, col_width), do: String.duplicate(" ", col_width)
+
+    defp side_text({kind, text}, col_width) do
+      prefix =
+        case kind do
+          :added -> "+ "
+          :removed -> "- "
+          :context -> "  "
+        end
+
+      body = prefix <> text
+      cur = String.length(body)
+
+      cond do
+        cur > col_width -> String.slice(body, 0, col_width - 1) <> "…"
+        true -> body <> String.duplicate(" ", col_width - cur)
+      end
+    end
+
+    defp side_style({:added, _}), do: %Style{fg: :green}
+    defp side_style({:removed, _}), do: %Style{fg: :red}
+    defp side_style({:context, _}), do: %Style{fg: :dark_gray}
+    defp side_style({:none, _}), do: %Style{}
+
+    # Compute a scroll_offset for a WidgetList. `above_bottom` is the user's
+    # manual scroll position (in rows above the natural bottom); nil = "at
+    # the bottom" (auto-pin to newest content). When the user has scrolled
+    # up, we step back from the auto-bottom by `above_bottom` rows, clamped
+    # to [0, max_offset] so it never escapes the content.
+    defp scroll_offset(items, height, above_bottom)
+         when is_integer(height) and height > 0 do
+      total = items |> Enum.map(fn {_w, h} -> h end) |> Enum.sum()
+      auto = max(total - height, 0)
+
+      case above_bottom do
+        nil -> auto
+        n when is_integer(n) -> auto |> Kernel.-(n) |> max(0)
+      end
+    end
+
+    defp scroll_offset(_items, _height, _above_bottom), do: 0
+
+    # Estimate the number of rows a string occupies once it's wrapped at
+    # `width` columns. Counts each explicit `\n` as a line break and uses
+    # `String.length/1` to approximate display columns (good enough for
+    # ASCII / European text; emoji and CJK may be off by one). The Paragraph
+    # widget does the actual wrapping; this just sizes the row in the
+    # surrounding WidgetList so wrapped content isn't clipped.
+    defp wrapped_height(text, width) when is_binary(text) and is_integer(width) and width > 0 do
+      text
+      |> String.split("\n")
+      |> Enum.map(fn line ->
+        case String.length(line) do
+          0 -> 1
+          n -> div(n - 1, width) + 1
+        end
+      end)
+      |> Enum.sum()
+      |> max(1)
+    end
+
+    defp wrapped_height(_text, _width), do: 1
+
+    defp detail_row_widget({:detail_header, text}, width) do
+      {%Paragraph{
+         text: text,
+         style: %Style{fg: :light_yellow, modifiers: [:bold]},
+         wrap: true
+       }, wrapped_height(text, width)}
+    end
+
+    defp detail_row_widget({:thinking, text}, width) do
+      {%Paragraph{
+         text: text,
+         style: %Style{fg: :magenta, modifiers: [:italic]},
+         wrap: true
+       }, wrapped_height(text, width)}
+    end
+
+    defp detail_row_widget({:assistant, text}, width) do
+      {%Paragraph{text: text, style: %Style{fg: :white}, wrap: true}, wrapped_height(text, width)}
+    end
+
+    defp detail_row_widget({:tool_call, text}, width) do
+      {%Paragraph{text: text, style: %Style{fg: :cyan}, wrap: true}, wrapped_height(text, width)}
+    end
+
+    defp detail_row_widget({:tool_result, text}, width) do
+      {%Paragraph{text: text, style: %Style{fg: :dark_gray}, wrap: true},
+       wrapped_height(text, width)}
+    end
+
+    defp detail_row_widget({:tool_result_error, text}, width) do
+      {%Paragraph{text: text, style: %Style{fg: :red}, wrap: true}, wrapped_height(text, width)}
+    end
+
+    defp detail_row_widget({:error, text}, width) do
+      {%Paragraph{text: text, style: %Style{fg: :red, modifiers: [:bold]}, wrap: true},
+       wrapped_height(text, width)}
+    end
+
+    defp detail_row_widget({:info, text}, width) do
+      {%Paragraph{text: text, style: %Style{fg: :dark_gray}, wrap: true},
+       wrapped_height(text, width)}
+    end
+
+    defp detail_row_widget({_kind, text}, width) do
+      {%Paragraph{text: text, style: %Style{fg: :dark_gray}, wrap: true},
+       wrapped_height(text, width)}
+    end
+
+    # ── Tool block (Claude-Code style: `● Tool(args)` + indented preview) ──
+
+    defp render_tool_block(%{todos: todos} = block, width) when is_list(todos) do
+      # Todo list: header + one row per item with a checkbox.
+      bullet = status_bullet(block.status)
+
+      header_text =
+        "#{bullet} TodoWrite (#{length(todos)} item#{if length(todos) == 1, do: "", else: "s"})"
+
+      header = {
+        %Paragraph{
+          text: header_text,
+          style: %Style{fg: bullet_color(block.status), modifiers: [:bold]},
+          wrap: true
+        },
+        wrapped_height(header_text, width)
+      }
+
+      {pending_and_active, completed} =
+        Enum.split_with(todos, &(get_todo_status(&1) != "completed"))
+
+      visible_rows =
+        pending_and_active
+        |> Enum.map(&todo_row_widget(&1, width))
+        |> Kernel.++(maybe_collapsed_completed_row(completed, width))
+
+      [header | visible_rows]
+    end
+
+    defp render_tool_block(block, width) do
+      color = bullet_color(block.status)
+      header_text = tool_header_text(block)
+
+      header = {
+        %Paragraph{
+          text: header_text,
+          style: %Style{fg: color, modifiers: [:bold]},
+          wrap: true
+        },
+        wrapped_height(header_text, width)
+      }
+
+      preview_rows = preview_widget_rows(block, width)
+
+      [header | preview_rows]
+    end
+
+    # ── Status bullet helpers ──
+
+    defp status_bullet(:pending), do: "●"
+    defp status_bullet(:success), do: "●"
+    defp status_bullet(:error), do: "●"
+    defp status_bullet(_), do: "●"
+
+    defp bullet_color(:pending), do: :light_blue
+    defp bullet_color(:success), do: :green
+    defp bullet_color(:error), do: :red
+    defp bullet_color(_), do: :dark_gray
+
+    # ── Header rendering: `● Tool(args)` ──
+
+    defp tool_header_text(%{name: name, ui: %{kind: :diff, payload: %{path: path}}})
+         when name in ["edit", "write", "apply_patch"] do
+      "#{status_bullet(:success)} #{verb_for(name)}(#{Path.relative_to_cwd(path)})"
+    end
+
+    defp tool_header_text(%{name: name, args: args}) do
+      "#{status_bullet(:success)} #{tool_display_name(name)}(#{args_summary(name, args)})"
+    end
+
+    defp tool_display_name(name) do
+      name
+      |> String.split("_")
+      |> Enum.map(&String.capitalize/1)
+      |> Enum.join("")
+    end
+
+    defp verb_for("write"), do: "Create"
+    defp verb_for("apply_patch"), do: "Patch"
+    defp verb_for(_), do: "Update"
+
+    defp args_summary("bash", %{"command" => cmd}) when is_binary(cmd), do: truncate(cmd, 100)
+    defp args_summary("bash", %{command: cmd}) when is_binary(cmd), do: truncate(cmd, 100)
+    defp args_summary("read", args), do: get_arg(args, "path") |> Path.relative_to_cwd()
+    defp args_summary("edit", args), do: get_arg(args, "path") |> Path.relative_to_cwd()
+    defp args_summary("write", args), do: get_arg(args, "path") |> Path.relative_to_cwd()
+    defp args_summary("grep", args), do: get_arg(args, "pattern")
+    defp args_summary("glob", args), do: get_arg(args, "pattern")
+    defp args_summary("web_fetch", args), do: args |> get_arg("url") |> truncate(80)
+    defp args_summary(_name, args) when args == %{} or is_nil(args), do: ""
+    defp args_summary(_name, args), do: args |> compact_args() |> truncate(80)
+
+    defp get_arg(args, key) when is_map(args) do
+      Map.get(args, key) || Map.get(args, String.to_atom(key)) || ""
+    end
+
+    defp get_arg(_args, _key), do: ""
+
+    defp compact_args(args) when is_map(args) do
+      Enum.map_join(args, ", ", fn {k, v} -> "#{k}: #{inspect(v)}" end)
+    end
+
+    defp compact_args(other), do: inspect(other)
+
+    # ── Indented preview rows ──
+
+    defp preview_widget_rows(%{ui: %{kind: :diff, payload: payload}} = _block, width) do
+      diff_preview_rows(payload, width)
+    end
+
+    defp preview_widget_rows(%{output_preview: nil}, _width), do: []
+
+    defp preview_widget_rows(%{output_preview: [], total_lines: _}, _width), do: []
+
+    defp preview_widget_rows(%{output_preview: lines, total_lines: total}, width) do
+      visible_count = length(lines)
+      preview_color = %Style{fg: :dark_gray}
+
+      visible =
+        lines
+        |> Enum.with_index()
+        |> Enum.map(fn {line, idx} ->
+          text = if idx == 0, do: "  └ #{line}", else: "    #{line}"
+          {%Paragraph{text: text, style: preview_color, wrap: true}, wrapped_height(text, width)}
+        end)
+
+      if total > visible_count do
+        remaining = total - visible_count
+
+        hint =
+          "    … +#{remaining} line#{if remaining == 1, do: "", else: "s"} (/expand 1 for full)"
+
+        visible ++
+          [{%Paragraph{text: hint, style: %Style{fg: :dark_gray, modifiers: [:italic]}}, 1}]
+      else
+        visible
+      end
+    end
+
+    # Edit / Write / apply_patch tool UI payloads carry the raw `before`
+    # and `after` strings — not a pre-diffed line list — so we compute the
+    # Myers diff inline. Same logic as ChatLive's `build_ui_entry(:diff)`
+    # in the web LiveView (chat_live.ex:1568).
+    defp diff_preview_rows(%{before: before, after: aft}, width) do
+      before_lines = String.split(to_string(before), "\n")
+      after_lines = String.split(to_string(aft), "\n")
+
+      all_lines =
+        Elixir.List.myers_difference(before_lines, after_lines)
+        |> Enum.flat_map(fn
+          {:eq, ls} -> Enum.map(ls, &{:eq, &1})
+          {:ins, ls} -> Enum.map(ls, &{:ins, &1})
+          {:del, ls} -> Enum.map(ls, &{:del, &1})
+        end)
+
+      added = Enum.count(all_lines, fn {k, _} -> k == :ins end)
+      removed = Enum.count(all_lines, fn {k, _} -> k == :del end)
+
+      stat_text =
+        cond do
+          added > 0 and removed > 0 -> "  └ +#{added} −#{removed} lines"
+          added > 0 -> "  └ Added #{added} line#{if added == 1, do: "", else: "s"}"
+          removed > 0 -> "  └ Removed #{removed} line#{if removed == 1, do: "", else: "s"}"
+          true -> "  └ no net change"
+        end
+
+      stat_row =
+        {%Paragraph{text: stat_text, style: %Style{fg: :dark_gray}, wrap: true},
+         wrapped_height(stat_text, width)}
+
+      snippet_rows =
+        all_lines
+        |> Enum.reject(fn {kind, _} -> kind == :eq end)
+        |> Enum.take(6)
+        |> Enum.map(fn {kind, line} ->
+          {prefix, style} =
+            case kind do
+              :ins -> {"    + ", %Style{fg: :green}}
+              :del -> {"    - ", %Style{fg: :red}}
+              _ -> {"      ", %Style{fg: :dark_gray}}
+            end
+
+          text = prefix <> truncate(line, max(width - 6, 20))
+          {%Paragraph{text: text, style: style, wrap: false}, 1}
+        end)
+
+      [stat_row | snippet_rows]
+    end
+
+    defp diff_preview_rows(_payload, _width), do: []
+
+    # ── Todo list rendering ──
+
+    defp todo_row_widget(todo, width) do
+      {marker, color} = todo_marker(get_todo_status(todo))
+      content = get_todo_field(todo, "content") || ""
+      text = "  #{marker} #{content}"
+      {%Paragraph{text: text, style: %Style{fg: color}, wrap: true}, wrapped_height(text, width)}
+    end
+
+    defp maybe_collapsed_completed_row([], _width), do: []
+
+    defp maybe_collapsed_completed_row(completed, width) do
+      n = length(completed)
+      text = "    … +#{n} completed"
+
+      [
+        {%Paragraph{text: text, style: %Style{fg: :dark_gray, modifiers: [:italic]}, wrap: true},
+         wrapped_height(text, width)}
+      ]
+    end
+
+    defp todo_marker("completed"), do: {"✓", :green}
+    defp todo_marker("in_progress"), do: {"◐", :light_blue}
+    defp todo_marker(_), do: {"□", :dark_gray}
+
+    defp get_todo_status(todo), do: get_todo_field(todo, "status") || "pending"
+
+    defp get_todo_field(todo, key) when is_map(todo) do
+      Map.get(todo, key) || Map.get(todo, String.to_atom(key))
+    end
+
+    defp get_todo_field(_, _), do: nil
+
+    defp truncate(text, max) when is_binary(text) and is_integer(max) do
+      if String.length(text) <= max, do: text, else: String.slice(text, 0, max - 1) <> "…"
+    end
+
+    defp truncate(other, max), do: other |> to_string() |> truncate(max)
+
+    defp row_widget({:user, text}, _model, width) do
+      full = "me ▸ " <> text
+
+      {%Paragraph{text: full, style: %Style{fg: :green, modifiers: [:bold]}, wrap: true},
+       wrapped_height(full, width)}
+    end
+
+    defp row_widget({:assistant, text}, model, width) do
+      full = model <> " ▸ " <> text
+
+      {%Paragraph{text: full, style: %Style{fg: :cyan, modifiers: [:bold]}, wrap: true},
+       wrapped_height(full, width)}
+    end
+
+    defp row_widget({:tool_call, text}, _model, width) do
+      {%Paragraph{text: text, style: %Style{fg: :cyan}, wrap: true}, wrapped_height(text, width)}
+    end
+
+    defp row_widget({:tool_result, text}, _model, width) do
+      {%Paragraph{text: text, style: %Style{fg: :dark_gray}, wrap: true},
+       wrapped_height(text, width)}
+    end
+
+    defp row_widget({:tool_result_error, text}, _model, width) do
+      {%Paragraph{text: text, style: %Style{fg: :red}, wrap: true}, wrapped_height(text, width)}
+    end
+
+    defp row_widget({:warning, text}, _model, width) do
+      {%Paragraph{text: text, style: %Style{fg: :yellow}, wrap: true},
+       wrapped_height(text, width)}
+    end
+
+    defp row_widget({:error, text}, _model, width) do
+      {%Paragraph{text: text, style: %Style{fg: :red, modifiers: [:bold]}, wrap: true},
+       wrapped_height(text, width)}
+    end
+
+    defp row_widget({:info, text}, _model, width) do
+      {%Paragraph{text: text, style: %Style{fg: :dark_gray}, wrap: true},
+       wrapped_height(text, width)}
+    end
+
+    defp row_widget({:status, text}, _model, width) do
+      {%Paragraph{text: text, style: %Style{fg: :dark_gray}, wrap: true},
+       wrapped_height(text, width)}
+    end
+
+    defp append_throbber(items, false), do: items
+
+    defp append_throbber(items, true) do
+      items ++
+        [
+          {%Throbber{
+             label: " thinking…",
+             throbber_set: :braille,
+             style: %Style{fg: :dark_gray}
+           }, 1}
+        ]
+    end
+
+    defp input(%State{input_ref: ref}) do
+      %Textarea{
+        state: ref,
+        placeholder: "Type a message and press Enter to send. /help for commands.",
+        placeholder_style: %Style{fg: :dark_gray},
+        block: @input_block
+      }
+    end
+
+    defp footer(%State{popup: nil}) do
+      %Paragraph{
+        text: "Enter: send  Ctrl+C: quit  /help",
+        style: %Style{fg: :dark_gray}
+      }
+    end
+
+    defp footer(%State{popup: _}) do
+      %Paragraph{
+        text: "↑↓ navigate  Enter select  Esc cancel",
+        style: %Style{fg: :dark_gray}
+      }
+    end
+
+    defp popup(%State{popup: nil}, _rect), do: nil
+
+    defp popup(%State{popup: {kind, items, idx}}, messages_rect) do
+      {title, list_items} =
+        case kind do
+          :model -> {" Pick a model ", items}
+          :mode -> {" Pick a mode ", Enum.map(items, &inspect/1)}
+        end
+
+      list = %List{
+        items: list_items,
+        selected: idx,
+        highlight_style: %Style{fg: :black, bg: :white, modifiers: [:bold]},
+        highlight_symbol: "> "
+      }
+
+      popup_widget = %Popup{
+        content: list,
+        block: %Block{title: title, borders: [:all], border_type: :rounded},
+        percent_width: 50,
+        percent_height: 60
+      }
+
+      {popup_widget, messages_rect}
+    end
   end
-end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExAthena.MixProject do
   use Mix.Project
 
-  @version "0.12.0"
+  @version "0.12.1"
   @source_url "https://github.com/udin-io/ex_athena"
 
   def project do


### PR DESCRIPTION
## Summary

Cuts **v0.12.1**, a hotfix for v0.12.0.

v0.12.0 shipped `:ex_ratatui` as an `optional` dependency, but the TUI modules still referenced it **at compile time** — so every consumer that didn't pull `ex_ratatui` failed to compile ExAthena entirely (`module ExRatatui.App is not loaded`). #95 fixed the root cause by guarding `ExAthena.Chat.Tui` and `…Tui.View` (and the `mix athena.chat` dispatch) behind `Code.ensure_loaded?/1`. This release is what gets that fix onto Hex.

## Changes

- **`chore(format)`** — #95 wrapped the two TUI modules in `if Code.ensure_loaded?(ExRatatui.App) do … end` without re-indenting the now-nested bodies, so `mix format --check-formatted` failed on them (no CI format gate caught it). Re-indented under the guard. Whitespace-only, plus one long-tuple line wrap — verified via `git diff -w`.
- **`chore(release)`** — bump `@version` `0.12.0 → 0.12.1`; move the #95 changelog entry out of the already-published v0.12.0 section into a new `## v0.12.1` section, noting v0.12.0 is being retired on Hex.

## Verification

- `mix format` — clean
- `mix compile --force --warnings-as-errors` — clean
- `mix test` — 809 tests, 2 doctests, 0 failures
- `mix hex.build` — builds as `ex_athena-0.12.1`

## Post-merge (manual, by maintainer)

```sh
git tag v0.12.1 && git push --tags
mix hex.publish
mix hex.retire ex_athena 0.12.0 invalid \
  --message "Broken for consumers without the optional :ex_ratatui dep; use 0.12.1+"
```