### PR TITLE
Native structured phase/task-completion signal (finish/submit tool or response_format) for reliable termination across providers

### DIFF
--- a/.artifacts/adr-1-finish-tool-structured-phase-completion.md
+++ b/.artifacts/adr-1-finish-tool-structured-phase-completion.md
@@ -1,0 +1,67 @@
+# ADR: Built-in `finish` Tool for Structured Phase/Task Completion
+
+## Status
+Accepted
+
+## Context
+
+Consumers (e.g. `udin_code`) need a reliable, provider-agnostic signal that
+the agent has produced its deliverable and the current phase is done. The loop
+previously terminated only on:
+
+- Tool exhaustion (model returns plain text → `:stop`)
+- Error caps (`:error_max_turns`, `:error_no_progress`, etc.)
+
+The `udin_code` client bolted a free-text sentinel (`~~~phase_complete~~~`)
+onto the prompt for non-Claude/local models, but weak local models (qwen3.5
+via Ollama) frequently never emit it, causing the loop to run indefinitely.
+
+## Decision
+
+Add a built-in `finish` tool (`ExAthena.Tools.Finish`) that the model calls to
+declare completion. The tool:
+
+1. Accepts optional `deliverable` and `summary` arguments.
+2. Returns `{:halt, {:submitted, deliverable}}` to the loop kernel.
+3. The loop kernel detects this specific halt reason in `to_result/2`,
+   reclassifies it as `finish_reason: :submitted` (a success subtype), and
+   surfaces the deliverable on `Result.deliverable`.
+
+A new `:submitted` termination subtype is added to `ExAthena.Loop.Terminations`:
+- `success?(:submitted) → true`
+- `error?(:submitted) → false`
+- `category(:submitted) → :success`
+
+A `{:submitted, deliverable}` event is emitted to `on_event` just before
+`{:done, result}` so streaming consumers can react immediately.
+
+The `Result.deliverable` field carries the payload. `Result.halted_reason`
+is set to `nil` for `:submitted` (consistent with its documented semantics:
+"nil for all terminations except `:error_halted`").
+
+## Alternatives considered
+
+**Option B — `response_format` / structured output**: Requires the provider to
+support structured output natively. Degrades silently on providers that ignore
+`response_format`. The `finish` tool works wherever tool calls are supported.
+
+**Free-text sentinel in the prompt**: Already proven fragile for weak local
+models. Text sentinels are parsing heuristics; tool calls are structural
+contracts.
+
+**Per-consumer halt hook**: Works but pushes the problem to every consumer
+rather than solving it once in the library.
+
+## Consequences
+
+- The finish tool is in `@builtins`, so it is available to all loops that use
+  the default `:all` tool set. Consumers who do not want it can exclude it
+  via `tools: [...]` without `ExAthena.Tools.Finish`.
+- `fire_terminal_hooks` treats `:submitted` like `:stop` — it fires the
+  `:Stop` lifecycle hook, not `:StopFailure`. This lets consumers attach
+  cleanup/notification logic to successful completions uniformly.
+- `Result.success?/1` and `Result.category/1` both treat `:submitted` as
+  success, so existing retry classifiers continue to work correctly.
+- Consumers migrate from free-text sentinels to `tools: [ExAthena.Tools.Finish]`
+  plus a system-prompt instruction; they then check `result.finish_reason ==
+  :submitted` and `result.deliverable` instead of parsing text.

--- a/lib/ex_athena/loop.ex
+++ b/lib/ex_athena/loop.ex
@@ -445,7 +445,14 @@ defmodule ExAthena.Loop do
   defp to_result({:error, _} = err, _), do: err
 
   defp to_result(%State{} = state, started_at) do
-    finish_reason = state.meta[:finish_reason] || :stop
+    raw_finish_reason = state.meta[:finish_reason] || :stop
+
+    {finish_reason, deliverable, halted_reason} =
+      case {raw_finish_reason, state.halted_reason} do
+        {:error_halted, {:submitted, d}} -> {:submitted, d, nil}
+        {reason, hr} -> {reason, nil, hr}
+      end
+
     final_text = extract_final_text(state)
 
     duration_ms = System.monotonic_time(:millisecond) - started_at
@@ -454,8 +461,9 @@ defmodule ExAthena.Loop do
       text: final_text,
       messages: state.messages,
       finish_reason: finish_reason,
-      halted_reason: state.halted_reason,
+      halted_reason: halted_reason,
       error_diagnostic: state.meta[:error_diagnostic],
