### PR TITLE
feat(web): image paste/upload/drop for vision input

### DIFF
--- a/lib/ex_athena/web/components/layouts.ex
+++ b/lib/ex_athena/web/components/layouts.ex
@@ -160,6 +160,58 @@ defmodule ExAthena.Web.Layouts do
               }
             },
 
+            ImageInput: {
+              mounted() {
+                const bar = this.el
+                const textarea = bar.querySelector("textarea")
+                const fileInput = bar.querySelector("#image-file-input")
+
+                const readAndPush = (file) => {
+                  if (!file || !file.type.startsWith("image/")) return
+                  const reader = new FileReader()
+                  reader.onload = (e) => {
+                    const [header, data] = e.target.result.split(",")
+                    const type = header.match(/:(.*?);/)[1]
+                    this.pushEvent("attach_image", {data, type})
+                  }
+                  reader.readAsDataURL(file)
+                }
+
+                if (textarea) {
+                  textarea.addEventListener("paste", (e) => {
+                    const items = Array.from(e.clipboardData?.items || [])
+                    const imgItems = items.filter(i => i.type.startsWith("image/"))
+                    if (imgItems.length > 0) {
+                      e.preventDefault()
+                      imgItems.forEach(i => readAndPush(i.getAsFile()))
+                    }
+                  })
+                }
+
+                bar.addEventListener("dragover", (e) => {
+                  e.preventDefault()
+                  bar.classList.add("drag-over")
+                })
+
+                bar.addEventListener("dragleave", (e) => {
+                  if (!bar.contains(e.relatedTarget)) bar.classList.remove("drag-over")
+                })
+
+                bar.addEventListener("drop", (e) => {
+                  e.preventDefault()
+                  bar.classList.remove("drag-over")
+                  Array.from(e.dataTransfer.files).forEach(readAndPush)
+                })
+
+                if (fileInput) {
+                  fileInput.addEventListener("change", (e) => {
+                    Array.from(e.target.files).forEach(readAndPush)
+                    e.target.value = ""
+                  })
+                }
+              }
+            },
+
             // Resizable split-pane divider inside .chat-main. Mouse-drag on
             // .chat-divider updates --left-w / --right-w CSS variables on
             // the .chat-main element (this.el). Ratio persists in

--- a/lib/ex_athena/web/live/chat_live.ex
+++ b/lib/ex_athena/web/live/chat_live.ex
@@ -3,6 +3,7 @@ defmodule ExAthena.Web.Live.ChatLive do
 
   alias ExAthena.Chat.{LlamaCpp, Ollama}
   alias ExAthena.Messages
