### PR TITLE
Size compaction budget from the model's real context window (n_ctx / llm_db) instead of static 200k

### DIFF
--- a/.artifacts/adr-1-derive-compaction-budget-from-llmdb.md
+++ b/.artifacts/adr-1-derive-compaction-budget-from-llmdb.md
@@ -1,0 +1,46 @@
+# ADR: Derive compaction budget from llm_db context limits
+
+**Status:** Accepted
+
+## Context
+
+`ExAthena.Providers.ReqLLM.capabilities/0` returns `max_tokens: 200_000` for every model regardless of the model's actual context window. The loop uses this value as the compaction budget, triggering compaction at ~120k tokens (60% of 200k). Local small-context models (Ollama / llama.cpp, typically 4k–32k) overflow their real window before compaction fires, causing silent truncation or provider errors.
+
+`llm_db` — already a transitive dependency via `req_llm` — carries `limits.context` per model, indexed by `{provider_atom, model_id}`. The fix reads this value to size the budget correctly.
+
+The `ExAthena.Provider` behaviour currently defines only a zero-arity `capabilities/0` callback, giving the provider no access to the resolved model or opts at capabilities-declaration time.
+
+## Decision
+
+1. **Add an optional `capabilities/1` callback** to the `ExAthena.Provider` behaviour. The callback accepts the per-call opts keyword list (which, after `Config.pop_provider!/1`, includes `:req_llm_provider_tag` and `:model`) so the provider can perform a model-aware catalog lookup.
+
+2. **Implement `capabilities/1` in `ReqLLM`** by calling `LLMDB.model(provider_atom, model_id)` and extracting `model.limits[:context]`. On any miss (model not in catalog, nil limits, non-positive context, unresolvable atom), return the base `capabilities/0` map unchanged.
+
+3. **Change the static fallback in `capabilities/0`** from `max_tokens: 200_000` to `max_tokens: 8_192`. This conservative value ensures that when neither llm_db nor a caller override supplies a context window, compaction fires early (at ~4.9k tokens) rather than at ~120k.
+
+4. **Update `Loop.build_initial_state/2`** to dispatch to `capabilities/1(opts)` when the provider exports it, falling back to `capabilities/0` for providers that only implement the original callback. The caller's `capabilities: %{max_tokens: N}` option remains the top priority via the existing `Map.merge`.
+
+5. **No changes to `maybe_compact/1` or `force_compact/1`**: they already read `state.capabilities[:max_tokens] || 128_000`; only the *source* of that value changes.
+
+6. **Add `compact_tool_schemas` to `ExAthena.Capabilities.t()`** typespec (it was already declared in `ReqLLM.capabilities/0` but missing from the type definition).
+
+## Priority chain (lowest → highest)
+
+| Priority | Source | Example |
+|---|---|---|
+| 1 (lowest) | `capabilities/0` static base | `max_tokens: 8_192` |
+| 2 | `capabilities/1` llm_db lookup | `max_tokens: 200_000` (claude-opus) |
+| 3 (highest) | Caller `capabilities:` opt | `capabilities: %{max_tokens: 4096}` |
+
+## Consequences
+
+### Positive
+- Compaction fires at the right threshold for small local models (e.g. 8192 × 0.6 = ~4915 tokens for unknown Ollama models vs ~120k previously).
+- Cloud models (Anthropic, OpenAI, Google) retain their real large context windows via llm_db.
+- Caller `capabilities:` override continues to win — no breaking change for existing users.
+- Full backward compatibility for custom `ExAthena.Provider` implementations that only implement `capabilities/0`.
+
+### Negative / trade-offs
+- Models configured via `Application.get_env` (not per-call opts) are absent from opts at capability-resolution time and therefore fall back to 8192. This is acceptable and conservative — sub-ticket 2 addresses runtime queries for local providers.
+- The `strip_provider_prefix` logic is duplicated between `build_model_spec/2` and `resolve_llmdb_context/1`. They operate at different abstraction layers (model spec building vs catalog lookup), so extraction is deferred to a third use case.
+- Tests that exercise the llm_db happy path require the catalog to be loaded (`LLMDB.load()` in setup), coupling those tests to the packaged snapshot.