+      deliverable: deliverable,
       iterations: state.iterations,
       tool_calls_made: state.tool_calls_made,
       usage: state.budget && state.budget.usage,
@@ -468,6 +476,10 @@ defmodule ExAthena.Loop do
     }
 
     fire_terminal_hooks(state, result)
+
+    if finish_reason == :submitted do
+      Events.emit(state.on_event, {:submitted, deliverable})
+    end
 
     Events.emit(state.on_event, {:done, result})
 
@@ -491,7 +503,7 @@ defmodule ExAthena.Loop do
       result: result
     }
 
-    if reason == :stop do
+    if reason in [:stop, :submitted] do
       _ = ExAthena.Hooks.run_lifecycle(hooks, :Stop, payload)
     else
       _ = ExAthena.Hooks.run_lifecycle(hooks, :StopFailure, payload)

--- a/lib/ex_athena/loop/events.ex
+++ b/lib/ex_athena/loop/events.ex
@@ -29,6 +29,10 @@ defmodule ExAthena.Loop.Events do
     * `{:structured_retry, %{attempt:, error:}}` — extract_structured
       retry.
     * `{:error, reason}` — non-fatal warning (the loop continues).
+    * `{:submitted, deliverable}` — the model called the `finish` tool to
+      declare completion. `deliverable` is the payload passed to the tool
+      (`nil` when no deliverable was provided). Emitted just before
+      `{:done, Result}` when `finish_reason` is `:submitted`.
     * `{:done, Result.t()}` — terminal event. Always the last event
       emitted; the Result carries the finish_reason.
   """
@@ -60,6 +64,7 @@ defmodule ExAthena.Loop.Events do
           | {:structured_retry,
              %{required(:attempt) => non_neg_integer(), required(:error) => term()}}
           | {:error, term()}
+          | {:submitted, term()}
           | {:done, Result.t()}
 
   @doc "Emit an event via the supplied callback (nil is a no-op)."

--- a/lib/ex_athena/loop/terminations.ex
+++ b/lib/ex_athena/loop/terminations.ex
@@ -12,6 +12,8 @@ defmodule ExAthena.Loop.Terminations do
   ## Subtypes
 
     * `:stop` — model returned text with no tool calls.
+    * `:submitted` — model explicitly called the `finish` tool to declare
+      completion. The `Result.deliverable` field carries the payload.
     * `:error_max_turns` — iteration cap reached.
     * `:error_max_budget_usd` — cost ceiling tripped.
     * `:error_during_execution` — unrecoverable tool / provider error.
@@ -37,6 +39,7 @@ defmodule ExAthena.Loop.Terminations do
 
   @type subtype ::
           :stop
+          | :submitted
           | :error_max_turns
           | :error_max_budget_usd
           | :error_during_execution
@@ -51,6 +54,7 @@ defmodule ExAthena.Loop.Terminations do
 
   @all_subtypes [
     :stop,
+    :submitted,
     :error_max_turns,
     :error_max_budget_usd,
     :error_during_execution,
@@ -71,11 +75,13 @@ defmodule ExAthena.Loop.Terminations do
   @doc "Is this a successful termination?"
   @spec success?(subtype()) :: boolean()
   def success?(:stop), do: true
+  def success?(:submitted), do: true
   def success?(_), do: false
 
   @doc "Is this an error termination?"
   @spec error?(subtype()) :: boolean()
   def error?(:stop), do: false
+  def error?(:submitted), do: false
   def error?(_), do: true
 
   @doc """
