### PR TITLE
fix(config): scope provider app-env to the requested atom (no base_url leak)

### DIFF
--- a/lib/ex_athena/config.ex
+++ b/lib/ex_athena/config.ex
@@ -153,16 +153,29 @@ defmodule ExAthena.Config do
   Flattens per-call overrides + application env for this provider into one
   keyword list. Providers use `Keyword.get/3` on the result.
   """
-  @spec provider_opts(module(), keyword()) :: keyword()
-  def provider_opts(provider_module, opts) do
-    app_env = provider_app_env(provider_module)
+  @spec provider_opts(module(), keyword(), atom() | nil) :: keyword()
+  def provider_opts(provider_module, opts, provider_atom \\ nil) do
+    atom = provider_atom || Keyword.get(opts, :provider)
+    app_env = provider_app_env(provider_module, atom)
 
     app_env
     |> Keyword.merge(opts)
     |> Keyword.delete(:provider)
   end
 
-  defp provider_app_env(provider_module) do
+  # Every built-in provider atom (:ollama, :openai, :gemini, :claude, …) maps to
+  # the SAME `ExAthena.Providers.ReqLLM` module. Accumulating config across all
+  # of a module's atoms leaks instance-specific keys — most damagingly
+  # `base_url` — from one provider into another (e.g. a configured Ollama
+  # `base_url` would be sent on a Gemini request, 404ing against the wrong host).
+  # When the concrete provider atom is known, read ONLY that atom's config.
+  defp provider_app_env(_provider_module, atom)
+       when is_atom(atom) and not is_nil(atom) and is_map_key(@builtin_providers, atom) do
+    Application.get_env(:ex_athena, atom, [])
+  end
+
+  # Unknown atom / custom module: fall back to module-wide accumulation.
+  defp provider_app_env(provider_module, _atom) do
     provider_module
     |> provider_atoms()
     |> Enum.flat_map(fn atom ->

--- a/lib/ex_athena/loop.ex
+++ b/lib/ex_athena/loop.ex
@@ -585,7 +585,7 @@ defmodule ExAthena.Loop do
         tool_specs: tool_specs,
         capabilities: capabilities,
         provider_mod: provider_mod,
-        provider_opts: Config.provider_opts(provider_mod, opts),
+        provider_opts: Config.provider_opts(provider_mod, opts, raw_provider),
         request_template: request_template,
         permissions_opts: permissions_opts,
         hooks: Keyword.get(opts, :hooks, %{}) |> ImplicitDiagnostics.maybe_merge(),

--- a/test/ex_athena/config_test.exs
+++ b/test/ex_athena/config_test.exs
@@ -82,6 +82,39 @@ defmodule ExAthena.ConfigTest do
     end
   end
 
+  describe "provider_opts/3 atom scoping" do
+    test "does not leak a sibling provider's base_url across the shared ReqLLM module" do
+      # :ollama and :gemini both map to ExAthena.Providers.ReqLLM. A configured
+      # Ollama base_url must NOT bleed into a Gemini request (that 404s).
+      Application.put_env(:ex_athena, :ollama, base_url: "http://localhost:11434")
+      on_exit(fn -> Application.delete_env(:ex_athena, :ollama) end)
+
+      gemini_opts =
+        Config.provider_opts(ExAthena.Providers.ReqLLM, [provider: :gemini], :gemini)
+
+      assert Keyword.get(gemini_opts, :base_url) == nil
+
+      ollama_opts =
+        Config.provider_opts(ExAthena.Providers.ReqLLM, [provider: :ollama], :ollama)
+
+      assert Keyword.get(ollama_opts, :base_url) == "http://localhost:11434"
+    end
+
+    test "per-call opts still override the scoped provider env" do
+      Application.put_env(:ex_athena, :ollama, base_url: "http://localhost:11434")
+      on_exit(fn -> Application.delete_env(:ex_athena, :ollama) end)
+
+      opts =
+        Config.provider_opts(
+          ExAthena.Providers.ReqLLM,
+          [provider: :ollama, base_url: "http://example.test"],
+          :ollama
+        )
+
+      assert Keyword.get(opts, :base_url) == "http://example.test"
+    end
+  end
+
   describe "provider_module/1" do
     test "resolves built-in atoms" do
       assert ExAthena.Providers.ReqLLM = Config.provider_module(:ollama)


### PR DESCRIPTION
## Summary

A downstream consumer hit repeated `HTTP 404` on **Gemini** requests:

```
Google attach_stream - computed_base_url: "https://generativelanguage.googleapis.com/v1beta",
  req_opts[:base_url]: "http://localhost:11434", final base_url: "http://localhost:11434"
URL: "http://localhost:11434/models/gemini-3.5-flash:streamGenerateContent..."
```

The Gemini request was sent to **Ollama's** URL.

## Root cause

Every built-in provider atom (`:ollama`, `:openai`, `:gemini`, `:claude`, …) maps to the **same** `ExAthena.Providers.ReqLLM` module. `Config.provider_opts/2` built its app-env via `provider_app_env/1`, which accumulated `Application.get_env(:ex_athena, <atom>)` across **all** of the module's atoms. So a consumer's `config :ex_athena, ollama: [base_url: "http://localhost:11434"]` leaked into **every** ReqLLM request — including `:gemini` and `:claude`, which use fixed cloud endpoints — and the leaked `base_url` overrode the provider's computed endpoint.

## Fix

`provider_opts/3` now accepts the concrete provider atom (threaded from the loop's `raw_provider`). When it's a known built-in atom, it reads **only that atom's** config; unknown atoms / custom modules fall back to the previous module-wide accumulation. Per-call opts still override.

So a Gemini request reads `config :ex_athena, :gemini` (typically empty) and no longer inherits Ollama's `base_url`; Ollama still reads its own.

## Test plan

- [x] New `config_test` cases: no base_url leak from `:ollama` into `:gemini`; Ollama keeps its own; per-call opts still override
- [x] `mix test` — **811 tests, 0 failures**