### PR TITLE
Built-in per-provider request queue / concurrency cap (upstream of udin_code#1625)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and ExAthena adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **Request queue wired into all public entry points.** `query/2`, `stream/3`,
+  `run/2`, and `extract_structured/2` now acquire a semaphore slot before
+  calling the provider and release it on every exit path — including success,
+  error return, and exception propagation. For streaming, the slot is held for
+  the full duration of the stream. Opt out per call with `queue: false`; set
+  `queue_timeout: ms` to override the default 5 s acquisition timeout. No
+  behaviour change when `config :ex_athena, :request_queue, enabled: true` is
+  not set (opt-in, default disabled).
+
+- **Request queue telemetry.** Four new events emitted around slot
+  acquire/release: `[:ex_athena, :request_queue, :wait]`,
+  `[:ex_athena, :request_queue, :acquired]`,
+  `[:ex_athena, :request_queue, :released]`, and
+  `[:ex_athena, :request_queue, :timeout]`. All carry `%{provider: atom}`
+  metadata and conform to the existing telemetry shape so they wire directly
+  into OpenTelemetry.
+
 - **`:openrouter` built-in provider.** Register OpenRouter as a first-class
   provider atom. Callers can now write `provider: :openrouter,
   base_url: "https://openrouter.ai/api/v1", api_key: ..., model: "anthropic/claude-3.5-sonnet"`.

--- a/config/test.exs
+++ b/config/test.exs
@@ -11,3 +11,6 @@ config :ex_athena, enable_checkpoint_sweeper: false
 # Disable implicit LSP diagnostics hook globally in tests so existing tests
 # are not affected. Individual ImplicitDiagnostics tests opt back in.
 config :ex_athena, lsp_implicit_diagnostics_enabled: false
+
+# Disable request queue supervisor; individual tests opt in via start_supervised!.
+config :ex_athena, :request_queue, enabled: false

--- a/lib/ex_athena.ex
+++ b/lib/ex_athena.ex
@@ -209,11 +209,18 @@ defmodule ExAthena do
   defp with_request_queue(provider_atom, true, timeout, fun)
        when is_atom(provider_atom) and not is_nil(provider_atom) do
     if Config.request_queue_enabled?() do
+      start_ms = System.monotonic_time(:millisecond)
       Telemetry.event([:ex_athena, :request_queue, :wait], %{}, %{provider: provider_atom})
 
       case do_acquire(provider_atom, timeout) do
         :ok ->
-          Telemetry.event([:ex_athena, :request_queue, :acquired], %{}, %{provider: provider_atom})
+          wait_ms = System.monotonic_time(:millisecond) - start_ms
+
+          Telemetry.event(
+            [:ex_athena, :request_queue, :acquired],
+            %{wait_ms: wait_ms, depth: RequestQueue.depth(provider_atom)},
+            %{provider: provider_atom}
+          )
 
           try do
             fun.()
@@ -222,13 +229,20 @@ defmodule ExAthena do
 
             Telemetry.event(
               [:ex_athena, :request_queue, :released],
-              %{},
+              %{depth: RequestQueue.depth(provider_atom)},
               %{provider: provider_atom}
             )
           end
 
         {:error, :timeout} ->
-          Telemetry.event([:ex_athena, :request_queue, :timeout], %{}, %{provider: provider_atom})
+          waited_ms = System.monotonic_time(:millisecond) - start_ms
+
+          Telemetry.event(
+            [:ex_athena, :request_queue, :timeout],
+            %{waited_ms: waited_ms},
+            %{provider: provider_atom}
+          )
+
           {:error, :request_queue_timeout}
       end
     else
@@ -243,7 +257,9 @@ defmodule ExAthena do
     try do
       RequestQueue.acquire(provider_atom, timeout)
     catch
-      :exit, _ -> {:error, :timeout}
+      :exit, _ ->
+        RequestQueue.cancel_acquire(provider_atom)
+        {:error, :timeout}
     end
   end
 end

--- a/lib/ex_athena.ex
+++ b/lib/ex_athena.ex
@@ -50,9 +50,23 @@ defmodule ExAthena do
   * `ExAthena.Providers.Mock` — test double with scripted responses.
 
   Consumers can also pass a custom module that implements `ExAthena.Provider`.
+
+  ## Request queue
+
+  An opt-in semaphore caps concurrent in-flight requests per provider. When
+  enabled, `query/2`, `stream/3`, `run/2`, and `extract_structured/2` all
+  acquire a slot before calling the provider and release it on every exit path
+  (success, error, or exception).
+
+  Enable via:
+
+      config :ex_athena, :request_queue, enabled: true
+
+  Pass `queue: false` on any individual call to bypass the queue for that call.
   """
 
-  alias ExAthena.{Config, Request, Response}
+  alias ExAthena.{Config, Request, Response, Telemetry}
+  alias ExAthena.RequestQueue
 
   @doc """
   One-shot inference. Returns the final `Response` struct with the full text.
@@ -75,12 +89,22 @@ defmodule ExAthena do
       images or `%{url: String.t()}` for remote image URLs. Merged into the
       user message created from `prompt`, or the last user message in
       `:messages` when no prompt is given.
+    * `:queue` — set to `false` to bypass the request queue for this call
+      (default `true`). Has no effect when the request queue is not enabled.
+    * `:queue_timeout` — milliseconds to wait for a queue slot before returning
+      `{:error, :request_queue_timeout}` (default 5_000).
   """
   @spec query(String.t() | nil, keyword()) :: {:ok, Response.t()} | {:error, term()}
   def query(prompt \\ nil, opts \\ []) do
+    {queue, opts} = Keyword.pop(opts, :queue, true)
+    {timeout, opts} = Keyword.pop(opts, :queue_timeout, 5_000)
+    provider_atom = peek_provider_atom(opts)
     {provider_mod, opts} = Config.pop_provider!(opts)
     request = Request.new(prompt, opts)
-    provider_mod.query(request, Config.provider_opts(provider_mod, opts))
+
+    with_request_queue(provider_atom, queue, timeout, fn ->
+      provider_mod.query(request, Config.provider_opts(provider_mod, opts))
+    end)
   end
 
   @doc """
@@ -91,31 +115,61 @@ defmodule ExAthena do
   and its return value is ignored. Callbacks must not block the caller; if you
   need to do expensive work per-delta, hand off to a `Task`.
 
-  Options are the same as `query/2`, including `:images`.
+  Options are the same as `query/2`, including `:images`, `:queue`, and
+  `:queue_timeout`. When the request queue is enabled, the slot is held for the
+  full duration of the stream and released on every exit path (success, error,
+  or callback exception).
   """
   @spec stream(String.t() | nil, function(), keyword()) ::
           {:ok, Response.t()} | {:error, term()}
   def stream(prompt \\ nil, callback, opts \\ []) when is_function(callback, 1) do
+    {queue, opts} = Keyword.pop(opts, :queue, true)
+    {timeout, opts} = Keyword.pop(opts, :queue_timeout, 5_000)
+    provider_atom = peek_provider_atom(opts)
     {provider_mod, opts} = Config.pop_provider!(opts)
     request = Request.new(prompt, opts)
-    provider_mod.stream(request, callback, Config.provider_opts(provider_mod, opts))
+
+    with_request_queue(provider_atom, queue, timeout, fn ->
+      provider_mod.stream(request, callback, Config.provider_opts(provider_mod, opts))
+    end)
   end
 
   @doc """
   Run a multi-turn agent loop: infer → tool call → execute → replay → repeat.
 
+  Accepts `:queue` and `:queue_timeout` options (see `query/2`). The slot is
+  held for the entire loop run.
+
   See `ExAthena.Loop.run/2` for the full option list.
   """
   @spec run(String.t() | nil, keyword()) :: {:ok, map()} | {:error, term()}
-  defdelegate run(prompt, opts \\ []), to: ExAthena.Loop
+  def run(prompt, opts \\ []) do
+    {queue, opts} = Keyword.pop(opts, :queue, true)
+    {timeout, opts} = Keyword.pop(opts, :queue_timeout, 5_000)
+    provider_atom = peek_provider_atom(opts)
+
+    with_request_queue(provider_atom, queue, timeout, fn ->
+      ExAthena.Loop.run(prompt, opts)
+    end)
+  end
 
   @doc """
   One-shot structured extraction. Returns a validated JSON map.
 
+  Accepts `:queue` and `:queue_timeout` options (see `query/2`).
+
   See `ExAthena.Structured.extract/2` for the full option list.
   """
   @spec extract_structured(String.t(), keyword()) :: {:ok, map()} | {:error, term()}
-  defdelegate extract_structured(prompt, opts), to: ExAthena.Structured, as: :extract
+  def extract_structured(prompt, opts) do
+    {queue, opts} = Keyword.pop(opts, :queue, true)
+    {timeout, opts} = Keyword.pop(opts, :queue_timeout, 5_000)
+    provider_atom = peek_provider_atom(opts)
+
+    with_request_queue(provider_atom, queue, timeout, fn ->
+      ExAthena.Structured.extract(prompt, opts)
+    end)
+  end
 
   @doc """
   Returns the capabilities map for a provider.
@@ -141,4 +195,55 @@ defmodule ExAthena do
   """
   @spec supports_multimodal?() :: true
   def supports_multimodal?, do: true
+
+  # ---------------------------------------------------------------------------
+  # Request queue helpers
+  # ---------------------------------------------------------------------------
+
+  defp peek_provider_atom(opts) do
+    Keyword.get(opts, :provider) || Application.get_env(:ex_athena, :default_provider)
+  end
+
+  defp with_request_queue(_provider_atom, false, _timeout, fun), do: fun.()
+
+  defp with_request_queue(provider_atom, true, timeout, fun)
+       when is_atom(provider_atom) and not is_nil(provider_atom) do
+    if Config.request_queue_enabled?() do
+      Telemetry.event([:ex_athena, :request_queue, :wait], %{}, %{provider: provider_atom})
+
+      case do_acquire(provider_atom, timeout) do
+        :ok ->
+          Telemetry.event([:ex_athena, :request_queue, :acquired], %{}, %{provider: provider_atom})
+
+          try do
+            fun.()
+          after
+            RequestQueue.release(provider_atom)
+
+            Telemetry.event(
+              [:ex_athena, :request_queue, :released],
+              %{},
+              %{provider: provider_atom}
+            )
+          end
+
+        {:error, :timeout} ->
+          Telemetry.event([:ex_athena, :request_queue, :timeout], %{}, %{provider: provider_atom})
+          {:error, :request_queue_timeout}
+      end
+    else
+      fun.()
+    end
+  end
+
+  # Provider is nil or a non-atom value — fall through without queue
+  defp with_request_queue(_provider_atom, true, _timeout, fun), do: fun.()
+
+  defp do_acquire(provider_atom, timeout) do
+    try do
+      RequestQueue.acquire(provider_atom, timeout)
+    catch
+      :exit, _ -> {:error, :timeout}
+    end
+  end
 end

--- a/lib/ex_athena/application.ex
+++ b/lib/ex_athena/application.ex
@@ -52,8 +52,15 @@ defmodule ExAthena.Application do
         children
       end
 
-    if Application.get_env(:ex_athena, :enable_mcp, true) do
-      children ++ [ExAthena.Mcp.Supervisor]
+    children =
+      if Application.get_env(:ex_athena, :enable_mcp, true) do
+        children ++ [ExAthena.Mcp.Supervisor]
+      else
+        children
+      end
+
+    if Application.get_env(:ex_athena, :request_queue, [])[:enabled] do
+      children ++ [ExAthena.RequestQueue.Supervisor]
     else
       children
     end

--- a/lib/ex_athena/config.ex
+++ b/lib/ex_athena/config.ex
@@ -28,7 +28,47 @@ defmodule ExAthena.Config do
   | `:mock` | `ExAthena.Providers.Mock` |
 
   You may also pass any module that implements `ExAthena.Provider` directly.
+
+  ## Request queue
+
+  `ExAthena.RequestQueue` is an opt-in semaphore that caps concurrent in-flight
+  requests per provider. Enable it with:
+
+      config :ex_athena, :request_queue, enabled: true
+
+  Per-provider depth limits can be set inside provider config blocks:
+
+      config :ex_athena, :ollama, request_queue: [max_depth: 3]
+
+  A global `max_depth` applies to all providers that don't have a per-provider
+  override:
+
+      config :ex_athena, :request_queue, enabled: true, max_depth: 5
+
+  Built-in defaults (used when no application config is set):
+
+  | Provider | Default max_depth |
+  |---|---|
+  | `:ollama` | 2 |
+  | `:llamacpp` | 1 |
+  | `:exo` | 3 |
+  | `:openai`, `:anthropic`, `:claude`, `:gemini`, `:openrouter`, `:req_llm` | 10 |
+  | unknown | 10 |
   """
+
+  @request_queue_defaults %{
+    ollama: 2,
+    llamacpp: 1,
+    exo: 3,
+    openai: 10,
+    openai_compatible: 10,
+    anthropic: 10,
+    claude: 10,
+    gemini: 10,
+    openrouter: 10,
+    req_llm: 10,
+    mock: 10
+  }
 
   @builtin_providers %{
     ollama: ExAthena.Providers.ReqLLM,
@@ -193,6 +233,45 @@ defmodule ExAthena.Config do
     @builtin_providers
     |> Enum.filter(fn {_atom, mod} -> mod == provider_module end)
     |> Enum.map(&elem(&1, 0))
+  end
+
+  @doc """
+  Return the maximum concurrent request depth for `provider_atom`.
+
+  Resolution order:
+    1. `config :ex_athena, provider_atom, request_queue: [max_depth: N]`
+    2. `config :ex_athena, :request_queue, max_depth: N`
+    3. Built-in per-provider default (ollama: 2, llamacpp: 1, exo: 3, cloud: 10).
+    4. `10` for unrecognised providers.
+  """
+  @spec request_queue_max_depth(atom()) :: pos_integer()
+  def request_queue_max_depth(provider_atom) when is_atom(provider_atom) do
+    per_provider =
+      :ex_athena
+      |> Application.get_env(provider_atom, [])
+      |> Keyword.get(:request_queue, [])
+      |> Keyword.get(:max_depth)
+
+    global =
+      :ex_athena
+      |> Application.get_env(:request_queue, [])
+      |> Keyword.get(:max_depth)
+
+    per_provider || global || Map.get(@request_queue_defaults, provider_atom, 10)
+  end
+
+  @doc """
+  Return `true` when the request queue feature is enabled via application config.
+
+  Opt-in: defaults to `false`. Enable with:
+
+      config :ex_athena, :request_queue, enabled: true
+  """
+  @spec request_queue_enabled?() :: boolean()
+  def request_queue_enabled? do
+    :ex_athena
+    |> Application.get_env(:request_queue, [])
+    |> Keyword.get(:enabled, false)
   end
 
   defp get_provider_env(provider_module, key) do

--- a/lib/ex_athena/request_queue.ex
+++ b/lib/ex_athena/request_queue.ex
@@ -67,13 +67,35 @@ defmodule ExAthena.RequestQueue do
   Return the number of active (acquired) slots for `provider`.
 
   Reads directly from the ETS table; never blocks the caller and never goes
-  through the GenServer mailbox.
+  through the GenServer mailbox. Returns `0` when the queue is disabled (ETS
+  table does not exist).
   """
   @spec depth(atom()) :: non_neg_integer()
   def depth(provider) do
-    case :ets.lookup(@table, provider) do
-      [{^provider, count}] -> count
-      [] -> 0
+    case :ets.whereis(@table) do
+      :undefined ->
+        0
+
+      _ ->
+        case :ets.lookup(@table, provider) do
+          [{^provider, count}] -> count
+          [] -> 0
+        end
+    end
+  end
+
+  @doc """
+  Cancel any pending acquire for the calling process on `provider`.
+
+  Called automatically by the entry-point helpers when a `GenServer.call`
+  timeout fires so that stale waiting entries do not prevent depth from
+  decrementing on the next `release/1`.
+  """
+  @spec cancel_acquire(atom()) :: :ok
+  def cancel_acquire(provider) do
+    case Process.whereis(__MODULE__) do
+      nil -> :ok
+      _pid -> GenServer.cast(__MODULE__, {:cancel_acquire, provider, self()})
     end
   end
 
@@ -114,6 +136,23 @@ defmodule ExAthena.RequestQueue do
     waiting =
       Map.new(state.waiting, fn {provider, queue} ->
         {provider, Enum.reject(queue, fn {r, _from} -> r == ref end)}
+      end)
+
+    {:noreply, %{state | waiting: waiting}}
+  end
+
+  @impl GenServer
+  def handle_cast({:cancel_acquire, provider, pid}, state) do
+    waiting =
+      Map.update(state.waiting, provider, [], fn queue ->
+        Enum.reject(queue, fn {ref, {from_pid, _tag}} ->
+          if from_pid == pid do
+            Process.demonitor(ref, [:flush])
+            true
+          else
+            false
+          end
+        end)
       end)
 
     {:noreply, %{state | waiting: waiting}}

--- a/lib/ex_athena/request_queue.ex
+++ b/lib/ex_athena/request_queue.ex
@@ -1,0 +1,139 @@
+defmodule ExAthena.RequestQueue do
+  @moduledoc """
+  ETS-backed GenServer semaphore that limits concurrent in-flight requests per provider.
+
+  Each provider has an independent slot cap (see `ExAthena.Config.request_queue_max_depth/1`).
+  `acquire/2` blocks the caller until a slot is available; `release/1` frees the slot
+  and wakes the next queued caller (FIFO). `depth/1` reads the ETS counter directly,
+  never blocking the caller.
+
+  The queue is opt-in and disabled by default. When the GenServer is not running
+  (feature disabled), `acquire/1` and `release/1` are no-ops returning `:ok`.
+
+  Enable via:
+
+      config :ex_athena, :request_queue, enabled: true
+
+  ## Dead-waiter cleanup
+
+  Every blocked caller is monitored. If a caller process exits before its slot is
+  granted, the monitor fires and removes the dead entry from the queue so the
+  corresponding slot is correctly freed on the next `release/1`.
+  """
+
+  use GenServer
+
+  @table __MODULE__
+
+  # ---------------------------------------------------------------------------
+  # Public API
+  # ---------------------------------------------------------------------------
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc """
+  Acquire a slot for `provider`. Blocks the caller until a slot is available or
+  `timeout` milliseconds elapse (default 5 000 ms).
+
+  Returns `:ok` when a slot is granted. When the GenServer is not running
+  (feature disabled), returns `:ok` immediately as a no-op.
+  """
+  @spec acquire(atom(), non_neg_integer()) :: :ok
+  def acquire(provider, timeout \\ 5_000) do
+    case Process.whereis(__MODULE__) do
+      nil -> :ok
+      _pid -> GenServer.call(__MODULE__, {:acquire, provider}, timeout)
+    end
+  end
+
+  @doc """
+  Release a previously acquired slot for `provider`. Returns `:ok`.
+
+  If callers are queued for this provider, the next one in line is unblocked
+  and inherits the slot (depth stays unchanged). When the GenServer is not
+  running, returns `:ok` immediately as a no-op.
+  """
+  @spec release(atom()) :: :ok
+  def release(provider) do
+    case Process.whereis(__MODULE__) do
+      nil -> :ok
+      _pid -> GenServer.call(__MODULE__, {:release, provider})
+    end
+  end
+
+  @doc """
+  Return the number of active (acquired) slots for `provider`.
+
+  Reads directly from the ETS table; never blocks the caller and never goes
+  through the GenServer mailbox.
+  """
+  @spec depth(atom()) :: non_neg_integer()
+  def depth(provider) do
+    case :ets.lookup(@table, provider) do
+      [{^provider, count}] -> count
+      [] -> 0
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # GenServer callbacks
+  # ---------------------------------------------------------------------------
+
+  @impl GenServer
+  def init(_opts) do
+    :ets.new(@table, [:named_table, :public, read_concurrency: true])
+    {:ok, %{waiting: %{}}}
+  end
+
+  @impl GenServer
+  def handle_call({:acquire, provider}, from, state) do
+    max = ExAthena.Config.request_queue_max_depth(provider)
+    current = depth(provider)
+
+    if current < max do
+      :ets.insert(@table, {provider, current + 1})
+      {:reply, :ok, state}
+    else
+      {pid, _tag} = from
+      ref = Process.monitor(pid)
+      waiting = Map.update(state.waiting, provider, [{ref, from}], &(&1 ++ [{ref, from}]))
+      {:noreply, %{state | waiting: waiting}}
+    end
+  end
+
+  @impl GenServer
+  def handle_call({:release, provider}, _from, state) do
+    state = do_release(provider, state)
+    {:reply, :ok, state}
+  end
+
+  @impl GenServer
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
+    waiting =
+      Map.new(state.waiting, fn {provider, queue} ->
+        {provider, Enum.reject(queue, fn {r, _from} -> r == ref end)}
+      end)
+
+    {:noreply, %{state | waiting: waiting}}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  defp do_release(provider, state) do
+    case Map.get(state.waiting, provider, []) do
+      [] ->
+        current = depth(provider)
+        :ets.insert(@table, {provider, max(0, current - 1)})
+        state
+
+      [{ref, from} | rest] ->
+        Process.demonitor(ref, [:flush])
+        GenServer.reply(from, :ok)
+        %{state | waiting: Map.put(state.waiting, provider, rest)}
+    end
+  end
+end

--- a/lib/ex_athena/request_queue/supervisor.ex
+++ b/lib/ex_athena/request_queue/supervisor.ex
@@ -1,0 +1,24 @@
+defmodule ExAthena.RequestQueue.Supervisor do
+  @moduledoc """
+  Supervisor for the `ExAthena.RequestQueue` GenServer.
+
+  Started by `ExAthena.Application` when the request queue is enabled:
+
+      config :ex_athena, :request_queue, enabled: true
+
+  The feature is opt-in and disabled by default. When disabled, the supervisor
+  is not started and `ExAthena.RequestQueue.acquire/2` / `release/1` are no-ops.
+  """
+
+  use Supervisor
+
+  def start_link(opts \\ []) do
+    Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl Supervisor
+  def init(_opts) do
+    children = [ExAthena.RequestQueue]
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end

--- a/lib/ex_athena/telemetry.ex
+++ b/lib/ex_athena/telemetry.ex
@@ -28,6 +28,16 @@ defmodule ExAthena.Telemetry do
       — a subagent was spawned / returned.
     * `[:ex_athena, :structured_retry]` — a structured-output repair
       attempt fired. Measurements include `:attempt`.
+    * `[:ex_athena, :request_queue, :wait]` — a call is about to attempt
+      acquiring a request-queue slot. Metadata includes `:provider`.
+    * `[:ex_athena, :request_queue, :acquired]` — a slot was granted.
+      Metadata includes `:provider`.
+    * `[:ex_athena, :request_queue, :released]` — a slot was released after
+      the call completed (success, error, or exception). Metadata includes
+      `:provider`.
+    * `[:ex_athena, :request_queue, :timeout]` — acquiring a slot timed out;
+      the call returns `{:error, :request_queue_timeout}`. Metadata includes
+      `:provider`.
 
   ## GenAI semconv metadata
 

--- a/test/ex_athena/config_test.exs
+++ b/test/ex_athena/config_test.exs
@@ -168,4 +168,76 @@ defmodule ExAthena.ConfigTest do
       refute Keyword.has_key?(rest, :openai_compatible_backend)
     end
   end
+
+  describe "request_queue_max_depth/1" do
+    setup do
+      on_exit(fn ->
+        Application.delete_env(:ex_athena, :request_queue)
+
+        for atom <- @all_provider_atoms,
+            do: Application.delete_env(:ex_athena, atom)
+      end)
+
+      :ok
+    end
+
+    test "returns built-in defaults for known local providers" do
+      assert Config.request_queue_max_depth(:ollama) == 2
+      assert Config.request_queue_max_depth(:llamacpp) == 1
+    end
+
+    test "returns 3 for :exo" do
+      assert Config.request_queue_max_depth(:exo) == 3
+    end
+
+    test "returns 10 for cloud providers" do
+      assert Config.request_queue_max_depth(:openai) == 10
+      assert Config.request_queue_max_depth(:anthropic) == 10
+      assert Config.request_queue_max_depth(:claude) == 10
+      assert Config.request_queue_max_depth(:gemini) == 10
+      assert Config.request_queue_max_depth(:openrouter) == 10
+    end
+
+    test "returns 10 for unknown providers" do
+      assert Config.request_queue_max_depth(:some_unknown_provider) == 10
+    end
+
+    test "per-provider config overrides built-in default" do
+      Application.put_env(:ex_athena, :ollama, request_queue: [max_depth: 5])
+      assert Config.request_queue_max_depth(:ollama) == 5
+    end
+
+    test "global max_depth overrides built-in default" do
+      Application.put_env(:ex_athena, :request_queue, max_depth: 7)
+      assert Config.request_queue_max_depth(:ollama) == 7
+    end
+
+    test "per-provider config wins over global max_depth" do
+      Application.put_env(:ex_athena, :ollama, request_queue: [max_depth: 5])
+      Application.put_env(:ex_athena, :request_queue, max_depth: 7)
+      assert Config.request_queue_max_depth(:ollama) == 5
+    end
+  end
+
+  describe "request_queue_enabled?/0" do
+    setup do
+      on_exit(fn -> Application.delete_env(:ex_athena, :request_queue) end)
+      :ok
+    end
+
+    test "returns false when not configured" do
+      Application.delete_env(:ex_athena, :request_queue)
+      refute Config.request_queue_enabled?()
+    end
+
+    test "returns false when explicitly disabled" do
+      Application.put_env(:ex_athena, :request_queue, enabled: false)
+      refute Config.request_queue_enabled?()
+    end
+
+    test "returns true when enabled" do
+      Application.put_env(:ex_athena, :request_queue, enabled: true)
+      assert Config.request_queue_enabled?()
+    end
+  end
 end

--- a/test/ex_athena/request_queue_crash_safety_test.exs
+++ b/test/ex_athena/request_queue_crash_safety_test.exs
@@ -23,6 +23,7 @@ defmodule ExAthena.RequestQueueCrashSafetyTest do
 
     def query(_req, _opts), do: raise("intentional provider error")
     def stream(_req, _cb, _opts), do: raise("intentional stream error")
+    def extract(_req, _opts), do: raise("intentional extract error")
   end
 
   setup do
@@ -77,6 +78,38 @@ defmodule ExAthena.RequestQueueCrashSafetyTest do
       for _ <- 1..5 do
         ExAthena.query("hi", provider: :mock, mock: [error: :err])
       end
+
+      assert RequestQueue.depth(:mock) == 0
+    end
+  end
+
+  describe "no permit leak on error — run/2" do
+    test "slot is released when run provider raises" do
+      assert_raise RuntimeError, "intentional provider error", fn ->
+        ExAthena.run("hi", provider: RaisingProvider)
+      end
+
+      assert RequestQueue.depth(RaisingProvider) == 0
+    end
+  end
+
+  describe "no permit leak on error — extract_structured/2" do
+    test "slot is released when extract_structured provider raises" do
+      assert_raise RuntimeError, "intentional provider error", fn ->
+        ExAthena.extract_structured("hi", provider: RaisingProvider, schema: %{})
+      end
+
+      assert RequestQueue.depth(RaisingProvider) == 0
+    end
+
+    test "slot is released when extract_structured returns an error" do
+      assert {:error, _} =
+               ExAthena.extract_structured("hi",
+                 provider: :mock,
+                 schema: %{},
+                 mock: [error: :extraction_failed],
+                 max_retries: 0
+               )
 
       assert RequestQueue.depth(:mock) == 0
     end

--- a/test/ex_athena/request_queue_crash_safety_test.exs
+++ b/test/ex_athena/request_queue_crash_safety_test.exs
@@ -1,0 +1,114 @@
+defmodule ExAthena.RequestQueueCrashSafetyTest do
+  use ExUnit.Case, async: false
+
+  alias ExAthena.RequestQueue
+
+  # A provider that always raises — bypasses Mock's try/rescue so the exception
+  # propagates out of the entry point and into the after block.
+  defmodule RaisingProvider do
+    @behaviour ExAthena.Provider
+
+    def capabilities do
+      %{
+        native_tool_calls: false,
+        streaming: false,
+        json_mode: false,
+        structured_output: false,
+        max_tokens: 1000,
+        supports_resume: false,
+        supports_system_prompt: false,
+        supports_temperature: false
+      }
+    end
+
+    def query(_req, _opts), do: raise("intentional provider error")
+    def stream(_req, _cb, _opts), do: raise("intentional stream error")
+  end
+
+  setup do
+    Application.put_env(:ex_athena, :request_queue, enabled: true)
+    start_supervised!(RequestQueue)
+
+    on_exit(fn ->
+      Application.delete_env(:ex_athena, :request_queue)
+    end)
+  end
+
+  describe "no permit leak on error" do
+    test "slot is released when query returns an error tuple" do
+      assert {:error, :some_error} =
+               ExAthena.query("hi", provider: :mock, mock: [error: :some_error])
+
+      assert RequestQueue.depth(:mock) == 0
+    end
+
+    test "slot is released when query provider raises an exception" do
+      assert_raise RuntimeError, "intentional provider error", fn ->
+        ExAthena.query("hi", provider: RaisingProvider)
+      end
+
+      assert RequestQueue.depth(RaisingProvider) == 0
+    end
+
+    test "slot is released when stream callback raises an exception" do
+      events = [%ExAthena.Streaming.Event{type: :text_delta, data: "x"}]
+      bad_callback = fn _event -> raise "callback crashed" end
+
+      assert_raise RuntimeError, "callback crashed", fn ->
+        ExAthena.stream("hi", bad_callback,
+          provider: :mock,
+          mock: [text: "ok"],
+          mock_events: events
+        )
+      end
+
+      assert RequestQueue.depth(:mock) == 0
+    end
+
+    test "slot is released when stream provider raises an exception" do
+      assert_raise RuntimeError, "intentional stream error", fn ->
+        ExAthena.stream("hi", fn _ -> :ok end, provider: RaisingProvider)
+      end
+
+      assert RequestQueue.depth(RaisingProvider) == 0
+    end
+
+    test "multiple sequential errors do not accumulate depth" do
+      for _ <- 1..5 do
+        ExAthena.query("hi", provider: :mock, mock: [error: :err])
+      end
+
+      assert RequestQueue.depth(:mock) == 0
+    end
+  end
+
+  describe "slot released for streaming errors mid-stream" do
+    test "depth returns to zero after callback exception regardless of stream position" do
+      # Emit two events; callback crashes on the second
+      events = [
+        %ExAthena.Streaming.Event{type: :text_delta, data: "first"},
+        %ExAthena.Streaming.Event{type: :text_delta, data: "second"}
+      ]
+
+      call_count = :counters.new(1, [])
+
+      callback = fn _event ->
+        :counters.add(call_count, 1, 1)
+
+        if :counters.get(call_count, 1) >= 2 do
+          raise "mid-stream crash"
+        end
+      end
+
+      assert_raise RuntimeError, "mid-stream crash", fn ->
+        ExAthena.stream("hi", callback,
+          provider: :mock,
+          mock: [text: "ok"],
+          mock_events: events
+        )
+      end
+
+      assert RequestQueue.depth(:mock) == 0
+    end
+  end
+end

--- a/test/ex_athena/request_queue_integration_test.exs
+++ b/test/ex_athena/request_queue_integration_test.exs
@@ -1,0 +1,170 @@
+defmodule ExAthena.RequestQueueIntegrationTest do
+  use ExUnit.Case, async: false
+
+  alias ExAthena.{RequestQueue, Response}
+
+  setup do
+    on_exit(fn ->
+      Application.delete_env(:ex_athena, :request_queue)
+      Application.delete_env(:ex_athena, :mock)
+    end)
+  end
+
+  describe "default-disabled behavior" do
+    test "queue is bypassed and query succeeds when request_queue is not enabled" do
+      assert {:ok, %Response{text: "pong"}} =
+               ExAthena.query("hi", provider: :mock, mock: [text: "pong"])
+    end
+
+    test "query succeeds with no RequestQueue process running" do
+      # Verify no RequestQueue process is running
+      assert Process.whereis(RequestQueue) == nil
+
+      assert {:ok, %Response{text: "ok"}} =
+               ExAthena.query("hi", provider: :mock, mock: [text: "ok"])
+    end
+  end
+
+  describe "opt-out with queue: false" do
+    setup do
+      Application.put_env(:ex_athena, :request_queue, enabled: true)
+      Application.put_env(:ex_athena, :mock, request_queue: [max_depth: 1])
+      start_supervised!(RequestQueue)
+      :ok
+    end
+
+    test "queue: false bypasses acquire even when queue is enabled and at capacity" do
+      # Occupy the only slot
+      :ok = RequestQueue.acquire(:mock)
+      assert RequestQueue.depth(:mock) == 1
+
+      # With queue: false, this must not block
+      assert {:ok, _} = ExAthena.query("hi", provider: :mock, mock: [text: "ok"], queue: false)
+
+      RequestQueue.release(:mock)
+    end
+
+    test "queue: false bypasses acquire for stream" do
+      :ok = RequestQueue.acquire(:mock)
+
+      assert {:ok, _} =
+               ExAthena.stream("hi", fn _ -> :ok end,
+                 provider: :mock,
+                 mock: [text: "ok"],
+                 queue: false
+               )
+
+      RequestQueue.release(:mock)
+    end
+  end
+
+  describe "concurrent cap enforcement" do
+    setup do
+      Application.put_env(:ex_athena, :request_queue, enabled: true)
+      Application.put_env(:ex_athena, :mock, request_queue: [max_depth: 1])
+      start_supervised!(RequestQueue)
+      :ok
+    end
+
+    test "query blocks when at capacity and unblocks after release" do
+      # Manually occupy the only slot
+      :ok = RequestQueue.acquire(:mock)
+      assert RequestQueue.depth(:mock) == 1
+
+      test_pid = self()
+
+      task =
+        Task.async(fn ->
+          result = ExAthena.query("hi", provider: :mock, mock: [text: "queued"])
+          send(test_pid, {:done, result})
+          result
+        end)
+
+      # Give the task time to attempt acquiring (it should be blocked)
+      Process.sleep(50)
+      refute_received {:done, _}
+      assert RequestQueue.depth(:mock) == 1
+
+      # Release the slot — query should unblock
+      RequestQueue.release(:mock)
+
+      assert_receive {:done, {:ok, %Response{text: "queued"}}}, 1_000
+      assert RequestQueue.depth(:mock) == 0
+      Task.await(task)
+    end
+
+    test "stream blocks when at capacity and unblocks after release" do
+      :ok = RequestQueue.acquire(:mock)
+
+      test_pid = self()
+
+      task =
+        Task.async(fn ->
+          result =
+            ExAthena.stream("hi", fn _ -> :ok end, provider: :mock, mock: [text: "streamed"])
+
+          send(test_pid, {:done, result})
+          result
+        end)
+
+      Process.sleep(50)
+      refute_received {:done, _}
+
+      RequestQueue.release(:mock)
+      assert_receive {:done, {:ok, _}}, 1_000
+      Task.await(task)
+    end
+
+    test "slot is held for the full duration of streaming" do
+      test_pid = self()
+
+      # Callback blocks on first text_delta so we can observe depth during streaming
+      callback = fn
+        %ExAthena.Streaming.Event{type: :text_delta} ->
+          send(test_pid, :streaming_started)
+
+          receive do
+            :continue -> :ok
+          end
+
+        _ ->
+          :ok
+      end
+
+      events = [%ExAthena.Streaming.Event{type: :text_delta, data: "hi"}]
+
+      task =
+        Task.async(fn ->
+          ExAthena.stream("hi", callback,
+            provider: :mock,
+            mock: [text: "hi"],
+            mock_events: events
+          )
+        end)
+
+      assert_receive :streaming_started, 1_000
+      assert RequestQueue.depth(:mock) == 1
+
+      send(task.pid, :continue)
+      assert {:ok, _} = Task.await(task, 1_000)
+      assert RequestQueue.depth(:mock) == 0
+    end
+
+    test "returns {:error, :request_queue_timeout} when acquire times out" do
+      # Occupy the slot so acquire will block
+      :ok = RequestQueue.acquire(:mock)
+
+      # Use a very short timeout so the test doesn't wait 5 seconds
+      result =
+        ExAthena.query("hi",
+          provider: :mock,
+          mock: [text: "never"],
+          queue_timeout: 20
+        )
+
+      assert result == {:error, :request_queue_timeout}
+
+      RequestQueue.release(:mock)
+    end
+  end
+end

--- a/test/ex_athena/request_queue_telemetry_test.exs
+++ b/test/ex_athena/request_queue_telemetry_test.exs
@@ -1,0 +1,123 @@
+defmodule ExAthena.RequestQueueTelemetryTest do
+  use ExUnit.Case, async: false
+
+  alias ExAthena.RequestQueue
+
+  setup tags do
+    test_pid = self()
+    handler_id = "rq-telemetry-#{inspect(tags.test)}"
+
+    events = [
+      [:ex_athena, :request_queue, :wait],
+      [:ex_athena, :request_queue, :acquired],
+      [:ex_athena, :request_queue, :released],
+      [:ex_athena, :request_queue, :timeout]
+    ]
+
+    :telemetry.attach_many(
+      handler_id,
+      events,
+      fn name, measurements, meta, _ ->
+        send(test_pid, {:telemetry, name, measurements, meta})
+      end,
+      nil
+    )
+
+    on_exit(fn ->
+      :telemetry.detach(handler_id)
+      Application.delete_env(:ex_athena, :request_queue)
+      Application.delete_env(:ex_athena, :mock)
+    end)
+  end
+
+  describe "telemetry with queue enabled" do
+    setup do
+      Application.put_env(:ex_athena, :request_queue, enabled: true)
+      start_supervised!(RequestQueue)
+      :ok
+    end
+
+    test "emits :wait, :acquired, :released on a successful query" do
+      assert {:ok, _} = ExAthena.query("hi", provider: :mock, mock: [text: "ok"])
+
+      assert_receive {:telemetry, [:ex_athena, :request_queue, :wait], _, %{provider: :mock}}
+      assert_receive {:telemetry, [:ex_athena, :request_queue, :acquired], _, %{provider: :mock}}
+      assert_receive {:telemetry, [:ex_athena, :request_queue, :released], _, %{provider: :mock}}
+    end
+
+    test "emits :wait, :acquired, :released when query returns an error" do
+      assert {:error, :some_error} =
+               ExAthena.query("hi", provider: :mock, mock: [error: :some_error])
+
+      assert_receive {:telemetry, [:ex_athena, :request_queue, :wait], _, %{provider: :mock}}
+      assert_receive {:telemetry, [:ex_athena, :request_queue, :acquired], _, %{provider: :mock}}
+      assert_receive {:telemetry, [:ex_athena, :request_queue, :released], _, %{provider: :mock}}
+    end
+
+    test "emits :released even when stream callback raises" do
+      events = [%ExAthena.Streaming.Event{type: :text_delta, data: "x"}]
+      bad_callback = fn _event -> raise "boom" end
+
+      assert_raise RuntimeError, "boom", fn ->
+        ExAthena.stream("hi", bad_callback,
+          provider: :mock,
+          mock: [text: "ok"],
+          mock_events: events
+        )
+      end
+
+      assert_receive {:telemetry, [:ex_athena, :request_queue, :wait], _, %{provider: :mock}}
+      assert_receive {:telemetry, [:ex_athena, :request_queue, :acquired], _, %{provider: :mock}}
+      assert_receive {:telemetry, [:ex_athena, :request_queue, :released], _, %{provider: :mock}}
+    end
+
+    test "emits :timeout when acquire times out" do
+      Application.put_env(:ex_athena, :mock, request_queue: [max_depth: 1])
+      :ok = RequestQueue.acquire(:mock)
+
+      assert {:error, :request_queue_timeout} =
+               ExAthena.query("hi",
+                 provider: :mock,
+                 mock: [text: "never"],
+                 queue_timeout: 20
+               )
+
+      assert_receive {:telemetry, [:ex_athena, :request_queue, :wait], _, %{provider: :mock}}
+      assert_receive {:telemetry, [:ex_athena, :request_queue, :timeout], _, %{provider: :mock}}
+      refute_received {:telemetry, [:ex_athena, :request_queue, :acquired], _, _}
+      refute_received {:telemetry, [:ex_athena, :request_queue, :released], _, _}
+
+      RequestQueue.release(:mock)
+    end
+
+    test "measurements are maps (may be empty, never nil)" do
+      assert {:ok, _} = ExAthena.query("hi", provider: :mock, mock: [text: "ok"])
+
+      assert_receive {:telemetry, [:ex_athena, :request_queue, :wait], wait_m, _}
+      assert_receive {:telemetry, [:ex_athena, :request_queue, :acquired], acq_m, _}
+      assert_receive {:telemetry, [:ex_athena, :request_queue, :released], rel_m, _}
+
+      assert is_map(wait_m)
+      assert is_map(acq_m)
+      assert is_map(rel_m)
+    end
+  end
+
+  describe "no telemetry when queue is disabled" do
+    test "no request_queue events are emitted when queue is not enabled" do
+      assert {:ok, _} = ExAthena.query("hi", provider: :mock, mock: [text: "ok"])
+
+      refute_received {:telemetry, [:ex_athena, :request_queue, _], _, _}
+    end
+
+    test "no request_queue events when queue: false is passed" do
+      Application.put_env(:ex_athena, :request_queue, enabled: true)
+      start_supervised!(RequestQueue)
+
+      assert {:ok, _} =
+               ExAthena.query("hi", provider: :mock, mock: [text: "ok"], queue: false)
+
+      refute_received {:telemetry, [:ex_athena, :request_queue, _], _, _}
+    end
+  end
+end

--- a/test/ex_athena/request_queue_telemetry_test.exs
+++ b/test/ex_athena/request_queue_telemetry_test.exs
@@ -90,7 +90,7 @@ defmodule ExAthena.RequestQueueTelemetryTest do
       RequestQueue.release(:mock)
     end
 
-    test "measurements are maps (may be empty, never nil)" do
+    test "measurements carry expected fields" do
       assert {:ok, _} = ExAthena.query("hi", provider: :mock, mock: [text: "ok"])
 
       assert_receive {:telemetry, [:ex_athena, :request_queue, :wait], wait_m, _}
@@ -98,8 +98,26 @@ defmodule ExAthena.RequestQueueTelemetryTest do
       assert_receive {:telemetry, [:ex_athena, :request_queue, :released], rel_m, _}
 
       assert is_map(wait_m)
-      assert is_map(acq_m)
-      assert is_map(rel_m)
+      assert is_integer(acq_m.wait_ms) and acq_m.wait_ms >= 0
+      assert is_integer(acq_m.depth) and acq_m.depth >= 0
+      assert is_integer(rel_m.depth) and rel_m.depth >= 0
+    end
+
+    test ":timeout measurement carries waited_ms" do
+      Application.put_env(:ex_athena, :mock, request_queue: [max_depth: 1])
+      :ok = RequestQueue.acquire(:mock)
+
+      assert {:error, :request_queue_timeout} =
+               ExAthena.query("hi",
+                 provider: :mock,
+                 mock: [text: "never"],
+                 queue_timeout: 20
+               )
+
+      assert_receive {:telemetry, [:ex_athena, :request_queue, :timeout], timeout_m, _}
+      assert is_integer(timeout_m.waited_ms) and timeout_m.waited_ms >= 0
+
+      RequestQueue.release(:mock)
     end
   end
 

--- a/test/ex_athena/request_queue_test.exs
+++ b/test/ex_athena/request_queue_test.exs
@@ -1,0 +1,112 @@
+defmodule ExAthena.RequestQueueTest do
+  use ExUnit.Case, async: false
+
+  alias ExAthena.RequestQueue
+
+  setup do
+    start_supervised!(RequestQueue)
+    :ok
+  end
+
+  describe "depth/1" do
+    test "returns 0 for a provider with no active slots" do
+      assert RequestQueue.depth(:ollama) == 0
+    end
+
+    test "returns 0 for unknown providers" do
+      assert RequestQueue.depth(:unknown_provider_xyz) == 0
+    end
+  end
+
+  describe "acquire/1" do
+    test "returns :ok and increments depth" do
+      assert :ok = RequestQueue.acquire(:openai)
+      assert RequestQueue.depth(:openai) == 1
+    end
+
+    test "allows multiple concurrent slots up to the max depth" do
+      max = ExAthena.Config.request_queue_max_depth(:openai)
+
+      for _ <- 1..max do
+        assert :ok = RequestQueue.acquire(:openai)
+      end
+
+      assert RequestQueue.depth(:openai) == max
+    end
+
+    test "blocks when max depth is reached and unblocks when a slot is released" do
+      max = ExAthena.Config.request_queue_max_depth(:ollama)
+      for _ <- 1..max, do: :ok = RequestQueue.acquire(:ollama)
+
+      test_pid = self()
+
+      task =
+        Task.async(fn ->
+          result = RequestQueue.acquire(:ollama)
+          send(test_pid, {:acquired, result})
+          result
+        end)
+
+      Process.sleep(30)
+      assert RequestQueue.depth(:ollama) == max
+
+      RequestQueue.release(:ollama)
+      assert_receive {:acquired, :ok}, 1_000
+
+      Task.shutdown(task, :brutal_kill)
+    end
+
+    test "multiple providers are independent" do
+      :ok = RequestQueue.acquire(:ollama)
+      :ok = RequestQueue.acquire(:openai)
+      assert RequestQueue.depth(:ollama) == 1
+      assert RequestQueue.depth(:openai) == 1
+    end
+  end
+
+  describe "release/1" do
+    test "decrements depth after acquire" do
+      :ok = RequestQueue.acquire(:ollama)
+      :ok = RequestQueue.release(:ollama)
+      assert RequestQueue.depth(:ollama) == 0
+    end
+
+    test "depth does not go below zero on extra release" do
+      :ok = RequestQueue.release(:ollama)
+      assert RequestQueue.depth(:ollama) == 0
+    end
+
+    test "releasing one slot allows a queued waiter to proceed" do
+      max = ExAthena.Config.request_queue_max_depth(:ollama)
+      for _ <- 1..max, do: :ok = RequestQueue.acquire(:ollama)
+
+      test_pid = self()
+
+      _waiter =
+        spawn(fn ->
+          :ok = RequestQueue.acquire(:ollama)
+          send(test_pid, :waiter_acquired)
+        end)
+
+      Process.sleep(20)
+      :ok = RequestQueue.release(:ollama)
+      assert_receive :waiter_acquired, 500
+    end
+  end
+
+  describe "dead waiter cleanup" do
+    test "a dying waiter is removed from the queue so the next release decrements depth" do
+      max = ExAthena.Config.request_queue_max_depth(:ollama)
+      for _ <- 1..max, do: :ok = RequestQueue.acquire(:ollama)
+
+      waiter = spawn(fn -> RequestQueue.acquire(:ollama) end)
+      Process.sleep(20)
+
+      Process.exit(waiter, :kill)
+      Process.sleep(20)
+
+      :ok = RequestQueue.release(:ollama)
+      assert RequestQueue.depth(:ollama) == max - 1
+    end
+  end
+end


### PR DESCRIPTION
## Description

GitHub Issue: https://github.com/udin-io/ex_athena/issues/114

## Goal

Add an optional, opt-in per-provider request queue to ex_athena so every consumer — the library API, `mix athena.chat` (TUI), `mix athena.web` (GUI), and downstream apps like udin_code — get the same protection from hammering local LLM endpoints (Ollama, llama.cpp, MLX) and respect cloud rate limits without each consumer reinventing the same semaphore.

## Background

A real incident in **udin_code#1625** showed that firing many serial `ExAthena.query/2` calls in a tight loop floods Ollama at `http://localhost:11434`. The local GPU serialises at the server, but the client opens 20 connections, hits timeout, retries, and amplifies the load. Cloud providers have similar exposure via rate limits.

udin_code is filing its own queue at the `UdinCode.Agent.AthenaBackend` layer as the immediate fix (won't wait on this). This ticket is the *upstream-correct* version that lives in ex_athena so:

- The ex_athena TUI / GUI benefit (today they have zero protection).
- Other downstream apps inherit the fix.
- udin_code can eventually remove its local queue in favour of the upstream one.

## Proposed shape

**New module: `ExAthena.RequestQueue`** — a GenServer-backed per-provider semaphore. ETS-stored for fast `acquire/release`.

```
ExAthena.RequestQueue.acquire(provider, timeout_ms) → {:ok, ref} | {:error, :timeout}
ExAthena.RequestQueue.release(ref) → :ok
ExAthena.RequestQueue.depth(provider) → non_neg_integer
```

**Wiring:** `ExAthena.query/2`, `ExAthena.stream/3`, `ExAthena.run/2`, `ExAthena.extract_structured/3` acquire on entry, release on exit. The semaphore key is the resolved provider atom (`:ollama`, `:openai`, `:openrouter`, etc.) — combine with `base_url` when distinguishing local instances matters (e.g. two Ollama servers on different ports should not share a permit).

**Default per-provider caps:**

| Provider | Default concurrency | Rationale |
|---|---|---|
| `:ollama` | 2 | Single local GPU; capping avoids retry storms |
| `:llamacpp` | 1 | Same hardware; usually single-model |
| `:exo` | 3 | P2P inference; more parallelism |
| `:openai` / `:openai_compatible` | 10 | Cloud; rate-limited by API key |
| `:anthropic` / `:claude` | 10 | Cloud |
| `:gemini` | 10 | Cloud |
| Unknown / runtime-registered (e.g. OpenRouter via ex_athena#111) | 10 | Cloud-class default |

**Opt-out:** disabled by default to preserve current behavior (no behavioral change for existing callers on dep bump). Enable via `config :ex_athena, :request_queue, enabled: true, defaults: [...]` or `Application.put_env/2`.

**Per-call override:** `ExAthena.query(prompt, opts ++ [queue: false])` skips the queue for callers that need raw throughput (e.g. throughput benchmarks).

## Streaming

Acquire BEFORE the request opens; release AFTER the stream closes. `on_event` callbacks fire inside the held permit so they are unaffected. The release must run on every termination path (success, error, caller cancellation) — implement with `Process.monitor` on the calling pid + `after` blocks so a crashed caller does not leak a permit.

## Provider-spec integration

If ex_athena#111 (runtime JSON provider config) lands first, each provider JSON gets an optional `request_queue` block:

```json
{
  \"name\": \"openrouter\",
  \"base_url\": \"https://openrouter.ai/api/v1\",
  \"request_queue\": { \"max_concurrency\": 20, \"acquire_timeout_ms\": 60000 }
}
```

The registry validator accepts these fields; `RequestQueue` consults the registry for per-provider caps before falling back to the global defaults map.

## Telemetry

Emit on every operation:

- `[:ex_athena, :request_queue, :wait]` with `%{provider, wait_ms}`
- `[:ex_athena, :request_queue, :acquired]` with `%{provider, depth}`
- `[:ex_athena, :request_queue, :released]` with `%{provider, depth}`
- `[:ex_athena, :request_queue, :timeout]` with `%{provider, waited_ms}`

The TUI's `/details` and the GUI's sidebar can surface live depth + wait p50/p99 from these.

## Files to change

- **New:** `lib/ex_athena/request_queue.ex`
- **New:** `lib/ex_athena/request_queue/supervisor.ex` (under `ExAthena.Application` if there is one, or a small Supervisor exposed for embedders to mount)
- `lib/ex_athena.ex` — wrap `query/2`, `stream/3`, `run/2`, `extract_structured/3` in acquire/release when `:enabled` is true
- `lib/ex_athena/config.ex` — register `:request_queue` settings, expose `RequestQueue.defaults/0`
- If ex_athena#111 has landed: `lib/ex_athena/provider_registry.ex` reads per-provider `request_queue` from JSON
- `mix athena.chat` and `mix athena.web` — optional small status indicator showing current provider queue depth
- CHANGELOG entry under \"Added\"

## Tests

- Unit: cap is honored under concurrent load; release is FIFO; timeout returns `{:error, :timeout}`.
- Unit: crashed caller does not leak a permit (verify with `Process.monitor`).
- Integration: 20 parallel `query/2` calls against a fake `:ollama` provider with cap 2 result in max 2 in-flight HTTP requests at any moment (assert via telemetry).
- Streaming: `stream/3` holds the permit for the duration of the stream and releases on close.
- Opt-out: `queue: false` skips the queue entirely.
- Default-disabled: with no config, behavior matches today's (no queue).

## Acceptance criteria

- [ ] `ExAthena.RequestQueue` exists, supervised, optional, default-disabled.
- [ ] When enabled, every entry point in `ExAthena` (`query/2`, `stream/3`, `run/2`, `extract_structured/3`) goes through acquire/release.
- [ ] Streaming sessions are not throttled below their natural latency.
- [ ] Crashed callers do not leak permits (verified test).
- [ ] Telemetry events documented in `docs/telemetry.md` (or in the ex_athena#112 docs ticket).
- [ ] CHANGELOG entry under \"Added\".
- [ ] Existing test suite still passes with the queue disabled.

## Coordination

- **udin_code#1625** ships first as the immediate fix at the AthenaBackend layer.
- After this ticket lands and is published to hex, udin_code bumps the dep, removes its local `UdinCode.LLM.RequestQueue`, and switches to `ExAthena.RequestQueue`.

## Related

- **udin_code#1625** — local queue (immediate fix).
- **ex_athena#111** — runtime provider JSON config; per-provider queue caps slot into that JSON.
- **ex_athena#112** — docs update; telemetry + queue config should appear there.

## Summary

This PR implements: **Built-in per-provider request queue / concurrency cap (upstream of udin_code#1625)**

---
*Created by UdinCode*

Closes https://github.com/udin-io/ex_athena/issues/114