@@ -89,6 +95,7 @@ defmodule ExAthena.Loop.Terminations do
   """
   @spec category(subtype()) :: :success | :retryable | :capacity | :fatal
   def category(:stop), do: :success
+  def category(:submitted), do: :success
   def category(:error_max_turns), do: :capacity
   def category(:error_max_budget_usd), do: :capacity
   def category(:error_max_structured_output_retries), do: :capacity

--- a/lib/ex_athena/result.ex
+++ b/lib/ex_athena/result.ex
@@ -29,6 +29,10 @@ defmodule ExAthena.Result do
     * `:error_diagnostic` — structured validation failure payload when
       `finish_reason` is `:error_schema_validation`; `nil` otherwise. Shape:
       `%{schema: term(), received: String.t() | nil, violations: [%{reason: String.t()}]}`.
+    * `:deliverable` — the payload passed to the `finish` tool when
+      `finish_reason` is `:submitted`; `nil` for all other terminations.
+      Carries the model's declared output (summary, plan text, or any
+      value the `finish` tool received).
     * `:telemetry` — span metadata summarising OTel attrs for the run
       (Phase 4).
     * `:no_progress_snapshot` — the last few message pairs (assistant +
@@ -56,6 +60,7 @@ defmodule ExAthena.Result do
             finish_reason: :stop,
             halted_reason: nil,
             error_diagnostic: nil,
+            deliverable: nil,
             iterations: 0,
             tool_calls_made: 0,
             usage: nil,
@@ -72,6 +77,7 @@ defmodule ExAthena.Result do
           finish_reason: Terminations.subtype(),
           halted_reason: term() | nil,
           error_diagnostic: error_diagnostic() | nil,
+          deliverable: term() | nil,
           iterations: non_neg_integer(),
           tool_calls_made: non_neg_integer(),
           usage: usage() | nil,

--- a/lib/ex_athena/tools.ex
+++ b/lib/ex_athena/tools.ex
@@ -34,7 +34,8 @@ defmodule ExAthena.Tools do
     ExAthena.Tools.TodoWrite,
     ExAthena.Tools.PlanMode,
     ExAthena.Tools.SpawnAgent,
-    ExAthena.Tools.Lsp
+    ExAthena.Tools.Lsp,
+    ExAthena.Tools.Finish
   ]
 
   @doc "List the builtin tool modules."

--- a/lib/ex_athena/tools/finish.ex
+++ b/lib/ex_athena/tools/finish.ex
@@ -1,0 +1,84 @@
+defmodule ExAthena.Tools.Finish do
+  @moduledoc """
+  Built-in completion signal tool.
+
+  The model calls `finish` to declare that the current task or phase is done
+  and optionally supply a deliverable payload. The loop recognises this call,
+  stops cleanly with `finish_reason: :submitted`, and surfaces the deliverable
+  on `Result.deliverable`.
+
+  This is far more reliable than free-text sentinels for weak or local models:
+  a structured tool call is explicit and unambiguous regardless of model size or
+  provider.
+
+  Arguments (all optional):
+
+    * `deliverable` — the primary output of the completed task (plan text, a
+      JSON summary, a file path, etc.).
+    * `summary` — a brief human-readable description of what was accomplished.
+      Used as the deliverable when `deliverable` is absent.
+
+  ## Usage rules
+
+  Add `ExAthena.Tools.Finish` to the tool list (or use the default `:all`
+  builtin set) and instruct the model in the system prompt to call `finish`
+  when its task is complete:
+
+      system_prompt: \"""
+      When you have finished the task, call the `finish` tool with your
+      deliverable so the caller can capture it.
+      \"""
+
+  The caller receives `result.finish_reason == :submitted` and
+  `result.deliverable` instead of needing to parse free text.
+  """
+
+  @behaviour ExAthena.Tool
+
+  @impl true
+  def name, do: "finish"
+
+  @impl true
+  def description,
+    do:
+      "Signal that the current task or phase is complete. " <>
+        "Call this tool when you have finished your work. " <>
+        "Optionally supply a `deliverable` (your primary output) or `summary` " <>
+        "(a brief description of what you accomplished). " <>
+        "The loop will stop and surface the deliverable to the caller."
+
+  @impl true
+  def schema do
+    %{
+      type: "object",
+      properties: %{
+        deliverable: %{
+          type: "string",
+          description:
+            "The primary output or result of the completed task " <>
+              "(plan text, summary, file path, etc.)."
+        },
+        summary: %{
+          type: "string",
+          description:
+            "A brief human-readable description of what was accomplished. " <>
+              "Used as the deliverable when `deliverable` is not provided."
+        }
+      },
+      required: []
+    }
+  end
+
+  @impl true
+  def parallel_safe?, do: false
+
+  @impl true
+  def execute(args, _ctx) do
+    deliverable =
+      if is_nil(Map.get(args, "deliverable")),
+        do: Map.get(args, "summary"),
+        else: Map.get(args, "deliverable")
+
+    {:halt, {:submitted, deliverable}}
+  end
+end

--- a/test/ex_athena/loop/terminations_test.exs
+++ b/test/ex_athena/loop/terminations_test.exs
@@ -6,6 +6,7 @@ defmodule ExAthena.Loop.TerminationsTest do
   describe "all/0" do
     test "enumerates every known subtype" do
       assert :stop in Terminations.all()
