### PR TITLE
feat(web): add light mode with sidebar toggle

### DIFF
--- a/lib/ex_athena/web/components/layouts.ex
+++ b/lib/ex_athena/web/components/layouts.ex
@@ -20,6 +20,12 @@ defmodule ExAthena.Web.Layouts do
             }
           }
         </script>
+        <script>
+          (function(){
+            var t = localStorage.getItem("ex_athena.theme")
+            if (t) document.documentElement.dataset.theme = t
+          })()
+        </script>
         <script type="module">
           import {Socket} from "phoenix"
           import {LiveSocket} from "phoenix_live_view"
@@ -112,7 +118,24 @@ defmodule ExAthena.Web.Layouts do
           }
 
           // ── LiveView hooks ─────────────────────────────────────────────────
+          const THEME_KEY = "ex_athena.theme"
+          const applyTheme = (light) => {
+            document.documentElement.dataset.theme = light ? "light" : "dark"
+            localStorage.setItem(THEME_KEY, light ? "light" : "dark")
+          }
+
           const Hooks = {
+            ThemeToggle: {
+              mounted() {
+                const input = this.el.querySelector("input[type=checkbox]")
+                const light = localStorage.getItem(THEME_KEY) === "light"
+                if (input) input.checked = light
+                document.documentElement.dataset.theme = light ? "light" : "dark"
+                if (input) {
+                  input.addEventListener("change", () => applyTheme(input.checked))
+                }
+              }
+            },
             ScrollToBottom: {
               mounted()  { this.scrollToBottom() },
               updated()  { this.scrollToBottom() },

--- a/lib/ex_athena/web/live/chat_live.ex
+++ b/lib/ex_athena/web/live/chat_live.ex
@@ -744,6 +744,14 @@ defmodule ExAthena.Web.Live.ChatLive do
           </div>
           <button class="btn-plus" phx-click="show_modal" title="New session">+</button>
         </div>
+        <div class="theme-row" id="theme-toggle" phx-hook="ThemeToggle">
+          <span class="theme-icon">☀</span>
+          <span class="theme-label">Light mode</span>
+          <label class="theme-switch">
+            <input type="checkbox" />
+            <span class="theme-track"></span>
+          </label>
+        </div>
 
         <%!-- Active project --%>
         <%= if @cwd do %>

--- a/priv/web/static/app.css
+++ b/priv/web/static/app.css
@@ -18,6 +18,37 @@
   --radius:       6px;
 }
 
+[data-theme="light"] {
+  --bg:           #f5f6fa;
+  --sidebar-bg:   #eceef5;
+  --border:       #d0d5e2;
+  --border-light: #b8bfcf;
+  --text:         #1c1f2e;
+  --muted:        #6b7385;
+  --accent:       #0ea573;
+  --accent-dim:   #cef5e7;
+  --user-accent:  #2563eb;
+  --user-dim:     #dbeafe;
+  --tool-bg:      #edf2ed;
+  --tool-border:  #c2d4c2;
+  --error-text:   #dc2626;
+  --error-bg:     #fee2e2;
+}
+
+[data-theme="light"] .diff-header,
+[data-theme="light"] .process-header,
+[data-theme="light"] .file-header,
+[data-theme="light"] .diff-panel-header,
+[data-theme="light"] .git-panel-header,
+[data-theme="light"] .tool-result,
+[data-theme="light"] .diff-gap,
+[data-theme="light"] .md-fence-lang {
+  background: rgba(0,0,0,0.04);
+}
+
+[data-theme="light"] .modal-overlay { background: rgba(0,0,0,0.35); }
+[data-theme="light"] .modal         { box-shadow: 0 24px 64px rgba(0,0,0,0.2); }
+
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 html, body { height: 100%; background: var(--bg); color: var(--text); font-family: var(--font-ui); font-size: 14px; line-height: 1.6; }
@@ -578,6 +609,76 @@ html, body { height: 100%; background: var(--bg); color: var(--text); font-famil
 
 @keyframes spin {
   to { transform: rotate(360deg); }
+}
+
+/* ── Theme toggle switch ─────────────────────────────────────────────────── */
+
+.theme-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.theme-icon {
+  font-size: 13px;
+  line-height: 1;
+  color: var(--muted);
+  width: 16px;
+  text-align: center;
+}
+
+.theme-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--muted);
+  flex: 1;
+}
+
+.theme-switch {
+  position: relative;
+  display: inline-block;
+  width: 36px;
+  height: 20px;
+  flex-shrink: 0;
+}
+
+.theme-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+  position: absolute;
+}
+
+.theme-track {
+  position: absolute;
+  inset: 0;
+  background: var(--border-light);
+  border-radius: 10px;
+  transition: background 0.2s;
+  cursor: pointer;
+}
+
+.theme-track::after {
+  content: "";
+  position: absolute;
+  left: 3px;
+  top: 3px;
+  width: 14px;
+  height: 14px;
+  background: var(--muted);
+  border-radius: 50%;
+  transition: transform 0.2s, background 0.2s;
+}
+
+.theme-switch input:checked + .theme-track {
+  background: var(--accent);
+}
+
+.theme-switch input:checked + .theme-track::after {
+  transform: translateX(16px);
+  background: #fff;
 }
 
 /* Scrollbar */


### PR DESCRIPTION
## Summary

- Adds a `[data-theme="light"]` CSS variable block with a full light colour palette
- Overrides dark-mode `rgba(0,0,0,…)` panel headers/overlays so they read cleanly on light backgrounds
- Adds a toggle switch row below the sidebar logo (sun icon + "Light mode" label + pill switch)
- Adds a `ThemeToggle` LiveView hook that reads/writes `localStorage` and applies the `data-theme` attribute to `<html>`
- Injects a small inline `<script>` before the module bundle to apply the saved theme immediately, preventing a flash of the wrong theme on hard reload

## Test plan

- [ ] Toggle switch appears below the logo in the sidebar
- [ ] Clicking the switch flips between dark and light theme
- [ ] Refreshing the page preserves the selected theme (no flash)
- [ ] All UI areas (sidebar, messages, tool events, modals, diff panel) look correct in light mode
- [ ] Dark mode is unchanged when toggle is off

ExAthena