### PR TITLE
Register :openrouter as a built-in provider (OpenAI-compatible)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and ExAthena adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### Added
+
+- **`:openrouter` built-in provider.** Register OpenRouter as a first-class
+  provider atom. Callers can now write `provider: :openrouter,
+  base_url: "https://openrouter.ai/api/v1", api_key: ..., model: "anthropic/claude-3.5-sonnet"`.
+  OpenRouter is 100% OpenAI wire-compatible so this is a pure registration
+  change backed by the existing `ExAthena.Providers.ReqLLM` adapter — no new
+  HTTP code, no streaming changes, no tool-call changes.
+
 ## v0.14.0 — Mid-loop intervention hook + structured completion signal
 
 Two control-flow features for steering long agent loops: a per-iteration hook for

--- a/lib/ex_athena/config.ex
+++ b/lib/ex_athena/config.ex
@@ -23,6 +23,7 @@ defmodule ExAthena.Config do
   | `:claude` | `ExAthena.Providers.ReqLLM` |
   | `:anthropic` | `ExAthena.Providers.ReqLLM` |
   | `:gemini` | `ExAthena.Providers.ReqLLM` |
+  | `:openrouter` | `ExAthena.Providers.ReqLLM` |
   | `:req_llm` | `ExAthena.Providers.ReqLLM` |
   | `:mock` | `ExAthena.Providers.Mock` |
 
@@ -37,6 +38,7 @@ defmodule ExAthena.Config do
     claude: ExAthena.Providers.ReqLLM,
     anthropic: ExAthena.Providers.ReqLLM,
     gemini: ExAthena.Providers.ReqLLM,
+    openrouter: ExAthena.Providers.ReqLLM,
     mock: ExAthena.Providers.Mock,
     req_llm: ExAthena.Providers.ReqLLM
   }
@@ -55,7 +57,8 @@ defmodule ExAthena.Config do
     llamacpp: "openai",
     claude: "anthropic",
     anthropic: "anthropic",
-    gemini: "google"
+    gemini: "google",
+    openrouter: "openai"
   }
 
   # Provider atoms that talk to a local OpenAI-compatible server. These

--- a/test/ex_athena/config_test.exs
+++ b/test/ex_athena/config_test.exs
@@ -11,7 +11,8 @@ defmodule ExAthena.ConfigTest do
     :claude,
     :anthropic,
     :req_llm,
-    :gemini
+    :gemini,
+    :openrouter
   ]
 
   setup do
@@ -124,6 +125,7 @@ defmodule ExAthena.ConfigTest do
       assert ExAthena.Providers.ReqLLM = Config.provider_module(:claude)
       assert ExAthena.Providers.Mock = Config.provider_module(:mock)
       assert ExAthena.Providers.ReqLLM = Config.provider_module(:gemini)
+      assert ExAthena.Providers.ReqLLM = Config.provider_module(:openrouter)
     end
 
     test "accepts modules that implement the behaviour" do
@@ -145,6 +147,25 @@ defmodule ExAthena.ConfigTest do
   describe "req_llm_provider_tag/1" do
     test "returns google for :gemini" do
       assert "google" = Config.req_llm_provider_tag(:gemini)
+    end
+
+    test "returns openai for :openrouter" do
+      assert "openai" = Config.req_llm_provider_tag(:openrouter)
+    end
+  end
+
+  describe "pop_provider!/1 with :openrouter" do
+    test "resolves to ReqLLM and injects openai req_llm_provider_tag" do
+      assert {ExAthena.Providers.ReqLLM, rest} =
+               Config.pop_provider!(
+                 provider: :openrouter,
+                 base_url: "https://openrouter.ai/api/v1",
+                 model: "anthropic/claude-3.5-sonnet"
+               )
+
+      assert rest[:req_llm_provider_tag] == "openai"
+      assert rest[:model] == "anthropic/claude-3.5-sonnet"
+      refute Keyword.has_key?(rest, :openai_compatible_backend)
     end
   end
 end