+      assert :submitted in Terminations.all()
       assert :error_max_turns in Terminations.all()
       assert :error_max_budget_usd in Terminations.all()
       assert :error_during_execution in Terminations.all()
@@ -26,8 +27,13 @@ defmodule ExAthena.Loop.TerminationsTest do
       refute Terminations.error?(:stop)
     end
 
+    test ":submitted is success, not error" do
+      assert Terminations.success?(:submitted)
+      refute Terminations.error?(:submitted)
+    end
+
     test "every error subtype is error, not success" do
-      for subtype <- Terminations.all() -- [:stop] do
+      for subtype <- Terminations.all() -- [:stop, :submitted] do
         refute Terminations.success?(subtype), "#{subtype} should not be success"
         assert Terminations.error?(subtype), "#{subtype} should be error"
       end
@@ -37,6 +43,10 @@ defmodule ExAthena.Loop.TerminationsTest do
   describe "category/1" do
     test ":stop is :success" do
       assert Terminations.category(:stop) == :success
+    end
+
+    test ":submitted is :success" do
+      assert Terminations.category(:submitted) == :success
     end
 
     test "cap-tripping terminations are :capacity" do

--- a/test/ex_athena/loop_test.exs
+++ b/test/ex_athena/loop_test.exs
@@ -353,4 +353,217 @@ defmodule ExAthena.LoopTest do
 
     assert result.text == "fallback ok"
   end
+
+  describe "finish tool — structured completion signal" do
+    test "model calling finish halts with :submitted and captures deliverable", %{dir: dir} do
+      responses = [
+        %Response{
+          text: "",
+          tool_calls: [
+            %ToolCall{
+              id: "f1",
+              name: "finish",
+              arguments: %{"deliverable" => "Here is the plan."}
+            }
+          ],
+          finish_reason: :tool_calls,
+          provider: :mock
+        }
+      ]
+
+      assert {:ok, result} =
+               Loop.run("plan the task",
+                 provider: :mock,
+                 mock: [responder: script(responses)],
+                 cwd: dir,
+                 tools: [ExAthena.Tools.Finish]
+               )
+
+      assert result.finish_reason == :submitted
+      assert result.deliverable == "Here is the plan."
+      assert result.halted_reason == nil
+    end
+
+    test ":submitted is a success termination" do
+      assert ExAthena.Result.success?(%ExAthena.Result{finish_reason: :submitted})
+      refute ExAthena.Result.error?(%ExAthena.Result{finish_reason: :submitted})
+    end
+
+    test "finish with summary field falls back when deliverable absent", %{dir: dir} do
+      responses = [
+        %Response{
+          text: "",
+          tool_calls: [
+            %ToolCall{
+              id: "f2",
+              name: "finish",
+              arguments: %{"summary" => "Task accomplished."}
+            }
+          ],
+          finish_reason: :tool_calls,
+          provider: :mock
+        }
+      ]
+
+      assert {:ok, result} =
+               Loop.run("do it",
+                 provider: :mock,
+                 mock: [responder: script(responses)],
+                 cwd: dir,
+                 tools: [ExAthena.Tools.Finish]
+               )
+
+      assert result.finish_reason == :submitted
+      assert result.deliverable == "Task accomplished."
+    end
+
+    test "finish with no args still produces :submitted with nil deliverable", %{dir: dir} do
+      responses = [
+        %Response{
+          text: "",
+          tool_calls: [
+            %ToolCall{id: "f3", name: "finish", arguments: %{}}
+          ],
+          finish_reason: :tool_calls,
+          provider: :mock
+        }
+      ]
+
+      assert {:ok, result} =
+               Loop.run("done",
+                 provider: :mock,
+                 mock: [responder: script(responses)],
+                 cwd: dir,
+                 tools: [ExAthena.Tools.Finish]
+               )
+
+      assert result.finish_reason == :submitted
+      assert result.deliverable == nil
+    end
+
+    test "on_event callback receives {:submitted, deliverable} before {:done, result}", %{
+      dir: dir
+    } do
+      test_pid = self()
+
+      responses = [
+        %Response{
+          text: "",
+          tool_calls: [
+            %ToolCall{
+              id: "f4",
+              name: "finish",
+              arguments: %{"deliverable" => "my output"}
+            }
+          ],
+          finish_reason: :tool_calls,
+          provider: :mock
+        }
+      ]
+
+      on_event = fn event -> send(test_pid, {:event, event}) end
+
+      assert {:ok, result} =
+               Loop.run("go",
+                 provider: :mock,
+                 mock: [responder: script(responses)],
+                 cwd: dir,
+                 tools: [ExAthena.Tools.Finish],
+                 on_event: on_event
+               )
+
+      assert result.finish_reason == :submitted
+
+      events =
+        Stream.repeatedly(fn ->
+          receive do
+            {:event, e} -> e
+          after
+            0 -> nil
+          end
+        end)
+        |> Stream.take_while(&(&1 != nil))
+        |> Enum.to_list()
+
+      submitted_event = Enum.find(events, fn e -> match?({:submitted, _}, e) end)
+      done_event = Enum.find(events, fn e -> match?({:done, _}, e) end)
+
+      assert {:submitted, "my output"} = submitted_event
+      assert {:done, %ExAthena.Result{finish_reason: :submitted}} = done_event
+
+      submitted_idx = Enum.find_index(events, &match?({:submitted, _}, &1))
+      done_idx = Enum.find_index(events, &match?({:done, _}, &1))
+      assert submitted_idx < done_idx
+    end
+
+    test "finish tool in builtins — available without explicit tools list", %{dir: _dir} do
+      assert ExAthena.Tools.Finish in ExAthena.Tools.builtins()
+    end
+
+    test "finish tool in :plan_and_solve mode halts with :submitted", %{dir: dir} do
+      responses = [
+        # Planning phase — text only, no tool calls
+        %Response{
+          text: "My plan: step 1 then step 2.",
+          tool_calls: [],
+          finish_reason: :stop,
+          provider: :mock
+        },
+        # Executing phase — model calls finish
+        %Response{
+          text: "",
+          tool_calls: [
+            %ToolCall{
+              id: "f_ps",
+              name: "finish",
+              arguments: %{"deliverable" => "plan_and_solve output"}
+            }
+          ],
+          finish_reason: :tool_calls,
+          provider: :mock
+        }
+      ]
+
+      assert {:ok, result} =
+               Loop.run("plan the task",
+                 provider: :mock,
+                 mock: [responder: script(responses)],
+                 cwd: dir,
+                 mode: :plan_and_solve,
+                 tools: [ExAthena.Tools.Finish]
+               )
+
+      assert result.finish_reason == :submitted
+      assert result.deliverable == "plan_and_solve output"
+    end
+
+    test "finish tool in :reflexion mode halts with :submitted", %{dir: dir} do
+      responses = [
+        %Response{
+          text: "",
+          tool_calls: [
+            %ToolCall{
+              id: "f_ref",
+              name: "finish",
+              arguments: %{"deliverable" => "reflexion output"}
+            }
+          ],
+          finish_reason: :tool_calls,
+          provider: :mock
+        }
+      ]
+
+      assert {:ok, result} =
+               Loop.run("do the task",
+                 provider: :mock,
+                 mock: [responder: script(responses)],
+                 cwd: dir,
+                 mode: :reflexion,
+                 tools: [ExAthena.Tools.Finish]
+               )
+
+      assert result.finish_reason == :submitted
+      assert result.deliverable == "reflexion output"
+    end
+  end
 end