--- a/.artifacts/adr-1-runtime-context-window-query-ollama-llamacpp-ets-cache.md
+++ b/.artifacts/adr-1-runtime-context-window-query-ollama-llamacpp-ets-cache.md
@@ -1,0 +1,30 @@
+# ADR: Runtime Context-Window Query for Ollama and llama.cpp with ETS Cache
+
+**Status:** Accepted
+
+## Context
+
+ExAthena's compaction budget is sized from `capabilities[:max_tokens]`. Sub-ticket 1 reads `llm_db` limits for known models, but local Ollama and llama.cpp models are not in the `llm_db` catalog (they use the generic `openai` tag pointing at a custom base_url). Without runtime querying, these models fall back to 8192, which may be smaller than the model's actual `n_ctx` (e.g. a model loaded with `--ctx-size 32768`).
+
+## Decision
+
+1. **Introduce `ExAthena.ContextWindow`** as a supervised GenServer. It owns an ETS table (`:ex_athena_context_window_cache`, `:set`, `:public`, `read_concurrency: true`) keyed by `{backend_atom, base_url, model_id}`.
+
+2. **Query endpoints:**
+   - Ollama: `POST {base_url}/api/show` → `model_info["<arch>.context_length"]` (find any key ending in `.context_length`)
+   - llama.cpp: `GET {base_url}/props` → `default_generation_settings.n_ctx`
+
+3. **Cache strategy:** ETS is read directly by callers (no GenServer roundtrip on hit). Cache misses serialize through `GenServer.call` with a double-check on entry (prevents duplicate HTTP requests when two callers miss simultaneously). HTTP timeout is 3 seconds. Errors are silent (`:error` → caller uses fallback). No TTL — model configs don't change at runtime.
+
+4. **Resolution tier:** sits between llm_db lookup and the 8192 fallback in `ReqLLM.capabilities/1`. Cloud providers (anthropic, openai, google) never reach this tier because llm_db covers them.
+
+5. **Defensive caller:** `lookup/1` wraps `GenServer.call` in `try/catch :exit` so that if the supervisor is not running (e.g. bare library use without starting the application), callers silently get `:error` and fall through to the 8192 fallback.
+
+## Consequences
+
+- **Positive:** Compaction now fires at the correct threshold for any Ollama/llama.cpp model, regardless of whether it's in llm_db. Context-length errors and silent truncation are eliminated for local deployments.
+- **Positive:** Cloud providers are unaffected — they resolve through llm_db before reaching the runtime query path.
+- **Positive:** After the first lookup per model, subsequent iterations in a loop pay zero HTTP cost (ETS read only).
+- **Neutral:** A new supervised process is added to the application. It is cheap (ETS table + idle GenServer) and always on.
+- **Neutral:** The HTTP query adds ~1-10ms latency to the first `capabilities/1` resolution for a local model. This happens once per run, not per iteration.
+- **Negative:** If the local server is unreachable at capabilities-resolution time, the query silently fails and falls back to 8192. The server being unreachable will be caught anyway when the first LLM call is made.

--- a/lib/ex_athena/application.ex
+++ b/lib/ex_athena/application.ex
@@ -41,7 +41,8 @@ defmodule ExAthena.Application do
       children ++
         [
           ExAthena.Sessions.Stores.InMemory,
-          ExAthena.Sessions.Stores.ETS
+          ExAthena.Sessions.Stores.ETS,
+          ExAthena.ContextWindow
         ]
 
     children =

--- a/lib/ex_athena/capabilities.ex
+++ b/lib/ex_athena/capabilities.ex
@@ -17,6 +17,7 @@ defmodule ExAthena.Capabilities do
           optional(:max_tokens) => pos_integer(),
           optional(:supports_resume) => boolean(),
           optional(:supports_system_prompt) => boolean(),
-          optional(:supports_temperature) => boolean()
+          optional(:supports_temperature) => boolean(),
+          optional(:compact_tool_schemas) => boolean()
         }
 end

