### PR TITLE
chore(release): prepare v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and ExAthena adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+## v0.14.0 — Mid-loop intervention hook + structured completion signal
+
+Two control-flow features for steering long agent loops: a per-iteration hook for
+mid-loop intervention, and a structured `finish` tool so models can declare task
+completion explicitly instead of relying on free-text sentinels.
+
+### Added
+
+- **`:PreIteration` hook for mid-loop intervention.** Fires at the start of every
+  iteration (after compaction, before `mode.iterate/1`), with a payload exposing
+  the iteration index, the consecutive unproductive-iteration count, and the last
+  tool fingerprint. Return `{:inject, msg}` to append message(s) before the model
+  call, `{:halt, reason}` to stop cleanly (`finish_reason: :error_halted`), or
+  `:ok` to proceed. Lets consumers detect a stall and inject guidance mid-loop
+  rather than absorbing a terminal `:error_no_progress` (#107, closes #106).
+- **`ExAthena.Tools.Finish` — structured completion signal.** A builtin tool the
+  model calls to declare the task/phase done, optionally supplying a `deliverable`
+  (and/or `summary`). The loop stops cleanly with the new `:submitted` termination
+  subtype (a success category) and surfaces the payload on `Result.deliverable`; a
+  `{:submitted, deliverable}` event is emitted just before `{:done, Result}`. More
+  reliable than free-text sentinels for weak or local models (#108).
+
+## v0.13.0 — Compaction budget sized from the model's real context window
+
+Compaction no longer assumes a static 200k-token window: ExAthena now sizes the
+budget from the model's actual context window, so compaction fires at the right
+point for both small local models and large hosted ones.
+
+### Added
+
+- **`capabilities/1` optional provider callback.** Providers can return a
+  model-aware capability map — given the per-call opts (including
+  `:req_llm_provider_tag` and `:model`) — so `max_tokens` reflects the model's
+  real context window instead of a static default. Backward-compatible: providers
+  that implement only `capabilities/0` are unaffected, as the loop falls back to
+  it via `function_exported?`.
+- **Runtime context-window detection for local models.** Resolves the real
+  context window for Ollama and llama.cpp at runtime, cached in ETS, feeding the
+  dynamic compaction budget. The bundled `ExAthena.Providers.ReqLLM` resolves
+  hosted-model windows from `llm_db`.
+
+### Changed
+
+- **Compaction budget is derived from the model's context window** rather than the
+  previous static 200k-token assumption, so compaction triggers appropriately
+  across models of very different sizes (#103).
+
 ## v0.12.2 — Provider base_url leak fix + Igniter/docs refresh
 
 Fixes a cross-provider `base_url` config leak and refreshes the Igniter

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExAthena.MixProject do
   use Mix.Project
 
-  @version "0.12.2"
+  @version "0.14.0"
   @source_url "https://github.com/udin-io/ex_athena"
 
   def project do
@@ -147,7 +147,8 @@ defmodule ExAthena.MixProject do
           ExAthena.Tools.WebFetch,
           ExAthena.Tools.TodoWrite,
           ExAthena.Tools.PlanMode,
-          ExAthena.Tools.SpawnAgent
+          ExAthena.Tools.SpawnAgent,
+          ExAthena.Tools.Finish
         ],
         "Memory + Skills": [
           ExAthena.Memory,


### PR DESCRIPTION
## Summary

Cuts **v0.14.0** covering the two features that landed on `main` since v0.13.0, and backfills the v0.13.0 CHANGELOG entry that was never recorded.

### v0.14.0 (new)
- **`:PreIteration` hook** (#107, closes #106) — fires at the start of every iteration (after compaction, before `mode.iterate/1`) with iteration index / unproductive-count / last-tool-fingerprint. Returns `{:inject, msg}`, `{:halt, reason}` (→ `finish_reason: :error_halted`), or `:ok`.
- **`ExAthena.Tools.Finish`** (#108) — builtin completion-signal tool; new `:submitted` termination subtype (success category), payload surfaced on `Result.deliverable`, and a `{:submitted, deliverable}` loop event. Registered in the hexdocs "Builtin tools" group.

### v0.13.0 (backfill)
v0.13.0 (the #103 dynamic-compaction-budget feature) was published to Hex from an unmerged branch, so `main` never recorded it. This adds the missing CHANGELOG entry; the `v0.13.0` git tag has been created at the published commit `6fed70f`.

## Test plan

- [x] `mix compile --force --warnings-as-errors` — clean
- [x] `mix format --check-formatted` — clean
- [x] `mix test` — 864 tests, 0 failures
- [x] `mix hex.build` — packs `ex_athena-0.14.0.tar`
- [x] `mix docs` — builds clean

## After merge

Tag `v0.14.0` on `main` and run `mix hex.publish` (Hex's latest is currently 0.13.0).