--- a/test/ex_athena/result_test.exs
+++ b/test/ex_athena/result_test.exs
@@ -5,11 +5,13 @@ defmodule ExAthena.ResultTest do
 
   test "success?/1 reflects the finish_reason subtype" do
     assert Result.success?(%Result{finish_reason: :stop})
+    assert Result.success?(%Result{finish_reason: :submitted})
     refute Result.success?(%Result{finish_reason: :error_max_turns})
   end
 
   test "error?/1 is the inverse of success?" do
     refute Result.error?(%Result{finish_reason: :stop})
+    refute Result.error?(%Result{finish_reason: :submitted})
     assert Result.error?(%Result{finish_reason: :error_halted})
     assert Result.error?(%Result{finish_reason: :error_during_execution})
     assert Result.error?(%Result{finish_reason: :error_schema_validation})
@@ -18,6 +20,7 @@ defmodule ExAthena.ResultTest do
 
   test "category/1 delegates to Terminations" do
     assert Result.category(%Result{finish_reason: :stop}) == :success
+    assert Result.category(%Result{finish_reason: :submitted}) == :success
     assert Result.category(%Result{finish_reason: :error_max_turns}) == :capacity
     assert Result.category(%Result{finish_reason: :error_during_execution}) == :retryable
     assert Result.category(%Result{finish_reason: :error_halted}) == :fatal