--- a/lib/ex_athena/context_window.ex
+++ b/lib/ex_athena/context_window.ex
@@ -1,0 +1,163 @@
+defmodule ExAthena.ContextWindow do
+  @moduledoc false
+
+  use GenServer
+
+  @table :ex_athena_context_window_cache
+  @timeout_ms 3_000
+
+  @ollama_default "http://localhost:11434"
+  @llamacpp_default "http://localhost:8080"
+
+  def start_link(_opts), do: GenServer.start_link(__MODULE__, [], name: __MODULE__)
+
+  @spec lookup(keyword()) :: {:ok, pos_integer()} | :error
+  def lookup(opts) do
+    with backend when backend in [:ollama, :llamacpp] <-
+           Keyword.get(opts, :openai_compatible_backend),
+         model_raw when is_binary(model_raw) and model_raw != "" <-
+           Keyword.get(opts, :model) do
+      model = strip_provider_prefix(model_raw, Keyword.get(opts, :req_llm_provider_tag))
+      base_url = resolve_base_url(opts, backend)
+      key = {backend, base_url, model}
+
+      case ets_lookup(key) do
+        {:ok, _} = hit ->
+          hit
+
+        :miss ->
+          try do
+            GenServer.call(__MODULE__, {:fetch, backend, base_url, model, key}, @timeout_ms + 1_000)
+          catch
+            :exit, _ -> :error
+          end
+      end
+    else
+      _ -> :error
+    end
+  end
+
+  @impl GenServer
+  def init(_) do
+    ensure_table()
+    {:ok, %{}}
+  end
+
+  @impl GenServer
+  def handle_call({:fetch, backend, base_url, model, key}, _from, state) do
+    case ets_lookup(key) do
+      {:ok, _} = hit ->
+        {:reply, hit, state}
+
+      :miss ->
+        result =
+          case do_fetch(backend, base_url, model) do
+            {:ok, ctx} ->
+              :ets.insert(@table, {key, ctx})
+              {:ok, ctx}
+
+            :error ->
+              :error
+          end
+
+        {:reply, result, state}
+    end
+  end
+
+  defp ensure_table do
+    if :ets.whereis(@table) == :undefined do
+      :ets.new(@table, [:set, :public, :named_table, read_concurrency: true])
+    end
+  end
+
+  defp ets_lookup(key) do
+    case :ets.lookup(@table, key) do
+      [{^key, value}] -> {:ok, value}
+      [] -> :miss
+    end
+  end
+
+  defp do_fetch(:ollama, base_url, model), do: fetch_ollama(base_url, model)
+  defp do_fetch(:llamacpp, base_url, _model), do: fetch_llamacpp(base_url)
+
+  defp fetch_ollama(base_url, model) do
+    url = strip_openai_suffix(base_url) <> "/api/show"
+
+    case Req.post(url, json: %{"model" => model}, receive_timeout: @timeout_ms, retry: false) do
+      {:ok, %Req.Response{status: 200, body: body}} ->
+        extract_ollama_context(body)
+
+      {:ok, %Req.Response{}} ->
+        :error
+
+      {:error, _} ->
+        :error
+    end
+  end
+
+  defp fetch_llamacpp(base_url) do
+    url = strip_openai_suffix(base_url) <> "/props"
+
+    case Req.get(url, receive_timeout: @timeout_ms, retry: false) do
+      {:ok, %Req.Response{status: 200, body: body}} ->
+        case body do
+          %{"default_generation_settings" => %{"n_ctx" => n_ctx}}
+          when is_integer(n_ctx) and n_ctx > 0 ->
+            {:ok, n_ctx}
+
+          _ ->
+            :error
+        end
+
+      _ ->
+        :error
+    end
+  end
+
+  defp extract_ollama_context(%{"model_info" => model_info}) when is_map(model_info) do
+    case Enum.find_value(model_info, fn {k, v} ->
+           if String.ends_with?(k, ".context_length") and is_integer(v) and v > 0, do: v
+         end) do
+      nil -> :error
+      ctx -> {:ok, ctx}
+    end
+  end
+
+  defp extract_ollama_context(_), do: :error
+
+  defp resolve_base_url(opts, backend) do
+    default =
+      case backend do
+        :ollama -> configured_ollama_url()
+        :llamacpp -> configured_llamacpp_url()
+      end
+
+    strip_openai_suffix(Keyword.get(opts, :base_url, default))
+  end
+
+  defp configured_ollama_url do
+    :ex_athena
+    |> Application.get_env(:ollama, [])
+    |> Keyword.get(:base_url, @ollama_default)
+  end
+
+  defp configured_llamacpp_url do
+    :ex_athena
+    |> Application.get_env(:llamacpp, [])
+    |> Keyword.get(:base_url, @llamacpp_default)
+  end
+
+  defp strip_openai_suffix(url) when is_binary(url) do
+    url
+    |> String.trim_trailing("/")
+    |> String.replace_suffix("/v1", "")
+  end
+
+  defp strip_provider_prefix(model, nil), do: model
+  defp strip_provider_prefix(model, tag) when is_binary(tag) do
+    prefix = tag <> ":"
+    if String.starts_with?(model, prefix),
+      do: String.replace_prefix(model, prefix, ""),
+      else: model
+  end
+end

--- a/lib/ex_athena/context_window.ex
+++ b/lib/ex_athena/context_window.ex
@@ -27,7 +27,11 @@ defmodule ExAthena.ContextWindow do
 
         :miss ->
           try do
