### PR TITLE
Per-iteration / no-progress hook for mid-loop intervention (inject/continue/halt)

### DIFF
--- a/guides/hooks_reference.md
+++ b/guides/hooks_reference.md
@@ -38,7 +38,7 @@ returns one of:
 
 ## Catalog
 
-`ExAthena.Hooks.events/0` enumerates all 17 supported events.
+`ExAthena.Hooks.events/0` enumerates all 18 supported events.
 
 ### Session lifecycle
 
@@ -53,12 +53,15 @@ returns one of:
 |---|---|---|
 | `:UserPromptSubmit` | Before the first iteration | `%{prompt, session_id, parent_session_id}` |
 | `:ChatParams` | Before every provider call inside `Modes.ReAct.iterate/1` | `%{request, session_id, messages}` |
+| `:PreIteration` | Before every `mode.iterate/1` call | `%{iteration, unproductive_iterations, fingerprint, session_id}` |
 | `:Stop` | Run finished cleanly (`finish_reason == :stop`) | `%{session_id, finish_reason: :stop, result}` |
 | `:StopFailure` | Run finished with any error finish_reason | `%{session_id, finish_reason, result}` |
 
 `UserPromptSubmit` honours `{:transform, prompt}` to rewrite the
 incoming user message; `ChatParams` honours `{:inject, msg}` to add
-context just before a provider call.
+context just before a provider call; `PreIteration` honours
+`{:inject, msg}` to nudge the model mid-loop and `{:halt, reason}` to
+stop cleanly before the iteration runs.
 
 ### Per-tool
 