@@ -40,8 +43,19 @@ defmodule ExAthena.ResultTest do
              tool_calls_made: 0,
              usage: nil,
              cost_usd: nil,
-             error_diagnostic: nil
+             error_diagnostic: nil,
+             deliverable: nil
            } = %Result{}
+  end
+
+  test "deliverable is nil by default" do
+    assert %Result{deliverable: nil} = %Result{}
+  end
+
+  test "deliverable is populated for :submitted runs" do
+    result = %Result{finish_reason: :submitted, deliverable: "my plan"}
+    assert result.deliverable == "my plan"
+    assert result.finish_reason == :submitted
   end
 
   test "no_progress_snapshot is nil by default" do

--- a/test/ex_athena/tools/finish_test.exs
+++ b/test/ex_athena/tools/finish_test.exs
@@ -1,0 +1,54 @@
+defmodule ExAthena.Tools.FinishTest do
+  use ExUnit.Case, async: true
+
+  alias ExAthena.Tools.Finish
+
+  describe "Tool behaviour" do
+    test "name/0 returns finish" do
+      assert Finish.name() == "finish"
+    end
+
+    test "description/0 is non-empty" do
+      assert is_binary(Finish.description())
+      assert byte_size(Finish.description()) > 0
+    end
+
+    test "schema/0 is a valid JSON schema object with optional fields" do
+      schema = Finish.schema()
+      assert schema.type == "object"
+
+      assert Map.has_key?(schema.properties, :summary) or
+               Map.has_key?(schema.properties, "summary")
+
+      assert Map.has_key?(schema.properties, :deliverable) or
+               Map.has_key?(schema.properties, "deliverable")
+
+      assert schema.required == [] or schema[:required] == []
+    end
+
+    test "parallel_safe?/0 returns false" do
+      refute Finish.parallel_safe?()
+    end
+  end
+
+  describe "execute/2" do
+    test "returns {:halt, {:submitted, deliverable}} with deliverable from args" do
+      assert {:halt, {:submitted, "my plan"}} =
+               Finish.execute(%{"deliverable" => "my plan"}, %{})
+    end
+
+    test "accepts summary as alias for deliverable" do
+      assert {:halt, {:submitted, "task done"}} =
+               Finish.execute(%{"summary" => "task done"}, %{})
+    end
+
+    test "prefers deliverable over summary when both present" do
+      assert {:halt, {:submitted, "the deliverable"}} =
+               Finish.execute(%{"deliverable" => "the deliverable", "summary" => "ignored"}, %{})
+    end
+
+    test "returns {:halt, {:submitted, nil}} when no args given" do
+      assert {:halt, {:submitted, nil}} = Finish.execute(%{}, %{})
+    end
+  end
+end


### PR DESCRIPTION
### Summary
This PR implements a reliable, provider-agnostic mechanism for signaling task completion within the ExAthena execution loop. Instead of relying on fragile text sentinels, the system now supports a structured `finish` or `submit` signal, allowing models to explicitly declare when they have produced a final deliverable.

### Key Changes
*   **Structured Completion Signal:** Introduced the concept of a `:submitted` termination reason, triggered when the model calls a dedicated `finish` tool.
*   **Result Struct Update:** The `ExAthena.Loop` result type and associated methods are updated to capture and expose the final deliverable payload alongside the finish reason.
*   **Event System Enhancement:** The `ExAthena.Loop.Events` module is updated to emit a specific `{:submitted, deliverable}` event, providing a clear hook for consumers and internal logic.
*   **Termination Logic:** The loop's state machine and lifecycle hooks now correctly handle and differentiate between a natural stop and a submitted termination, ensuring the deliverable is captured and surfaced reliably.
*   **Provider Agnosticism:** The implementation is designed to gracefully utilize tool calling capabilities, ensuring compatibility across different LLM providers (OpenAI, Anthropic, Ollama, etc.).

### Implementation Details
*   The core change centralizes completion logic in `ExAthena.Loop.to_result/2`, which now checks for a special state meta key (`:finish_reason`) to determine if the process terminated via submission.
*   The `Result` struct now includes a `deliverable` field and the primary finish reason is set to `:submitted` in this case.
*   The termination system (`ExAthena.Loop.Terminations`) is extended to acknowledge `:submitted` as a formal, non-error exit state, making the process semantically explicit.
*   This refactoring replaces the brittle practice of relying on text pattern matching for task completion, dramatically improving reliability when integrating with diverse model backends, especially weaker local models.

Closes https://github.com/udin-io/ex_athena/issues/105