-            GenServer.call(__MODULE__, {:fetch, backend, base_url, model, key}, @timeout_ms + 1_000)
+            GenServer.call(
+              __MODULE__,
+              {:fetch, backend, base_url, model, key},
+              @timeout_ms + 1_000
+            )
           catch
             :exit, _ -> :error
           end
@@ -43,6 +47,12 @@ defmodule ExAthena.ContextWindow do
     {:ok, %{}}
   end
 
+  # Blocking HTTP is intentional: this call happens at most once per
+  # (backend, base_url, model) tuple across the process lifetime — subsequent
+  # calls hit the ETS cache directly and never reach the GenServer. Serialising
+  # through the GenServer also prevents duplicate HTTP requests when two callers
+  # race on the same key. The 3 s HTTP timeout is well within the 4 s
+  # GenServer call timeout set by the caller.
   @impl GenServer
   def handle_call({:fetch, backend, base_url, model, key}, _from, state) do
     case ets_lookup(key) do
@@ -71,9 +81,13 @@ defmodule ExAthena.ContextWindow do
   end
 
   defp ets_lookup(key) do
-    case :ets.lookup(@table, key) do
-      [{^key, value}] -> {:ok, value}
-      [] -> :miss
+    try do
+      case :ets.lookup(@table, key) do
+        [{^key, value}] -> {:ok, value}
+        [] -> :miss
+      end
+    rescue
+      ArgumentError -> :miss
     end
   end
 
@@ -154,8 +168,10 @@ defmodule ExAthena.ContextWindow do
   end
 
   defp strip_provider_prefix(model, nil), do: model
+
   defp strip_provider_prefix(model, tag) when is_binary(tag) do
     prefix = tag <> ":"
+
     if String.starts_with?(model, prefix),
       do: String.replace_prefix(model, prefix, ""),
       else: model

--- a/lib/ex_athena/loop.ex
+++ b/lib/ex_athena/loop.ex
@@ -511,7 +511,11 @@ defmodule ExAthena.Loop do
 
     with :ok <- validate_tools(tool_specs) do
       capabilities =
-        provider_mod.capabilities()
+        if function_exported?(provider_mod, :capabilities, 1) do
+          provider_mod.capabilities(opts)
+        else
+          provider_mod.capabilities()
+        end
         |> Map.merge(Keyword.get(opts, :capabilities, %{}))
 
       memory_messages = resolve_memory(cwd, opts)

--- a/lib/ex_athena/provider.ex
+++ b/lib/ex_athena/provider.ex
@@ -35,5 +35,15 @@ defmodule ExAthena.Provider do
   @doc "Static capability map for this provider."
   @callback capabilities() :: Capabilities.t()
 
-  @optional_callbacks [stream: 3]
+  @doc """
+  Model-aware capability map. Receives the per-call opts (includes
+  `:req_llm_provider_tag` and `:model`) so the provider can resolve
+  the actual context window from a catalog (e.g. llm_db) and return
+  a precise `max_tokens` instead of a static default.
+
+  When not implemented, the loop falls back to `capabilities/0`.
+  """
+  @callback capabilities(opts :: keyword()) :: Capabilities.t()
+
+  @optional_callbacks [stream: 3, capabilities: 1]
 end

--- a/lib/ex_athena/providers/req_llm.ex
+++ b/lib/ex_athena/providers/req_llm.ex
@@ -54,12 +54,22 @@ defmodule ExAthena.Providers.ReqLLM do
       streaming: true,
       json_mode: true,
       structured_output: true,
-      max_tokens: 200_000,
+      max_tokens: 8_192,
       supports_resume: false,
       supports_system_prompt: true,
       supports_temperature: true,
       compact_tool_schemas: true
     }
+  end
+
+  @impl ExAthena.Provider
+  def capabilities(opts) do
+    base = capabilities()
+
+    case resolve_llmdb_context(opts) do
+      {:ok, context} -> %{base | max_tokens: context}
+      :error -> base
+    end
   end
 
   @impl ExAthena.Provider
@@ -755,5 +765,34 @@ defmodule ExAthena.Providers.ReqLLM do
 
   defp to_error(reason) do
     Error.new(:server_error, inspect(reason), provider: :req_llm, raw: reason)