--- a/test/ex_athena/providers/openrouter_live_test.exs
+++ b/test/ex_athena/providers/openrouter_live_test.exs
@@ -1,0 +1,20 @@
+defmodule ExAthena.Providers.OpenrouterLiveTest do
+  use ExUnit.Case, async: false
+
+  @moduletag :external
+
+  test "live openrouter call returns a Response" do
+    api_key = System.fetch_env!("OPENROUTER_API_KEY")
+
+    assert {:ok, %ExAthena.Response{} = resp} =
+             ExAthena.query("ping",
+               provider: :openrouter,
+               base_url: "https://openrouter.ai/api/v1",
+               model: "anthropic/claude-3.5-sonnet",
+               api_key: api_key
+             )
+
+    assert is_binary(resp.text) and resp.text != ""
+    assert resp.finish_reason in [:stop, :length]
+  end
+end

--- a/test/ex_athena/providers/req_llm_test.exs
+++ b/test/ex_athena/providers/req_llm_test.exs
@@ -68,8 +68,17 @@ defmodule ExAthena.Providers.ReqLLMTest do
   end
 
   describe "Config resolves builtin provider atoms to the ReqLLM adapter" do
-    test ":ollama, :openai*, :llamacpp, :claude, :anthropic all route here" do
-      for atom <- [:ollama, :openai, :openai_compatible, :llamacpp, :claude, :anthropic, :req_llm] do
+    test ":ollama, :openai*, :llamacpp, :claude, :anthropic, :openrouter all route here" do
+      for atom <- [
+            :ollama,
+            :openai,
+            :openai_compatible,
+            :llamacpp,
+            :claude,
+            :anthropic,
+            :openrouter,
+            :req_llm
+          ] do
         assert Config.provider_module(atom) == Adapter,
                "expected provider atom #{inspect(atom)} to resolve to ReqLLM adapter"
       end
@@ -113,6 +122,16 @@ defmodule ExAthena.Providers.ReqLLMTest do
 
     test ":openai_compatible does NOT inject the ollama backend marker" do
       {_mod, opts} = Config.pop_provider!(provider: :openai_compatible)
+      refute Keyword.has_key?(opts, :openai_compatible_backend)
+    end
+
+    test ":openrouter uses the openai tag (OpenRouter is OpenAI wire-compatible)" do
+      {_mod, opts} = Config.pop_provider!(provider: :openrouter)
+      assert Keyword.get(opts, :req_llm_provider_tag) == "openai"
+    end
+
+    test ":openrouter does NOT inject the openai_compatible_backend marker" do
+      {_mod, opts} = Config.pop_provider!(provider: :openrouter)
       refute Keyword.has_key?(opts, :openai_compatible_backend)
     end
 


### PR DESCRIPTION
Seamlessly adds OpenRouter as a built-in, first-class LLM provider.

OpenRouter integration is a purely declarative addition. Since OpenRouter is designed to be 100% OpenAI wire-compatible (sharing the `/v1/chat/completions` endpoint, SSE streaming, and tool-call JSON structure), existing logic in `ExAthena.Providers.ReqLLM` can handle all required functionality without modifications.

### Key Changes

*   **Provider Registration:** Added `:openrouter` to the built-in provider list in `lib/ex_athena/config.ex`.
*   **Configuration Linking:** Ensured `:openrouter` correctly maps to `ExAthena.Providers.ReqLLM` and is tagged with `"openai"` under the `req_llm_provider_tag` map.
*   **Contract/Behavior Testing:** Updated configuration tests and added a dedicated live test (`ex_athena/providers/openrouter_live_test`) to validate the new provider's configuration and basic functionality.
*   **Documentation:** Added a descriptive entry to `CHANGELOG.md` for version tracking.

### Important Implementation Details

*   **Backward Compatibility:** This change introduces no new external API behaviors, streaming code paths, or tool-call parsing logic. It is a pure registration change.
*   **Usage:** Callers can now use the following syntax:
    ```elixir
    ExAthena.query(
      prompt,
      provider: :openrouter,
      base_url: "https://openrouter.ai/api/v1",
      api_key: System.get_env("OPENROUTER_API_KEY"),
      model: "anthropic/claude-3.5-sonnet"
    )
    ```
*   **Handling:** All API interactions are routed through the existing `ExAthena.Providers.ReqLLM` adapter, maintaining consistency with other OpenAI-compatible models.

Closes https://github.com/udin-io/ex_athena/issues/110