@@ -129,6 +132,26 @@ end
 
 ExAthena.run("...", tools: :all, hooks: %{ChatParams: [inject_metadata]})
 ```
+
+### Inject a nudge after N stalled iterations
+
+```elixir
+nudge = fn %{unproductive_iterations: n}, _id ->
+  if n >= 2 do
+    {:inject,
+     ExAthena.Messages.user(
+       "You have enough context. Produce your deliverable now and call finish."
+     )}
+  else
+    :ok
+  end
+end
+
+ExAthena.run("...", tools: :all, hooks: %{PreIteration: [nudge]})
+```
+
+Return `{:halt, reason}` instead to stop the loop cleanly without
+producing the next iteration at all.
 
 ### Rewrite a user prompt with project conventions
 

--- a/lib/ex_athena/hooks.ex
+++ b/lib/ex_athena/hooks.ex
@@ -32,7 +32,7 @@ defmodule ExAthena.Hooks do
   ## Catalog of supported events
 
     * Session: `:SessionStart`, `:SessionEnd`
-    * Per-turn: `:UserPromptSubmit`, `:ChatParams`, `:Stop`, `:StopFailure`
+    * Per-turn: `:UserPromptSubmit`, `:ChatParams`, `:PreIteration`, `:Stop`, `:StopFailure`
     * Per-tool: `:PreToolUse`, `:PostToolUse`, `:PostToolUseFailure`,
       `:PermissionRequest`, `:PermissionDenied`, `:ToolDenied`
     * Subagent: `:SubagentStart`, `:SubagentStop`
@@ -67,6 +67,7 @@ defmodule ExAthena.Hooks do
       :SessionEnd,
       :UserPromptSubmit,
       :ChatParams,
+      :PreIteration,
       :Stop,
       :StopFailure,
       :PreToolUse,

--- a/lib/ex_athena/loop.ex
+++ b/lib/ex_athena/loop.ex
@@ -144,21 +144,29 @@ defmodule ExAthena.Loop do
           {:ok, state} ->
             Events.emit(state.on_event, {:iteration, state.iterations})
 
-            case state.mode.iterate(state) do
-              {:continue, new_state} ->
-                new_state = update_progress_tracking(state, new_state)
-                loop(%{new_state | iterations: new_state.iterations + 1})
-
-              {:halt, new_state} ->
-                new_state
-
-              {:error, :error_prompt_too_long} ->
-                handle_prompt_too_long(state)
-
-              {:error, reason} ->
+            case run_pre_iteration_hook(state) do
+              {:halt, reason} ->
                 state
                 |> Map.put(:halted_reason, reason)
-                |> set_finish_reason(:error_during_execution)
+                |> set_finish_reason(:error_halted)
+
+              {:ok, state} ->
+                case state.mode.iterate(state) do
+                  {:continue, new_state} ->
+                    new_state = update_progress_tracking(state, new_state)
+                    loop(%{new_state | iterations: new_state.iterations + 1})
+
+                  {:halt, new_state} ->
+                    new_state
+
+                  {:error, :error_prompt_too_long} ->
+                    handle_prompt_too_long(state)
+
+                  {:error, reason} ->
+                    state
+                    |> Map.put(:halted_reason, reason)
+                    |> set_finish_reason(:error_during_execution)
+                end
             end
 
           {:error, reason} ->
@@ -355,6 +363,23 @@ defmodule ExAthena.Loop do
 
   defp set_finish_reason(%State{} = state, reason) do
     put_in(state.meta[:finish_reason], reason)
+  end
+
+  # ── PreIteration hook ─────────────────────────────────────────────
+
+  defp run_pre_iteration_hook(%State{} = state) do
+    payload = %{
+      iteration: state.iterations,
+      unproductive_iterations: state.unproductive_iterations,
+      fingerprint: state.last_tool_fingerprint || [],
+      session_id: state.session_id
+    }
+
+    case ExAthena.Hooks.run_lifecycle_with_outputs(state.hooks, :PreIteration, payload) do
+      %{halt: {:halt, reason}} -> {:halt, reason}
+      %{injects: [_ | _] = msgs} -> {:ok, %{state | messages: state.messages ++ msgs}}
+      _ -> {:ok, state}
+    end
   end
 
   # ── No-progress tracking ──────────────────────────────────────────

--- a/test/ex_athena/loop/hooks_modes_test.exs
+++ b/test/ex_athena/loop/hooks_modes_test.exs
@@ -291,6 +291,179 @@ defmodule ExAthena.Loop.HooksModesTest do
     end
   end
 
+  describe "PreIteration hook" do
+    test "catalog includes :PreIteration" do
+      assert :PreIteration in ExAthena.Hooks.events()
+    end
+
+    test "fires every iteration with correct payload" do
+      parent = self()
+      ref = make_ref()
+
+      hooks = %{
+        PreIteration: [
+          fn p, _ ->
+            send(parent, {ref, :pre_iter, p})
+            :ok
+          end
+        ]
+      }
+
+      counter = :counters.new(1, [:atomics])
+
+      responder = fn _req ->
+        :counters.add(counter, 1, 1)
+
+        case :counters.get(counter, 1) do
+          n when n < 3 ->
+            %Response{
+              text: "step #{n}",
+              tool_calls: [
+                %ToolCall{id: "c#{n}", name: "read", arguments: %{"path" => "/f#{n}"}}
+              ],
+              finish_reason: :tool_calls,
+              provider: :mock
+            }
+
+          _ ->
+            %Response{text: "done", finish_reason: :stop, provider: :mock}
+        end
+      end
+
+      {:ok, _} =
+        Loop.run("go",
+          provider: :mock,
+          mock: [responder: responder],
+          tools: [ExAthena.Tools.Read],
+          hooks: hooks,
+          memory: false
+        )
+
+      assert_receive {^ref, :pre_iter, %{iteration: 0, unproductive_iterations: 0}}
+      assert_receive {^ref, :pre_iter, %{iteration: 1}}
+      assert_receive {^ref, :pre_iter, %{iteration: 2}}
+    end
+
+    test "{:inject, msg} adds a message before the model sees the next turn" do
+      injected = %Message{
+        role: :system,
+        content: "nudge from PreIteration",
+        name: "pre-iter-inject"
+      }
+
+      hooks = %{
+        PreIteration: [fn _p, _ -> {:inject, injected} end]
+      }
+
+      {:ok, result} =
+        Loop.run("hi",
+          provider: :mock,
+          mock: [responder: single_text("ok")],
+          tools: [],
+          hooks: hooks,
+          memory: false
+        )
+
+      assert Enum.any?(result.messages, fn m ->
+               m.role == :system and m.name == "pre-iter-inject"
+             end)
+    end
+
+    test "{:halt, reason} stops with finish_reason: :error_halted" do
+      hooks = %{
+        PreIteration: [
+          fn %{iteration: iter}, _ ->
+            if iter == 1, do: {:halt, :my_reason}, else: :ok
+          end
+        ]
+      }
+
+      responder = fn _req ->
+        %Response{
+          text: "thinking",
+          tool_calls: [%ToolCall{id: "c1", name: "read", arguments: %{"path" => "/x"}}],
+          finish_reason: :tool_calls,
+          provider: :mock
+        }
+      end
+
+      {:ok, result} =
+        Loop.run("hi",
+          provider: :mock,
+          mock: [responder: responder],
+          tools: [ExAthena.Tools.Read],
+          hooks: hooks,
+          memory: false
+        )
+
+      assert result.finish_reason == :error_halted
+      assert result.halted_reason == :my_reason
+    end
+
+    test ":ok / :continue allows normal completion" do
+      hooks = %{
+        PreIteration: [fn _p, _ -> :ok end]
+      }
+
+      {:ok, result} =
+        Loop.run("hi",
+          provider: :mock,
+          mock: [responder: single_text("done")],
+          tools: [],
+          hooks: hooks,
+          memory: false
+        )
+
+      assert result.finish_reason == :stop
+    end
+
+    test "unproductive_iterations increments in payload and hook can halt before :error_no_progress" do
+      parent = self()
+      ref = make_ref()
+
+      hooks = %{
+        PreIteration: [
+          fn p, _ ->
+            send(parent, {ref, :pre_iter, p})
+
+            if p.unproductive_iterations >= 2 do
+              {:halt, :stalled}
+            else
+              :ok
+            end
+          end
+        ]
+      }
+
+      responder = fn _req ->
+        %Response{
+          text: "",
+          tool_calls: [%ToolCall{id: "c1", name: "read", arguments: %{"path" => "/same"}}],
+          finish_reason: :tool_calls,
+          provider: :mock
+        }
+      end
+
+      {:ok, result} =
+        Loop.run("hi",
+          provider: :mock,
+          mock: [responder: responder],
+          tools: [ExAthena.Tools.Read],
+          hooks: hooks,
+          memory: false,
+          max_unproductive_iterations: 5
+        )
+
+      assert result.finish_reason == :error_halted
+      assert result.halted_reason == :stalled
+
+      assert_receive {^ref, :pre_iter, %{unproductive_iterations: 0}}
+      assert_receive {^ref, :pre_iter, %{unproductive_iterations: 0}}
+      assert_receive {^ref, :pre_iter, %{unproductive_iterations: 1}}
+      assert_receive {^ref, :pre_iter, %{unproductive_iterations: 2}}
+    end
+  end
+
   describe "permission modes" do
     alias ExAthena.{Permissions, ToolContext}
 

--- a/test/ex_athena/loop/hooks_modes_test.exs
+++ b/test/ex_athena/loop/hooks_modes_test.exs
@@ -49,6 +49,7 @@ defmodule ExAthena.Loop.HooksModesTest do
       assert :PermissionDenied in events
       assert :SubagentStart in events
       assert :SubagentStop in events
+      assert :PreIteration in events
       assert :PreCompact in events
       assert :PreCompactStage in events
       assert :PostCompact in events


### PR DESCRIPTION
This PR introduces a `PreIteration` hook to enhance the resilience and control of iterative loops, particularly when detecting and handling stalled progress (no-progress scenarios).

Previously, when a loop stalled (e.g., due to weak model exploration), termination was simply reported as an error, preventing consumers from gracefully intervening mid-stream. This feature provides a vital mechanism for consumers to observe per-iteration progress and intervene with guidance, allowing models to be "nudged" back on track without restarting the entire process.

### Key Changes

*   **New Hook Introduced:** Implemented the `:PreIteration` hook, which fires before every iteration (or when no-progress is detected).
*   **Hook Context:** The hook receives the current iteration index, no-progress counter, and the current progress fingerprint.
*   **Intervention Flow:** The hook's return value can now steer the loop's execution:
    *   `{:inject, msg}`: Inserts a specific instructional message into the model's context for the current iteration (a "nudge").
    *   `{:halt, reason}`: Stops the loop cleanly and explicitly.
    *   `:continue` (or default return): Allows the loop to proceed as normal.
*   **Documentation:** Updated `guides/hooks_reference.md` and `lib/ex_athena/hooks.ex` to correctly recognize and document the new `PreIteration` hook and its specific usage rules.
*   **Core Logic Update:** Modified `ExAthena.Loop.run/0` (in `lib/ex_athena/loop.ex`) to execute the `PreIteration` hook synchronously before attempting `state.mode.iterate/1`, respecting any directive (`:halt` or `:inject`) returned by the consumer.

### Implementation Details

The implementation stabilizes the loop execution flow by wrapping the core iteration logic. If a consumer hook detects stall conditions, it can now influence the session state *before* the model generates its next output, providing surgical control over the iterative process. This aligns the local/local backend with the existing mid-loop reprompting capabilities of other consumer backends.

Closes https://github.com/udin-io/ex_athena/issues/106