### PR TITLE
chore(igniter): v0.12 installer/upgrader + docs cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,28 @@ and ExAthena adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
-## v0.12.2 — Provider config no longer leaks base_url across providers
+## v0.12.2 — Provider base_url leak fix + Igniter/docs refresh
+
+Fixes a cross-provider `base_url` config leak and refreshes the Igniter
+installer/upgrader and docs for v0.12 (no runtime changes beyond the config fix).
+
+### Added
+
+- **`0.12.0` Igniter upgrade migration.** `mix igniter.upgrade ex_athena` from a
+  pre-0.12 version now emits a notice that the TUI/web deps (`ex_ratatui`,
+  `phoenix`, `phoenix_live_view`, `bandit`) became `optional` in v0.12, so
+  consumers who rely on `mix athena.chat` / `mix athena.web` know to add the deps
+  to their own `mix.exs`. Library-only consumers are unaffected. Previously the
+  upgrader only carried the `0.4.0` migration, so the v0.12 packaging change was a
+  silent footgun.
+
+### Changed
+
+- **Installer notice covers the v0.12 front-ends.** `mix ex_athena.install`'s
+  post-install notice advertised only the v0.4 feature set; it now also points at
+  the optional `mix athena.chat` (TUI) and `mix athena.web` (web UI) front-ends
+  and the deps each requires. The moduledoc's dep-pin example is bumped from
+  `~> 0.4` to `~> 0.12`.
 
 ### Fixed
 