+  end
+
+  # ── llm_db context resolution ─────────────────────────────────────
+
+  defp resolve_llmdb_context(opts) do
+    with tag when is_binary(tag) and tag != "" <- Keyword.get(opts, :req_llm_provider_tag),
+         {:ok, provider_atom} <- safe_to_atom(tag),
+         model_str when is_binary(model_str) and model_str != "" <-
+           Keyword.get(opts, :model, ""),
+         model_id = strip_provider_prefix(model_str, tag),
+         {:ok, %LLMDB.Model{limits: limits}} <- LLMDB.model(provider_atom, model_id),
+         context when is_integer(context) and context > 0 <- (limits || %{})[:context] do
+      {:ok, context}
+    else
+      _ -> :error
+    end
+  end
+
+  defp safe_to_atom(str) do
+    {:ok, String.to_existing_atom(str)}
+  rescue
+    ArgumentError -> :error
+  end
+
+  defp strip_provider_prefix(model, tag) do
+    prefix = tag <> ":"
+    if String.starts_with?(model, prefix),
+      do: String.replace_prefix(model, prefix, ""),
+      else: model
   end
 end

--- a/lib/ex_athena/providers/req_llm.ex
+++ b/lib/ex_athena/providers/req_llm.ex
@@ -67,8 +67,14 @@ defmodule ExAthena.Providers.ReqLLM do
     base = capabilities()
 
     case resolve_llmdb_context(opts) do
-      {:ok, context} -> %{base | max_tokens: context}
-      :error -> base
+      {:ok, context} ->
+        %{base | max_tokens: context}
+
+      :error ->
+        case ExAthena.ContextWindow.lookup(opts) do
+          {:ok, context} -> %{base | max_tokens: context}
+          :error -> base
+        end
     end
   end
 

--- a/lib/ex_athena/providers/req_llm.ex
+++ b/lib/ex_athena/providers/req_llm.ex
@@ -797,6 +797,7 @@ defmodule ExAthena.Providers.ReqLLM do
 
   defp strip_provider_prefix(model, tag) do
     prefix = tag <> ":"
+
     if String.starts_with?(model, prefix),
       do: String.replace_prefix(model, prefix, ""),
       else: model