+  alias ExAthena.Messages.ContentPart
   alias ExAthena.Web.Sessions
 
   @providers [
@@ -55,6 +56,7 @@ defmodule ExAthena.Web.Live.ChatLive do
         modes: @modes,
         # Conversation
         messages: [],
+        pending_images: [],
         streaming: false,
         stream_text: "",
         stream_events: [],
@@ -106,11 +108,21 @@ defmodule ExAthena.Web.Live.ChatLive do
     text = String.trim(text)
 
     cond do
-      text == "" -> {:noreply, socket}
+      text == "" and socket.assigns.pending_images == [] -> {:noreply, socket}
       socket.assigns.streaming -> {:noreply, socket}
       is_nil(socket.assigns.cwd) -> {:noreply, socket}
       true -> start_agent_run(socket, text)
     end
+  end
+
+  def handle_event("attach_image", %{"data" => data, "type" => type}, socket) do
+    image = %{data: data, media_type: type}
+    {:noreply, update(socket, :pending_images, &(&1 ++ [image]))}
+  end
+
+  def handle_event("remove_image", %{"index" => idx}, socket) do
+    idx = if is_binary(idx), do: String.to_integer(idx), else: idx
+    {:noreply, assign(socket, pending_images: List.delete_at(socket.assigns.pending_images, idx))}
   end
 
   def handle_event("stop", _params, socket) do
@@ -170,6 +182,7 @@ defmodule ExAthena.Web.Live.ChatLive do
          session_title: nil,
          session_created_at: DateTime.utc_now(),
          messages: [],
+         pending_images: [],
          ex_messages: [],
          tool_uis: %{},
          expanded_uis: MapSet.new(),
@@ -202,6 +215,7 @@ defmodule ExAthena.Web.Live.ChatLive do
          session_title: nil,
          session_created_at: DateTime.utc_now(),
          messages: [],
+         pending_images: [],
          ex_messages: [],
          tool_uis: %{},
          expanded_uis: MapSet.new(),
@@ -233,6 +247,7 @@ defmodule ExAthena.Web.Live.ChatLive do
        session_title: nil,
        session_created_at: DateTime.utc_now(),
        messages: [],
+       pending_images: [],
        ex_messages: [],
        tool_uis: %{},
        expanded_uis: MapSet.new(),
@@ -289,6 +304,7 @@ defmodule ExAthena.Web.Live.ChatLive do
        session_title: nil,
        session_created_at: DateTime.utc_now(),
        messages: [],
+       pending_images: [],
        ex_messages: [],
        tool_uis: %{},
        expanded_uis: MapSet.new(),
@@ -324,6 +340,7 @@ defmodule ExAthena.Web.Live.ChatLive do
            model: data.model,
            mode: data.mode,
            messages: data.display_messages,
+           pending_images: [],
            ex_messages: data.ex_messages,
            tool_uis: tool_uis,
            expanded_uis: MapSet.new(),
@@ -375,6 +392,7 @@ defmodule ExAthena.Web.Live.ChatLive do
            session_title: title,
            session_created_at: DateTime.utc_now(),
            messages: forked_messages,
+           pending_images: [],
            ex_messages: ex_messages,
            details_stream: details_stream,
            pending_assistant_msg_id: nil,
@@ -930,8 +948,35 @@ defmodule ExAthena.Web.Live.ChatLive do
           <.details_pane stream={@details_stream} max_diff_lines={@max_diff_lines} />
         </div>
 
-        <div class="input-bar">
+        <div class="input-bar" id="image-input-bar" phx-hook="ImageInput">
+          <%= if @pending_images != [] do %>
+            <div class="img-preview-bar">
+              <div
+                :for={{img, idx} <- Enum.with_index(@pending_images)}
+                class="img-preview-item"
+              >
+                <img
+                  src={"data:#{img.media_type};base64,#{img.data}"}
+                  class="img-preview-thumb"
+                  alt="attached image"
+                />
+                <button
+                  type="button"
+                  class="img-preview-remove"
+                  phx-click="remove_image"
+                  phx-value-index={idx}
+                  title="Remove image"
+                >×</button>
+              </div>
+            </div>
+          <% end %>
           <form class="input-form" phx-submit="send">
+            <label
+              class={"btn-attach#{if @streaming or is_nil(@cwd), do: " btn-attach--disabled", else: ""}"}
+              for="image-file-input"
+              title="Attach image (or paste / drop)"
+            >⊕</label>
+            <input type="file" id="image-file-input" accept="image/*" multiple />
             <textarea
               id="chat-input"
               class="input-textarea"
@@ -1036,10 +1081,19 @@ defmodule ExAthena.Web.Live.ChatLive do
   # ---------------------------------------------------------------------------
 
   defp message(%{msg: %{role: :user}} = assigns) do
+    assigns = assign(assigns, :msg_images, Map.get(assigns.msg, :images, []))
+
     ~H"""
     <div class="msg msg--user">
       <div class="msg-role">you</div>
-      <div class="msg-body">{@msg.text}</div>
+      <%= if @msg_images != [] do %>
+        <div class="msg-images">
+          <img :for={src <- @msg_images} src={src} class="msg-image" alt="attached image" />
+        </div>
+      <% end %>
+      <%= if @msg.text != "" do %>
+        <div class="msg-body">{@msg.text}</div>
+      <% end %>
     </div>
     """
   end
@@ -1389,10 +1443,35 @@ defmodule ExAthena.Web.Live.ChatLive do
     provider = socket.assigns.provider
     model = socket.assigns.model
     mode = socket.assigns.mode
+    images = socket.assigns.pending_images
 
-    user_msg = %{id: unique_id(), role: :user, text: text, tool_events: [], status: nil}
+    image_data_urls =
+      Enum.map(images, fn %{data: d, media_type: t} -> "data:#{t};base64,#{d}" end)
+
+    user_msg = %{
+      id: unique_id(),
+      role: :user,
+      text: text,
+      images: image_data_urls,
+      tool_events: [],
+      status: nil
+    }
+
     assistant_msg_id = unique_id()
-    new_ex_msg = Messages.user(text)
+
+    new_ex_msg =
+      if images == [] do
+        Messages.user(text)
+      else
+        parts =
+          Enum.map(images, fn %{data: data, media_type: type} ->
+            ContentPart.image(Base.decode64!(data), type)
+          end)
+
+        parts = if text != "", do: parts ++ [ContentPart.text(text)], else: parts
+        Messages.user(parts)
+      end
+
     ex_messages = socket.assigns.ex_messages ++ [new_ex_msg]
 
     {:ok, task_pid} =
@@ -1425,6 +1504,7 @@ defmodule ExAthena.Web.Live.ChatLive do
      assign(socket,
        messages: socket.assigns.messages ++ [user_msg],
        ex_messages: ex_messages,
+       pending_images: [],
        streaming: true,
        streaming_task_pid: task_pid,
        stream_text: "",
@@ -1725,7 +1805,8 @@ defmodule ExAthena.Web.Live.ChatLive do
     |> Enum.find(&(&1.role == :user))
     |> case do
       nil -> "Untitled"
-      msg -> truncate(msg.text, 60)
+      %{text: text} when is_binary(text) and text != "" -> truncate(text, 60)
+      _ -> "[Image]"
     end
   end
 

--- a/priv/web/static/app.css
+++ b/priv/web/static/app.css
@@ -483,6 +483,88 @@ html, body { height: 100%; background: var(--bg); color: var(--text); font-famil
 }
 .btn-stop:hover { background: #ff2244; }
 
+/* ── Image attachment ──────────────────────────────────────────────────────── */
+
+#image-file-input { display: none; }
+
+.btn-attach {
+  background: transparent;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  color: var(--muted);
+  font-size: 18px;
+  width: 44px;
+  height: 44px;
+  flex-shrink: 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.btn-attach:hover { border-color: var(--accent); color: var(--accent); }
+.btn-attach--disabled { opacity: 0.4; pointer-events: none; }
+
+.input-bar.drag-over {
+  border-top-color: var(--accent);
+  background: var(--accent-dim);
+}
+
+.img-preview-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 0 0 10px;
+  max-width: 760px;
+}
+
+.img-preview-item {
+  position: relative;
+  display: inline-flex;
+}
+
+.img-preview-thumb {
+  width: 72px;
+  height: 72px;
+  object-fit: cover;
+  border-radius: var(--radius);
+  border: 1px solid var(--border-light);
+}
+
+.img-preview-remove {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--error-text);
+  color: #fff;
+  border: none;
+  font-size: 11px;
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.msg-images {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.msg-image {
+  max-width: 300px;
+  max-height: 200px;
+  object-fit: contain;
+  border-radius: var(--radius);
+  border: 1px solid var(--border-light);
+}
+
 /* Spinner */
 .spinner {
   width: 16px;


### PR DESCRIPTION
## Summary

- **Clipboard paste** — Ctrl+V an image directly into the chat textarea; the `ImageInput` LiveView hook intercepts the paste event and ships the base64 payload to the server
- **Drag-and-drop** — drag an image file onto the input bar; visual `drag-over` highlight confirms the drop zone, then the image is pushed to the server
- **File picker** — click the `⊕` button to open a native file chooser (multi-select, `image/*`)

Images accumulate as `pending_images` in the socket assigns and are rendered as 72 × 72 thumbnails with `×` remove buttons. On send, the server builds a multipart `Messages.user([ContentPart.image(...), ContentPart.text(...)])` so any vision-capable provider (Claude, Gemini, OpenAI-compatible) receives the images alongside the text. After send, `pending_images` is cleared.

Received image turns are stored as data-URLs on the display message and rendered as `<img>` thumbnails in the chat history. Image-only messages (no text) are supported; session titles fall back to `[Image]` when there is no text.

## Test plan

- [ ] Paste a screenshot with Ctrl+V — thumbnail appears in preview bar, `×` removes it
- [ ] Drag an image file onto the input area — `drag-over` highlight shows, thumbnail appears on drop
- [ ] Click `⊕` and select one or more images via file picker
- [ ] Send image + text — user turn renders thumbnail + text; assistant responds describing the image
- [ ] Send image with no text — works; session titled `[Image]`
- [ ] Stream stop, new session, fork, load session — `pending_images` correctly cleared in all cases
- [ ] Non-vision provider — images still sent (provider will reject or ignore gracefully)

ExAthena