@@ -22,6 +43,12 @@ and ExAthena adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   concrete provider atom is now threaded from the loop and only that atom's
   config is read (unknown atoms / custom modules still fall back to module-wide
   accumulation); per-call opts still override (#99).
+- **Gemini guide now renders on hexdocs.** `guides/gemini.md` shipped in the
+  package and was linked from the README and other guides, but it was missing
+  from `docs.extras` — so those links broke and the guide never appeared in the
+  published docs. Added it to the docs extras.
+- **Stale dependency-version pins in the docs.** `guides/getting_started.md`
+  pinned `{:ex_athena, "~> 0.1"}`; corrected to `~> 0.12` to match the README.
 
 ## v0.12.1 — Optional TUI dep no longer breaks library consumers
 

--- a/guides/getting_started.md
+++ b/guides/getting_started.md
@@ -10,7 +10,7 @@ mix igniter.install ex_athena
 
 The installer:
 
-- Adds `{:ex_athena, "~> 0.1"}` to your deps.
+- Adds `{:ex_athena, "~> 0.12"}` to your deps.
 - Writes `config :ex_athena, default_provider: :ollama` (and per-provider defaults) to `config/config.exs`.
 - Is idempotent — re-running preserves whatever you've already configured.
 
@@ -19,7 +19,7 @@ Alternatively, add the dep manually:
 ```elixir
 def deps do
   [
-    {:ex_athena, "~> 0.1"},
+    {:ex_athena, "~> 0.12"},
     {:claude_code, "~> 0.36"}  # only needed for the :claude provider
   ]
 end

--- a/lib/mix/tasks/ex_athena.install.ex
+++ b/lib/mix/tasks/ex_athena.install.ex
@@ -5,7 +5,7 @@ if Code.ensure_loaded?(Igniter) do
     @moduledoc """
     Installs ExAthena into your project.
 
-    Run once after adding `{:ex_athena, "~> 0.4"}` to `mix.exs`, or via Igniter:
+    Run once after adding `{:ex_athena, "~> 0.12"}` to `mix.exs`, or via Igniter:
 
         mix igniter.install ex_athena
         mix ex_athena.install
@@ -69,8 +69,8 @@ if Code.ensure_loaded?(Igniter) do
         `config :ex_athena, default_provider: :claude` and provide
         ANTHROPIC_API_KEY in the environment.
 
-      v0.4 features available out of the box
-      ──────────────────────────────────────
+      Features available out of the box
+      ─────────────────────────────────
       • Memory: drop AGENTS.md at your project root for project-wide
         rules the agent honours on every turn.
       • Skills: drop SKILL.md files under .exathena/skills/<name>/
@@ -79,6 +79,16 @@ if Code.ensure_loaded?(Igniter) do
         with optional git-worktree isolation.
       • Sessions: pass `store: :jsonl` to ExAthena.Session for durable
         conversations with Session.resume/2.
+
+      Interactive front-ends (optional deps)
+      ──────────────────────────────────────
+      The TUI and web UI ship as optional deps so the core library stays
+      lean. Add the ones you want to your mix.exs, then run mix deps.get:
+      • `mix athena.chat` — full-screen terminal TUI. Needs
+        {:ex_ratatui, "~> 0.10"}.
+      • `mix athena.web` — Phoenix LiveView web UI. Needs
+        {:phoenix, "~> 1.7"}, {:phoenix_live_view, "~> 1.0"}, and
+        {:bandit, "~> 1.5"}.
 
       Full docs: https://hexdocs.pm/ex_athena.
       """)

--- a/lib/mix/tasks/ex_athena.upgrade.ex
+++ b/lib/mix/tasks/ex_athena.upgrade.ex
@@ -20,6 +20,11 @@ if Code.ensure_loaded?(Igniter) do
         callers are unaffected. Also scaffolds `.exathena/.gitignore`
         so session JSONL logs and the file-history snapshots aren't
         accidentally committed.
+      * **`0.12.0`** — notices that the TUI/web deps (`ex_ratatui`,
+        `phoenix`, `phoenix_live_view`, `bandit`) became `optional`, so
+        consumers who use `mix athena.chat` / `mix athena.web` must add
+        the deps to their own `mix.exs`. Library-only consumers are
+        unaffected.
     """
 
     use Igniter.Mix.Task
@@ -45,7 +50,8 @@ if Code.ensure_loaded?(Igniter) do
       options = igniter.args.options
 
       upgrades = %{
-        "0.4.0" => [&upgrade_0_3_to_0_4/2]
+        "0.4.0" => [&upgrade_0_3_to_0_4/2],
+        "0.12.0" => [&upgrade_0_11_to_0_12/2]
       }
 
       Igniter.Upgrades.run(igniter, arguments.from, arguments.to, upgrades, options)
@@ -58,6 +64,45 @@ if Code.ensure_loaded?(Igniter) do
       |> ensure_exathena_gitignore()
       |> notice_tool_result_split()
       |> notice_new_features()
+    end
+
+    # ── 0.11.x → 0.12.0 migration ────────────────────────────────────
+
+    defp upgrade_0_11_to_0_12(igniter, _opts) do
+      notice_optional_frontend_deps(igniter)
+    end
+
+    # v0.12 marked the TUI/web stack `optional`, so the core library no
+    # longer pulls in ex_ratatui / Phoenix / Bandit transitively. That's
+    # a silent footgun for anyone who relied on `mix athena.chat` or
+    # `mix athena.web`: after the bump those tasks fail to start unless
+    # the consumer adds the deps to their own mix.exs. We can't add deps
+    # for them (we don't know if they want the TUI, the web UI, or
+    # neither), so we surface a notice with the exact dep list.
+    defp notice_optional_frontend_deps(igniter) do
+      Igniter.add_notice(igniter, """
+      ⚠ v0.12 packaging change — TUI/web deps are now optional.
+
+      `ex_ratatui`, `phoenix`, `phoenix_live_view`, and `bandit` are
+      marked `optional: true`, so the core agent loop no longer pulls
+      them in transitively — library consumers stay lean.
+
+      If you use the interactive front-ends, add the deps you need to
+      your own mix.exs:
+
+          # interactive terminal TUI — `mix athena.chat`
+          {:ex_ratatui, "~> 0.10"},
+
+          # Phoenix LiveView web UI — `mix athena.web`
+          {:phoenix, "~> 1.7"},
+          {:phoenix_live_view, "~> 1.0"},
+          {:bandit, "~> 1.5"},
+
+      Then run `mix deps.get`. If you only use ExAthena as a library
+      (via `ExAthena.run/2` / `Loop.run/2`), no action is needed.
+
+      See CHANGELOG.md (v0.12.0 → Packaging) for details.
+      """)
     end
 
     # Scaffold `.exathena/.gitignore` so users don't accidentally commit

--- a/mix.exs
+++ b/mix.exs
@@ -79,6 +79,7 @@ defmodule ExAthena.MixProject do
         "CHANGELOG.md",
         "guides/getting_started.md",
         "guides/providers.md",
+        "guides/gemini.md",
         "guides/multimodal.md",
         "guides/tool_calls.md",
         "guides/tools.md",

--- a/test/mix/tasks/ex_athena_install_test.exs
+++ b/test/mix/tasks/ex_athena_install_test.exs
@@ -48,7 +48,7 @@ defmodule Mix.Tasks.ExAthena.InstallTest do
     """)
   end
 
-  test "surfaces a notice that mentions v0.4 features" do
+  test "surfaces a notice that mentions core features" do
     igniter =
       test_project()
       |> Igniter.compose_task("ex_athena.install", [])
@@ -59,6 +59,18 @@ defmodule Mix.Tasks.ExAthena.InstallTest do
     assert notice =~ "AGENTS.md"
     assert notice =~ "Skills"
     assert notice =~ "Sessions"
+  end
+
+  test "notice points at the optional TUI/web front-ends and their deps" do
+    igniter =
+      test_project()
+      |> Igniter.compose_task("ex_athena.install", [])
+
+    notice = Enum.join(igniter.notices, "\n")
+    assert notice =~ "mix athena.chat"
+    assert notice =~ "mix athena.web"
+    assert notice =~ "optional"
+    assert notice =~ "ex_ratatui"
   end
 
   test "is idempotent — re-running preserves user changes" do

--- a/test/mix/tasks/ex_athena_upgrade_test.exs
+++ b/test/mix/tasks/ex_athena_upgrade_test.exs
@@ -67,6 +67,34 @@ defmodule Mix.Tasks.ExAthena.UpgradeTest do
     end
   end
 
+  describe "0.11.0 -> 0.12.0 (optional TUI/web deps)" do
+    test "emits a notice that the TUI/web deps are now optional" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("ex_athena.upgrade", ["0.11.0", "0.12.0"])
+
+      notice = Enum.join(igniter.notices, "\n")
+      assert notice =~ "optional"
+      assert notice =~ "ex_ratatui"
+      assert notice =~ "phoenix"
+      assert notice =~ "phoenix_live_view"
+      assert notice =~ "bandit"
+      assert notice =~ "mix athena.chat"
+      assert notice =~ "mix athena.web"
+    end
+
+    test "does not emit the v0.4 tool-result-split notice" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("ex_athena.upgrade", ["0.11.0", "0.12.0"])
+
+      # The 0.4.0 migration must not run — its target falls outside
+      # `> 0.11.0 and <= 0.12.0`.
+      notice = Enum.join(igniter.notices, "\n")
+      refute notice =~ "tool-result split"
+    end
+  end
+
   describe "version routing (Igniter.Upgrades.run/5)" do
     test "0.4.0 -> 0.4.0 is a no-op (range is exclusive of from)" do
       igniter =
@@ -77,6 +105,16 @@ defmodule Mix.Tasks.ExAthena.UpgradeTest do
       # falls outside `> 0.4.0 and <= 0.4.0`.
       assert igniter.notices == []
       refute Map.has_key?(igniter.rewrite.sources, ".exathena/.gitignore")
+    end
+
+    test "0.12.0 -> 0.12.2 is a no-op (no migration in the exclusive range)" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("ex_athena.upgrade", ["0.12.0", "0.12.2"])
+
+      # The 0.12.0 migration's target is 0.12.0, which is outside
+      # `> 0.12.0 and <= 0.12.2`, so a within-0.12 bump emits nothing.
+      assert igniter.notices == []
     end
   end
 end


### PR DESCRIPTION
## Summary

Completes the igniter installer/upgrader for v0.12 and tidies the docs.

- **0.11→0.12 upgrader** (`mix ex_athena.upgrade`): adds the missing `upgrade_0_11_to_0_12/2` — a notice-only step explaining the TUI/web front-ends are now optional deps. This also **fixes a compile error**: the upgrade task referenced `upgrade_0_11_to_0_12/2` without defining it, which broke compilation for any consumer that has igniter.
- **Installer** (`mix ex_athena.install`) updates for v0.12.
- **Docs:** add `guides/gemini.md` to the docs extras, refresh `getting_started`, and document the installer/upgrader in the CHANGELOG.
- Tests for the upgrade + install tasks.

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [x] `mix test test/mix/tasks/ex_athena_upgrade_test.exs test/mix/tasks/ex_athena_install_test.exs` — 13 passing
- [x] full suite — 815 tests, 0 failures
- [x] `guides/gemini.md` exists (docs extras valid)