--- a/test/ex_athena/context_window_test.exs
+++ b/test/ex_athena/context_window_test.exs
@@ -1,0 +1,298 @@
+defmodule ExAthena.ContextWindowTest do
+  use ExUnit.Case, async: true
+
+  alias ExAthena.ContextWindow
+
+  setup do
+    bypass = Bypass.open()
+    {:ok, bypass: bypass, base_url: "http://localhost:#{bypass.port}"}
+  end
+
+  describe "Ollama runtime fetch" do
+    test "returns context length on successful POST /api/show response",
+         %{bypass: bypass, base_url: base_url} do
+      model = "ollama-fetch-success-#{System.unique_integer([:positive])}"
+
+      Bypass.expect_once(bypass, "POST", "/api/show", fn conn ->
+        body =
+          Jason.encode!(%{
+            "model_info" => %{
+              "llama.context_length" => 4096
+            }
+          })
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, body)
+      end)
+
+      assert {:ok, 4096} =
+               ContextWindow.lookup(
+                 openai_compatible_backend: :ollama,
+                 model: model,
+                 base_url: base_url
+               )
+    end
+
+    test "parses any arch key ending in .context_length",
+         %{bypass: bypass, base_url: base_url} do
+      model = "ollama-fetch-arch-#{System.unique_integer([:positive])}"
+
+      Bypass.expect_once(bypass, "POST", "/api/show", fn conn ->
+        body =
+          Jason.encode!(%{
+            "model_info" => %{
+              "qwen2.context_length" => 8192
+            }
+          })
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, body)
+      end)
+
+      assert {:ok, 8192} =
+               ContextWindow.lookup(
+                 openai_compatible_backend: :ollama,
+                 model: model,
+                 base_url: base_url
+               )
+    end
+
+    test "strips /v1 suffix from base_url before hitting /api/show",
+         %{bypass: bypass, base_url: base_url} do
+      model = "ollama-fetch-strip-v1-#{System.unique_integer([:positive])}"
+
+      Bypass.expect_once(bypass, "POST", "/api/show", fn conn ->
+        body =
+          Jason.encode!(%{
+            "model_info" => %{"mistral.context_length" => 32768}
+          })
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, body)
+      end)
+
+      assert {:ok, 32768} =
+               ContextWindow.lookup(
+                 openai_compatible_backend: :ollama,
+                 model: model,
+                 base_url: base_url <> "/v1"
+               )
+    end
+
+    test "returns :error on 404",
+         %{bypass: bypass, base_url: base_url} do
+      model = "ollama-fetch-404-#{System.unique_integer([:positive])}"
+
+      Bypass.expect_once(bypass, "POST", "/api/show", fn conn ->
+        Plug.Conn.resp(conn, 404, "not found")
+      end)
+
+      assert :error =
+               ContextWindow.lookup(
+                 openai_compatible_backend: :ollama,
+                 model: model,
+                 base_url: base_url
+               )
+    end
+
+    test "returns :error on connection refused" do
+      model = "ollama-fetch-refused-#{System.unique_integer([:positive])}"
+
+      assert :error =
+               ContextWindow.lookup(
+                 openai_compatible_backend: :ollama,
+                 model: model,
+                 base_url: "http://127.0.0.1:1"
+               )
+    end
+
+    test "returns :error when model_info key is absent",
+         %{bypass: bypass, base_url: base_url} do
+      model = "ollama-fetch-no-model-info-#{System.unique_integer([:positive])}"
+
+      Bypass.expect_once(bypass, "POST", "/api/show", fn conn ->
+        body = Jason.encode!(%{"other" => "data"})
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, body)
+      end)
+
+      assert :error =
+               ContextWindow.lookup(
+                 openai_compatible_backend: :ollama,
+                 model: model,
+                 base_url: base_url
+               )
+    end
+
+    test "returns :error when no .context_length key found in model_info",
+         %{bypass: bypass, base_url: base_url} do
+      model = "ollama-fetch-no-ctx-key-#{System.unique_integer([:positive])}"
+
+      Bypass.expect_once(bypass, "POST", "/api/show", fn conn ->
+        body =
+          Jason.encode!(%{
+            "model_info" => %{
+              "llama.some_other_field" => 42
+            }
+          })
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, body)
+      end)
+
+      assert :error =
+               ContextWindow.lookup(
+                 openai_compatible_backend: :ollama,
+                 model: model,
+                 base_url: base_url
+               )
+    end
+  end
+
+  describe "llama.cpp runtime fetch" do
+    test "returns n_ctx on successful GET /props response",
+         %{bypass: bypass, base_url: base_url} do
+      model = "llamacpp-fetch-success-#{System.unique_integer([:positive])}"
+
+      Bypass.expect_once(bypass, "GET", "/props", fn conn ->
+        body =
+          Jason.encode!(%{
+            "default_generation_settings" => %{
+              "n_ctx" => 2048
+            }
+          })
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, body)
+      end)
+
+      assert {:ok, 2048} =
+               ContextWindow.lookup(
+                 openai_compatible_backend: :llamacpp,
+                 model: model,
+                 base_url: base_url
+               )
+    end
+
+    test "returns :error on connection refused" do
+      model = "llamacpp-fetch-refused-#{System.unique_integer([:positive])}"
+
+      assert :error =
+               ContextWindow.lookup(
+                 openai_compatible_backend: :llamacpp,
+                 model: model,
+                 base_url: "http://127.0.0.1:1"
+               )
+    end
+
+    test "returns :error when body lacks default_generation_settings.n_ctx",
+         %{bypass: bypass, base_url: base_url} do
+      model = "llamacpp-fetch-no-n-ctx-#{System.unique_integer([:positive])}"
+
+      Bypass.expect_once(bypass, "GET", "/props", fn conn ->
+        body = Jason.encode!(%{"default_generation_settings" => %{"other" => 1}})
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, body)
+      end)
+
+      assert :error =
+               ContextWindow.lookup(
+                 openai_compatible_backend: :llamacpp,
+                 model: model,
+                 base_url: base_url
+               )
+    end
+  end
+
+  describe "caching" do
+    test "returns cached value on second call without hitting server",
+         %{bypass: bypass, base_url: base_url} do
+      model = "cache-hit-#{System.unique_integer([:positive])}"
+
+      Bypass.expect_once(bypass, "POST", "/api/show", fn conn ->
+        body =
+          Jason.encode!(%{"model_info" => %{"phi3.context_length" => 16384}})
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, body)
+      end)
+
+      opts = [openai_compatible_backend: :ollama, model: model, base_url: base_url]
+
+      assert {:ok, 16384} = ContextWindow.lookup(opts)
+      # Second call must return cached value; Bypass.expect_once ensures only one HTTP request
+      assert {:ok, 16384} = ContextWindow.lookup(opts)
+    end
+
+    test "different {backend, base_url, model} tuples are cached independently",
+         %{bypass: bypass, base_url: base_url} do
+      model_a = "cache-independent-a-#{System.unique_integer([:positive])}"
+      model_b = "cache-independent-b-#{System.unique_integer([:positive])}"
+
+      # Use agent to track how many requests were served
+      {:ok, agent} = Agent.start_link(fn -> 0 end)
+
+      Bypass.expect(bypass, "POST", "/api/show", fn conn ->
+        {:ok, raw_body, conn} = Plug.Conn.read_body(conn)
+        %{"model" => req_model} = Jason.decode!(raw_body)
+
+        Agent.update(agent, &(&1 + 1))
+
+        ctx =
+          cond do
+            req_model == model_a -> 1024
+            req_model == model_b -> 2048
+            true -> 512
+          end
+
+        body = Jason.encode!(%{"model_info" => %{"llama.context_length" => ctx}})
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, body)
+      end)
+
+      opts_a = [openai_compatible_backend: :ollama, model: model_a, base_url: base_url]
+      opts_b = [openai_compatible_backend: :ollama, model: model_b, base_url: base_url]
+
+      assert {:ok, 1024} = ContextWindow.lookup(opts_a)
+      assert {:ok, 2048} = ContextWindow.lookup(opts_b)
+
+      # Second calls must return cached values — server still gets only 2 total requests
+      assert {:ok, 1024} = ContextWindow.lookup(opts_a)
+      assert {:ok, 2048} = ContextWindow.lookup(opts_b)
+
+      assert Agent.get(agent, & &1) == 2
+    end
+  end
+
+  describe "non-local providers" do
+    test "returns :error when openai_compatible_backend is not :ollama or :llamacpp" do
+      assert :error =
+               ContextWindow.lookup(
+                 openai_compatible_backend: :openai,
+                 model: "gpt-4",
+                 base_url: "https://api.openai.com"
+               )
+    end
+
+    test "returns :error when model key is missing" do
+      assert :error =
+               ContextWindow.lookup(
+                 openai_compatible_backend: :ollama,
+                 base_url: "http://localhost:11434"
+               )
+    end
+  end
+
+end

--- a/test/ex_athena/context_window_test.exs
+++ b/test/ex_athena/context_window_test.exs
@@ -294,5 +294,4 @@ defmodule ExAthena.ContextWindowTest do
                )
     end
   end
-
 end

--- a/test/ex_athena/loop_test.exs
+++ b/test/ex_athena/loop_test.exs
@@ -10,6 +10,36 @@ defmodule ExAthena.LoopTest do
   alias ExAthena.{Loop, Response}
   alias ExAthena.Messages.ToolCall
 
+  defmodule CapabilitiesV1Provider do
+    @behaviour ExAthena.Provider
+
+    def capabilities do
+      %{
+        native_tool_calls: true,
+        streaming: false,
+        json_mode: false,
+        structured_output: false,
+        max_tokens: 500
+      }
+    end
+
+    def capabilities(opts) do
+      parent = Process.get(:caps1_test_parent)
+      if parent, do: send(parent, {:caps1_called, opts})
+      %{capabilities() | max_tokens: 99_999}
+    end
+
+    def query(_request, _opts) do
+      {:ok,
+       %ExAthena.Response{
+         text: "caps1 response",
+         tool_calls: [],
+         finish_reason: :stop,
+         provider: :caps_v1
+       }}
+    end
+  end
+
   defp script(responses) do
     counter = :counters.new(1, [:atomics])
 
@@ -290,5 +320,37 @@ defmodule ExAthena.LoopTest do
              )
 
     assert result.text == "saw image"
+  end
+
+  test "loop dispatches capabilities/1 when provider exports it", %{dir: dir} do
+    Process.put(:caps1_test_parent, self())
+
+    assert {:ok, result} =
+             Loop.run("hi",
+               provider: CapabilitiesV1Provider,
+               model: "test-model",
+               cwd: dir,
+               tools: []
+             )
+
+    assert result.text == "caps1 response"
+    assert_received {:caps1_called, opts}
+    assert Keyword.get(opts, :model) == "test-model"
+  end
+
+  test "loop falls back to capabilities/0 for providers without capabilities/1", %{dir: dir} do
+    responses = [
+      %Response{text: "fallback ok", tool_calls: [], finish_reason: :stop, provider: :mock}
+    ]
+
+    assert {:ok, result} =
+             Loop.run("hi",
+               provider: :mock,
+               mock: [responder: script(responses)],
+               cwd: dir,
+               tools: []
+             )
+
+    assert result.text == "fallback ok"
   end
 end

--- a/test/ex_athena/providers/req_llm_test.exs
+++ b/test/ex_athena/providers/req_llm_test.exs
@@ -4,7 +4,7 @@ defmodule ExAthena.Providers.ReqLLMTest do
   alias ExAthena.Config
   alias ExAthena.Providers.ReqLLM, as: Adapter
 
-  describe "capabilities/0" do
+  describe "capabilities/0 conservative fallback" do
     test "declares streaming + native tool-calls + json mode" do
       caps = Adapter.capabilities()
       assert caps.streaming
@@ -14,6 +14,56 @@ defmodule ExAthena.Providers.ReqLLMTest do
 
     test "declares structured_output: true" do
       assert Adapter.capabilities().structured_output == true
+    end
+
+    test "returns max_tokens: 8_192 as conservative fallback" do
+      assert Adapter.capabilities().max_tokens == 8_192
+    end
+  end
+
+  describe "capabilities/1 llm_db resolution" do
+    setup do
+      LLMDB.load()
+      :ok
+    end
+
+    test "with empty opts returns conservative fallback" do
+      assert Adapter.capabilities([]).max_tokens == 8_192
+    end
+
+    test "with provider tag but no model returns conservative fallback" do
+      opts = [req_llm_provider_tag: "openai"]
+      assert Adapter.capabilities(opts).max_tokens == 8_192
+    end
+
+    test "with a model not in llm_db returns conservative fallback" do
+      opts = [model: "custom-local:7b", req_llm_provider_tag: "openai"]
+      assert Adapter.capabilities(opts).max_tokens == 8_192
+    end
+
+    test "uses llm_db context for known openai model" do
+      opts = [model: "gpt-4o-mini", req_llm_provider_tag: "openai"]
+      caps = Adapter.capabilities(opts)
+      {:ok, model} = LLMDB.model(:openai, "gpt-4o-mini")
+      assert caps.max_tokens == model.limits[:context]
+    end
+
+    test "uses llm_db context for known anthropic model" do
+      opts = [model: "claude-opus-4-5", req_llm_provider_tag: "anthropic"]
+      caps = Adapter.capabilities(opts)
+      {:ok, model} = LLMDB.model(:anthropic, "claude-opus-4-5")
+      assert caps.max_tokens == model.limits[:context]
+      assert caps.max_tokens >= 100_000
+    end
+
+    test "preserves all other capability flags from capabilities/0" do
+      opts = [model: "gpt-4o-mini", req_llm_provider_tag: "openai"]
+      caps = Adapter.capabilities(opts)
+      assert caps.streaming == true
+      assert caps.native_tool_calls == true
+      assert caps.json_mode == true
+      assert caps.structured_output == true
+      assert caps.compact_tool_schemas == true
     end
   end
 


### PR DESCRIPTION
### Summary

This PR significantly improves context awareness for ExAthena by dynamically determining the actual context window size for the configured LLM, rather than relying on the outdated, hardcoded assumption of 200k tokens.

This fix ensures that context compaction mechanisms fire at appropriate points within the model's true capacity, preventing silent truncation, context-length overflow errors, and improving the reliability of local and smaller-context models.

### Key Changes

*   **Introduced `ExAthena.ContextWindow`:** A new `GenServer` module is added to handle the retrieval and caching of per-model context window sizes.
*   **Dynamic Window Resolution:** The logic implements specific fetching strategies for various providers:
    *   Reads predefined `limits.context` from `llm_db` for known models.
    *   Queries local providers (e.g., Ollama, llama.cpp) APIs at runtime (`/api/show` or `/props`) to fetch their actual `n_ctx`.
    *   Uses a conservative fallback default if no actual window size can be determined.
*   **Updated Core Logic:** The main ExAthena loop and capability setup now utilize the resolved context window (`N`) in place of the static 200k default, specifically for calculating the compaction budget (`compact_at`).
*   **Code Cleanup:** Updated `ExAthena.Capabilities` to include the `:compact_tool_schemas` option, ensuring a consistent interface for capability declaration.

### Implementation Details

*   **Reliability Improvement:** The context window is fetched and cached using an ETS table keyed by `{backend, base_url, model}`, ensuring that network lookups are performed only once per unique (provider, model) combination, even under load.
*   **Prioritization:** The current mechanism remains preserved: an explicitly set `capabilities` override will always take precedence over the dynamically resolved context window, maintaining backward compatibility for explicit client settings.
*   **Scope of Change:** The fix focuses solely on adapting the *budget* for context compaction. The existing `$chars/4` token estimation heuristic for calculating the budget is considered acceptable and was not modified.
*   **Scope:** Cloud provider services (OpenAI, Anthropic, Gemini) continue to utilize their large or specified context limits, ensuring no regression for large-context environments.

Closes https://github.com/udin-io/ex_athena/issues/102