### PR TITLE
Docs: runtime provider config (JSON), OpenRouter & friends, TUI/GUI provider management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and ExAthena adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- **Runtime JSON provider config + example providers (#110).** Drop a `*.json`
+- **Runtime JSON provider config + example providers (#111).** Drop a `*.json`
   file into `~/.config/ex_athena/providers/` to define a named provider at
   startup with no changes to `config.exs`. The new `ExAthena.ProviderRegistry`
   reads every file at boot, validates the schema, and registers each provider

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,29 @@ and ExAthena adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- **`:openrouter` built-in provider.** Register OpenRouter as a first-class
-  provider atom. Callers can now write `provider: :openrouter,
-  base_url: "https://openrouter.ai/api/v1", api_key: ..., model: "anthropic/claude-3.5-sonnet"`.
-  OpenRouter is 100% OpenAI wire-compatible so this is a pure registration
-  change backed by the existing `ExAthena.Providers.ReqLLM` adapter — no new
-  HTTP code, no streaming changes, no tool-call changes.
+- **Runtime JSON provider config + example providers (#110).** Drop a `*.json`
+  file into `~/.config/ex_athena/providers/` to define a named provider at
+  startup with no changes to `config.exs`. The new `ExAthena.ProviderRegistry`
+  reads every file at boot, validates the schema, and registers each provider
+  under its `name` string. Files that fail validation are skipped with a warning
+  — a bad file does not prevent the application from starting. Five ready-to-copy
+  example providers ship in `priv/provider_examples/`:
+  - **`openrouter.json`** — OpenRouter gateway; routes to hundreds of models
+    from Anthropic, Google, Meta, and Mistral through a single OpenAI-compatible
+    endpoint. Also registered as the `:openrouter` built-in atom for
+    `config.exs` users.
+  - **`groq.json`** — Groq LPU inference; ultra-low-latency open-source models
+    including Llama 3.3 and Mixtral.
+  - **`together.json`** — Together AI; broad catalog of hosted open-source
+    models with optional fine-tuning support.
+  - **`fireworks.json`** — Fireworks AI; fast serverless inference for popular
+    open-source models.
+  - **`deepseek.json`** — DeepSeek; cost-effective inference for DeepSeek-series
+    models including the reasoning variant.
+
+  See the [Providers guide](guides/providers.md#runtime-json-config) for the
+  full schema reference and the new [Upgrading guide](guides/upgrading.md) for
+  migration notes (existing `config.exs` setups require no changes).
 
 ## v0.14.0 — Mid-loop intervention hook + structured completion signal
 

--- a/README.md
+++ b/README.md
@@ -298,6 +298,8 @@ a chosen UUID. See [sessions + checkpoints](guides/sessions_and_checkpoints.md).
 
 - [Getting started](guides/getting_started.md)
 - [Providers](guides/providers.md)
+- [Terminal chat (mix athena.chat)](guides/tui.md)
+- [Browser chat (mix athena.web)](guides/web.md)
 - [Multimodal (vision)](guides/multimodal.md)
 - [Gemini setup](guides/gemini.md)
 - [Tool calls](guides/tool_calls.md)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,27 @@ only if you want `mix athena.chat` or `mix athena.web`. Then run
 `mix ex_athena.install` once to wire up defaults, or configure manually (see
 [Configuration](#configuration)).
 
+## Configuring providers
+
+Provider settings resolve in three layers, highest priority first:
+
+1. **Per-call opts** — `ExAthena.query("…", provider: :groq, model: "…")` — overrides everything.
+2. **Application config** — `config :ex_athena, :ollama, model: "…"` in `config.exs`.
+3. **JSON files** — `~/.config/ex_athena/providers/*.json` — named providers loaded at startup.
+
+**Quickstart with a JSON provider (Groq):**
+
+```bash
+mkdir -p ~/.config/ex_athena/providers
+cp priv/provider_examples/groq.json ~/.config/ex_athena/providers/
+export GROQ_API_KEY=gsk_…
+mix athena.chat
+```
+
+ExAthena reads `groq.json` at startup and makes `"groq"` available by name. Full schema,
+security notes, and example files for Groq, Together, Fireworks, DeepSeek, and OpenRouter are
+in [guides/providers.md](guides/providers.md).
+
 ## Quick start
 
 ```elixir

--- a/guides/providers.md
+++ b/guides/providers.md
@@ -1,7 +1,9 @@
 # Providers
 
-ExAthena ships four built-in providers plus a `:mock` for tests. Consumers
-can also pass any module that implements `ExAthena.Provider` directly.
+ExAthena ships five built-in providers plus a `:mock` for tests. Consumers
+can also pass any module that implements `ExAthena.Provider` directly, or drop
+a JSON file into `~/.config/ex_athena/providers/` to define a named provider
+at runtime without touching `config.exs`.
 
 ## Ollama (`:ollama`)
 
@@ -111,6 +113,33 @@ ExAthena.query("…", provider: :gemini, model: "gemini-2.5-pro")
 For the full walkthrough — API key setup, model table, tool-calling caveats,
 and rate-limit notes — see the **[Gemini setup guide](gemini.md)**.
 
+## OpenRouter (`:openrouter`)
+
+Hosted model gateway that routes to hundreds of models from Anthropic, Google,
+Meta, Mistral, and others through a single OpenAI-compatible endpoint. Requires
+an [OpenRouter API key](https://openrouter.ai).
+
+```elixir
+config :ex_athena, :openrouter,
+  api_key: System.get_env("OPENROUTER_API_KEY"),
+  model: "anthropic/claude-opus-4-5"
+```
+
+Per-call model switch:
+
+```elixir
+ExAthena.query("…", provider: :openrouter, model: "google/gemini-2.5-pro")
+```
+
+### Capabilities
+
+| Feature | Status |
+|---|---|
+| Native tool calls | ✅ (model-dependent) |
+| Streaming | ✅ SSE |
+| JSON mode | ✅ via `response_format: %{type: "json_object"}` |
+| Resume | ❌ |
+
 ## Mock (`:mock`)
 
 Unit-test double. Scripted responses either via canned text or a responder
@@ -148,6 +177,155 @@ walkthrough including examples for each provider.
 | `:openai_compatible` | ✅ gpt-4o, gpt-4o-mini | URL + inline |
 | `:claude` | ✅ Any `claude-3`+ model | PNG, JPEG, GIF, WebP |
 | `:gemini` | ✅ Any `gemini-1.5`+ model | Inline + URL |
+
+## Runtime JSON config
+
+ExAthena reads every `*.json` file from `~/.config/ex_athena/providers/` at
+application startup via `ExAthena.ProviderRegistry`. Each file defines one named
+provider that you reference by its `name` string, the same way you pass a
+built-in atom.
+
+```elixir
+ExAthena.query("…", provider: "my-groq")
+ExAthena.query("…", provider: "my-groq", model: "mixtral-8x7b-32768")
+```
+
+Files that fail validation are skipped with a warning — a single bad file does
+not prevent others from loading and the application still starts.
+
+### Schema
+
+| Field | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `name` | string | ✅ | — | Unique provider name; used as the lookup key |
+| `adapter` | string | ✅ | — | `"req_llm"` or `"mock"` |
+| `req_llm_provider_tag` | string | — | `null` | req_llm routing tag (`"openai"`, `"anthropic"`, `"google"`) |
+| `base_url` | string | — | `null` | Override the adapter's default endpoint URL |
+| `api_key` | string | — | `null` | Static API key (prefer `api_key_env` — see Security) |
+| `api_key_env` | string | — | `null` | Environment variable name; key is read at startup |
+| `default_model` | string | — | `null` | Model used when no `model:` is supplied per-call |
+| `metadata` | object | — | `{}` | Arbitrary pass-through data; ignored by ExAthena |
+
+### Security
+
+Never store raw API keys in JSON files that may be committed to version control.
+
+* Use `api_key_env` to name the environment variable instead of embedding the
+  key directly:
+
+```json
+{
+  "name": "my-groq",
+  "adapter": "req_llm",
+  "req_llm_provider_tag": "openai",
+  "base_url": "https://api.groq.com/openai/v1",
+  "api_key_env": "GROQ_API_KEY",
+  "default_model": "llama-3.3-70b-versatile"
+}
+```
+
+* Restrict file permissions on any file that does contain a literal key:
+
+```sh
+chmod 600 ~/.config/ex_athena/providers/my-provider.json
+```
+
+* Add `~/.config/ex_athena/providers/` to `.gitignore` when files may contain
+  credentials.
+
+### Writing your own
+
+1. **`name`** must be a non-empty string unique across all files in the
+   directory. It becomes the string you pass to `provider:`.
+2. **`adapter`** must be exactly `"req_llm"` (any HTTP-based model endpoint) or
+   `"mock"` (tests only).
+3. **`req_llm_provider_tag`** routes requests through req_llm's model catalog.
+   Use `"openai"` for OpenAI-compatible endpoints, `"anthropic"` for Anthropic,
+   `"google"` for Google Gemini.
+4. **Validation errors** (missing required fields, unknown adapter, malformed
+   JSON) are logged as warnings and the file is skipped — the application still
+   starts normally.
+5. Files are loaded once at startup. Restart the application to pick up changes.
+
+Ready-to-copy examples live in `priv/provider_examples/`.
+
+## Groq
+
+[Groq](https://groq.com) provides ultra-fast inference for open-source models on
+dedicated LPU hardware.
+
+```json
+{
+  "name": "groq",
+  "adapter": "req_llm",
+  "req_llm_provider_tag": "openai",
+  "base_url": "https://api.groq.com/openai/v1",
+  "api_key_env": "GROQ_API_KEY",
+  "default_model": "llama-3.3-70b-versatile"
+}
+```
+
+Copy `priv/provider_examples/groq.json` to `~/.config/ex_athena/providers/` and
+set `GROQ_API_KEY`. Supported models include `llama-3.3-70b-versatile`,
+`llama-3.1-8b-instant`, and `mixtral-8x7b-32768`.
+
+## Together AI
+
+[Together AI](https://www.together.ai) hosts a broad catalog of open-source
+models with optional fine-tuning.
+
+```json
+{
+  "name": "together",
+  "adapter": "req_llm",
+  "req_llm_provider_tag": "openai",
+  "base_url": "https://api.together.xyz/v1",
+  "api_key_env": "TOGETHER_API_KEY",
+  "default_model": "meta-llama/Llama-3-70b-chat-hf"
+}
+```
+
+Copy `priv/provider_examples/together.json` to `~/.config/ex_athena/providers/`
+and set `TOGETHER_API_KEY`.
+
+## Fireworks AI
+
+[Fireworks AI](https://fireworks.ai) offers serverless inference for popular
+open-source models with low latency.
+
+```json
+{
+  "name": "fireworks",
+  "adapter": "req_llm",
+  "req_llm_provider_tag": "openai",
+  "base_url": "https://api.fireworks.ai/inference/v1",
+  "api_key_env": "FIREWORKS_API_KEY",
+  "default_model": "accounts/fireworks/models/llama-v3p3-70b-instruct"
+}
+```
+
+Copy `priv/provider_examples/fireworks.json` to
+`~/.config/ex_athena/providers/` and set `FIREWORKS_API_KEY`.
+
+## DeepSeek
+
+[DeepSeek](https://www.deepseek.com) provides cost-effective inference for the
+DeepSeek family of models.
+
+```json
+{
+  "name": "deepseek",
+  "adapter": "req_llm",
+  "req_llm_provider_tag": "openai",
+  "base_url": "https://api.deepseek.com/v1",
+  "api_key_env": "DEEPSEEK_API_KEY",
+  "default_model": "deepseek-chat"
+}
+```
+
+Copy `priv/provider_examples/deepseek.json` to
+`~/.config/ex_athena/providers/` and set `DEEPSEEK_API_KEY`. Use
+`"deepseek-reasoner"` for the reasoning-optimised variant.
 
 ## Custom providers
 

--- a/guides/providers.md
+++ b/guides/providers.md
@@ -204,6 +204,7 @@ not prevent others from loading and the application still starts.
 | `api_key` | string | — | `null` | Static API key (prefer `api_key_env` — see Security) |
 | `api_key_env` | string | — | `null` | Environment variable name; key is read at startup |
 | `default_model` | string | — | `null` | Model used when no `model:` is supplied per-call |
+| `api_key_prompt` | boolean | — | `false` | When `true`, the web UI sidebar shows an inline API-key password field; key is held in socket state and never written to disk. Web UI only — has no effect in the TUI. |
 | `metadata` | object | — | `{}` | Arbitrary pass-through data; ignored by ExAthena |
 
 ### Security

--- a/guides/tui.md
+++ b/guides/tui.md
@@ -112,6 +112,10 @@ The key is read once at application startup and held in memory for the
 session — it is never written to disk by the TUI. Use `api_key_env`
 instead of a literal `api_key` field for any file that may be shared.
 
+The `api_key_prompt: true` field has no effect in the TUI — it only
+activates the inline key field in the web sidebar (`mix athena.web`).
+See the [Web UI guide](web.md#inline-api-key-prompt) for details.
+
 See the [providers guide](providers.md) for the full JSON schema and
 ready-to-copy examples for Groq, Together AI, Fireworks, DeepSeek, and
 others.

--- a/guides/tui.md
+++ b/guides/tui.md
@@ -1,0 +1,255 @@
+# Terminal chat (mix athena.chat)
+
+`mix athena.chat` drops you into a full-screen TUI powered by
+[ExRatatui](https://github.com/livebook-dev/ex_ratatui). It connects to
+the ExAthena agent loop, streams tokens live, and surfaces tool calls and
+their results inline.
+
+## Prerequisites
+
+The TUI requires the optional `:ex_ratatui` dependency:
+
+```elixir
+# mix.exs
+{:ex_ratatui, "~> 0.10"}
+```
+
+ExAthena declares it `optional: true` so projects that only use the
+programmatic API don't pull it in. Without it, `mix athena.chat` prints
+an error and exits.
+
+## Launching
+
+```bash
+mix athena.chat
+mix athena.chat --provider llamacpp
+mix athena.chat --provider ollama --model qwen2.5-coder:14b
+mix athena.chat --mode plan_and_solve
+mix athena.chat -p ~/projects/my_app
+```
+
+### Flags
+
+| Flag | Alias | Description |
+|---|---|---|
+| `--provider NAME` | | Which provider to use (`:ollama`, `:llamacpp`, `:openai_compatible`, `:claude`, `:gemini`, `:openrouter`, or a JSON-defined name). Defaults to `config :ex_athena, default_provider:`. |
+| `--model NAME` | | Initial model. Overrides the provider's configured default. |
+| `--mode NAME` | | Agent mode: `react`, `plan_and_solve`, or `reflexion`. |
+| `--path PATH` | `-p` | Working directory for filesystem tools. `~` is expanded. The chat process does **not** `cd` — tools just receive this as their `cwd`. |
+
+## Selecting a provider
+
+### Built-in providers
+
+Providers are configured in `config/config.exs`. The TUI reads the same
+configuration your application uses at runtime:
+
+```elixir
+# Ollama (local, free — requires `ollama serve`)
+config :ex_athena, default_provider: :ollama
+config :ex_athena, :ollama,
+  base_url: "http://localhost:11434",
+  model: "qwen2.5-coder:14b"
+
+# llama.cpp (local, free — requires `llama-server --model ...`)
+config :ex_athena, :llamacpp,
+  base_url: "http://localhost:8080",
+  model: "qwen2.5-coder"
+
+# OpenAI / OpenAI-compatible
+config :ex_athena, :openai_compatible,
+  base_url: "https://api.openai.com/v1",
+  api_key: System.get_env("OPENAI_API_KEY"),
+  model: "gpt-4o-mini"
+
+# Anthropic Claude
+config :ex_athena, :claude,
+  api_key: System.get_env("ANTHROPIC_API_KEY"),
+  model: "claude-opus-4-5"
+
+# Google Gemini
+config :ex_athena, :gemini,
+  api_key: System.get_env("GOOGLE_API_KEY"),
+  model: "gemini-2.5-flash"
+
+# OpenRouter
+config :ex_athena, :openrouter,
+  api_key: System.get_env("OPENROUTER_API_KEY"),
+  model: "anthropic/claude-opus-4-5"
+```
+
+Then launch with the provider you configured:
+
+```bash
+mix athena.chat --provider openai_compatible
+mix athena.chat --provider gemini --model gemini-2.5-pro
+```
+
+### JSON-defined providers
+
+ExAthena loads every `*.json` file in `~/.config/ex_athena/providers/` at
+startup. Drop a file there to define a named provider without touching
+`config.exs` — useful for personal keys that shouldn't live in a project
+repository:
+
+```json
+{
+  "name": "groq",
+  "adapter": "req_llm",
+  "req_llm_provider_tag": "openai",
+  "base_url": "https://api.groq.com/openai/v1",
+  "api_key_env": "GROQ_API_KEY",
+  "default_model": "llama-3.3-70b-versatile"
+}
+```
+
+```bash
+mix athena.chat --provider groq
+```
+
+The `api_key_env` field names the environment variable that holds the key.
+The key is read once at application startup and held in memory for the
+session — it is never written to disk by the TUI. Use `api_key_env`
+instead of a literal `api_key` field for any file that may be shared.
+
+See the [providers guide](providers.md) for the full JSON schema and
+ready-to-copy examples for Groq, Together AI, Fireworks, DeepSeek, and
+others.
+
+## Layout
+
+```
+┌─────────────────────────────────────────────────────┬────────────────────┐
+│ ollama · qwen2.5-coder:14b · react  iter 3  1.2k t  │ Timeline  Changes  │
+├─────────────────────────────────────────────────────┤                    │
+│                                                     │ iteration 1        │
+│  You: refactor the auth module                      │ → read             │
+│                                                     │   {"path":"lib/…"} │
+│  Assistant: I'll start by reading the current …     │ ← result           │
+│                                                     │   defmodule Auth…  │
+│  ● read(lib/auth.ex)                                │ iteration 2        │
+│    └ defmodule Auth do                              │ → edit             │
+│                                                     │   …                │
+│  ● edit(lib/auth.ex)                                │                    │
+│    └ patch applied (14 lines)                       │                    │
+│                                                     │                    │
+├─────────────────────────────────────────────────────┤                    │
+│ ┌─────────────────────────────────────────────────┐ │                    │
+│ │ /                                               │ │                    │
+│ └─────────────────────────────────────────────────┘ │                    │
+├─────────────────────────────────────────────────────┴────────────────────┤
+│ Enter: send  Ctrl+C: quit  /help                                          │
+└───────────────────────────────────────────────────────────────────────────┘
+```
+
+- **Header** — active provider, model, mode, iteration count, token usage, and accumulated cost.
+- **Messages** (left, flex height) — streaming assistant text, tool-call blocks with inline output previews.
+- **Details** (right pane) — Timeline tab shows the full tool argument / result for every call; Changes tab shows `git diff HEAD` refreshed after each tool result.
+- **Input** — multiline textarea. `Enter` sends; `Shift+Enter` inserts a newline.
+- **Footer** — context-sensitive keyboard hints.
+
+## Model and mode pickers
+
+Typing `/model` or `/mode` with no argument opens a scrollable popup over
+the messages area:
+
+```
+┌──────────────────────────────┐
+│ Select model                 │
+│ ▶ qwen2.5-coder:14b          │
+│   llama3.1                   │
+│   mistral-nemo               │
+│   phi-3.5                    │
+└──────────────────────────────┘
+```
+
+- `↑` / `k` — move up
+- `↓` / `j` — move down
+- `Enter` — confirm selection
+- `Esc` — close without selecting
+
+Or set directly to skip the picker:
+
+```
+/model mistral-nemo
+/mode plan_and_solve
+```
+
+## Slash commands
+
+Type `/` in the input to open autocomplete. A dropdown shows matching
+commands and their descriptions as you type the verb. Press `Tab` or
+`Enter` on a suggestion to complete it.
+
+| Command | Description |
+|---|---|
+| `/help`, `/?` | Show full usage help |
+| `/clear` | Wipe the conversation history and start a fresh session |
+| `/tools` | List the tools currently available to the agent |
+| `/model [name]` | Open the model picker, or set the model directly |
+| `/mode [name]` | Open the mode picker, or set the mode directly (`react`, `plan_and_solve`, `reflexion`) |
+| `/expand [N]` | Show the full text of the Nth most-recent tool result (default: 1 = most recent) |
+| `/details [on\|off]` | Show or hide the right details pane; no argument toggles |
+| `/tab` | Cycle the details pane tab: Timeline ↔ Changes |
+| `/timeline` | Switch to the Timeline tab |
+| `/diff [side\|inline]` | Switch to the Changes tab; optionally set the layout (`side` = side-by-side, `inline` = unified diff) |
+| `/cd PATH` | Set the working directory for filesystem tools (`~` is expanded; the chat process does not chdir) |
+| `/pwd` | Print the current working directory |
+| `/mouse [on\|off]` | Toggle crossterm mouse capture; `off` restores native terminal text selection |
+| `/exit`, `/quit`, `/q` | Leave the chat |
+
+## Keyboard shortcuts
+
+| Key | Action |
+|---|---|
+| `Enter` | Send message |
+| `Shift+Enter` | Insert newline |
+| `Ctrl+C` | Quit |
+| `↑` / `↓` | Navigate input history (outside a picker) |
+| `↑` / `k`, `↓` / `j` | Move picker / autocomplete selection |
+| `Esc` | Close picker without selecting |
+| `PgUp` / `PgDn` | Scroll the messages pane by ~10 rows |
+| `Shift+PgUp` / `Shift+PgDn` | Scroll the details pane |
+| `End` | Jump both panes back to the bottom (auto-follow mode) |
+| Mouse wheel | Scroll the pane under the cursor (requires mouse capture on) |
+
+Mouse capture is on by default. Use `/mouse off` to drop back to native
+terminal copy/paste (click-drag to select). Many terminals also let you
+bypass capture temporarily by holding `Option` (macOS) or `Shift` while
+click-dragging.
+
+## Streaming and thinking
+
+Tokens stream directly into the messages pane as they arrive. Models that
+emit `<think>` or `<thinking>` blocks have those routed to the details
+pane in real time — you see the reasoning on the right while the final
+answer builds on the left.
+
+## Tool output
+
+Each tool call renders as a collapsible block in the messages pane:
+
+```
+● read(lib/auth.ex)
+  └ defmodule Auth do
+      @moduledoc "…
+      …4 more lines (18 total)
+```
+
+The preview shows up to four lines. To see the full output, use `/expand`
+(or `/expand 2` for the second-most-recent result). The details pane
+always shows the complete text.
+
+## Tips
+
+- **Working directory**: set `-p ~/projects/my_app` at launch or use `/cd`
+  during the session. The TUI shows the active path in the details pane
+  header after `/cd`.
+- **Long responses**: if the model is still running and you need to scroll
+  up to re-read earlier output, `PgUp` pauses auto-follow. `End` or
+  sending your next message resumes it.
+- **Side-by-side diff**: `/diff side` switches the Changes tab to a
+  two-column layout. `/diff inline` or `/diff` switches back to unified.
+- **Mode switching**: `plan_and_solve` adds an explicit planning phase
+  before the agent executes tools — useful for complex multi-file tasks.
+  `reflexion` adds a self-critique loop after each iteration.

--- a/guides/upgrading.md
+++ b/guides/upgrading.md
@@ -1,0 +1,100 @@
+# Upgrading ExAthena
+
+This guide covers migration steps for notable version changes.
+
+## Upgrading to runtime provider config (current)
+
+ExAthena now loads provider definitions from JSON files at startup in addition
+to the traditional `config.exs` approach. **No migration is required** — every
+existing `config :ex_athena, :provider_atom, [...]` entry continues to work
+exactly as before.
+
+### What's new
+
+A `ProviderRegistry` reads every `*.json` file from
+`~/.config/ex_athena/providers/` at application boot. Each file defines one
+named provider that you pass to `provider:` as a string:
+
+```elixir
+ExAthena.query("…", provider: "my-groq")
+ExAthena.query("…", provider: "my-groq", model: "mixtral-8x7b-32768")
+```
+
+Files that fail validation are skipped with a warning — a bad file does not
+prevent the application from starting or other providers from loading.
+
+### Existing config.exs setup — no changes needed
+
+If you already configure providers in `config.exs`, keep doing so:
+
+```elixir
+# config/config.exs — still works, nothing to change
+config :ex_athena, default_provider: :ollama
+config :ex_athena, :ollama,
+  base_url: "http://localhost:11434",
+  model: "llama3.1"
+
+config :ex_athena, :openrouter,
+  api_key: System.get_env("OPENROUTER_API_KEY"),
+  model: "anthropic/claude-opus-4-5"
+```
+
+Per-call opts still override everything:
+
+```elixir
+ExAthena.query("…", provider: :ollama, model: "qwen2.5-coder:14b")
+```
+
+### Adding a new provider via JSON (OpenRouter, Groq, Together, etc.)
+
+If you want to use a hosted provider like OpenRouter without touching
+`config.exs`, drop a JSON file into `~/.config/ex_athena/providers/`:
+
+**Step 1 — copy an example:**
+
+```bash
+mkdir -p ~/.config/ex_athena/providers/
+cp deps/ex_athena/priv/provider_examples/openrouter.json \
+   ~/.config/ex_athena/providers/openrouter.json
+```
+
+Ready-to-use examples ship in `priv/provider_examples/`:
+
+- `openrouter.json` — routes to hundreds of models through a single endpoint
+- `groq.json` — ultra-low-latency Llama and Mixtral inference
+- `together.json` — broad catalog of hosted open-source models
+- `fireworks.json` — fast serverless inference
+- `deepseek.json` — cost-effective DeepSeek-series models
+
+**Step 2 — set the API key env var:**
+
+Each example file uses `api_key_env` to name the environment variable to read:
+
+```bash
+export OPENROUTER_API_KEY="sk-or-…"
+```
+
+**Step 3 — use the provider:**
+
+```elixir
+ExAthena.query("…", provider: "openrouter")
+ExAthena.query("…", provider: "openrouter", model: "google/gemini-2.5-pro")
+```
+
+Or set it as the default in `config.exs`:
+
+```elixir
+config :ex_athena, default_provider: "openrouter"
+```
+
+### Picking a provider in the TUI and web UI
+
+Both `mix athena.chat` and `mix athena.web` surface every registered provider —
+both built-in atoms and JSON-defined names — in their provider picker. No extra
+configuration is needed once the JSON file is in place.
+
+### Full schema reference
+
+See the **[Providers guide](providers.md#runtime-json-config)** for the
+complete field reference, security recommendations, and instructions for writing
+a custom JSON provider.

--- a/guides/web.md
+++ b/guides/web.md
@@ -1,0 +1,222 @@
+# Browser chat (mix athena.web)
+
+`mix athena.web` starts a Phoenix LiveView chat UI backed by the same agent
+loop as `mix athena.chat`. The server binds to all interfaces so you can reach
+it from a phone, a second machine, or any browser on the same network — no
+native install required.
+
+## Prerequisites
+
+The web UI requires three optional dependencies:
+
+```elixir
+# mix.exs
+{:phoenix, "~> 1.7"},
+{:phoenix_live_view, "~> 1.0"},
+{:bandit, "~> 1.5"}
+```
+
+ExAthena declares them `optional: true` so the core library stays lean.
+Without them, `mix athena.web` prints an error and exits.
+
+The JS bundle is served directly from the installed Hex packages — there is no
+npm or esbuild step.
+
+## Launching
+
+```bash
+mix athena.web                  # http://0.0.0.0:4000
+mix athena.web --port 8080      # custom port
+```
+
+### Flags
+
+| Flag | Description |
+|---|---|
+| `--port PORT` | HTTP port. Default: `4000`. |
+
+The server listens on `0.0.0.0`, so any device on the same network can reach
+it at `http://<your-ip>:<port>`.
+
+## Layout
+
+```
+┌──────────────┬────────────────────────────────────┬───────────────────────┐
+│ ◈ ExAthena   │                                    │ ⚡ Reading · foo.ex   │
+│              │  You: refactor the auth module      │                       │
+│ Provider     │                                    │ call  read            │
+│ [Ollama    ▼]│  Assistant: I'll start by …        │  └ {"path":"lib/…"}   │
+│              │                                    │ result                │
+│ Model        │  ● read(lib/auth.ex)               │  └ defmodule Auth…    │
+│ [qwen2.5…  ▼]│    └ defmodule Auth do             │                       │
+│              │      …4 more lines                  │ call  edit            │
+│ Mode         │                                    │  └ {"path":"lib/…"}   │
+│ [ReAct     ▼]│  ● edit(lib/auth.ex)               │ result                │
+│              │    └ patch applied (14 lines)       │  └ patch applied …    │
+│ + New session│                                    │                       │
+│ ▼ Sessions   │  ┌─────────────────────────────┐   │                       │
+│              │  │ /                           │   │                       │
+│ Recent       │  └─────────────────────────────┘   │                       │
+│ my_app       │                                    │                       │
+└──────────────┴────────────────────────────────────┴───────────────────────┘
+```
+
+- **Sidebar** (left) — provider, model, and mode selectors; session list and
+  recent projects; live token/cost status block while the model is running.
+- **Messages** (center) — streaming assistant text with inline tool-call blocks
+  showing collapsible output previews.
+- **Details** (right) — chronological log of every tool call and result,
+  thinking blocks, and iteration markers for the current session.
+- **Right panels** (optional, toggled via ⊟ / ± buttons) — color-coded diff
+  viewer for file edits, raw stdout for Bash calls, and a live `git diff HEAD`
+  panel.
+
+## Sidebar: provider and model selector
+
+The sidebar dropdown lists every provider the registry knows about at startup —
+the five built-in providers **plus** any JSON-defined providers loaded from
+`~/.config/ex_athena/providers/`:
+
+```
+┌──────────────┐
+│ Provider     │
+│ ┌──────────┐ │
+│ │ Ollama ▼ │ │
+│ └──────────┘ │
+│  llama.cpp   │
+│  Ollama      │
+│  Claude      │
+│  OpenAI-compat│
+│  Gemini      │
+│  groq        │  ← JSON-defined provider
+│  deepseek    │  ← JSON-defined provider
+└──────────────┘
+```
+
+This is the same registry the TUI (`mix athena.chat`) reads. A provider
+defined in `~/.config/ex_athena/providers/groq.json` appears in both front-ends
+automatically. See [providers.md](providers.md) for the JSON schema and
+example files.
+
+Switching provider triggers an async model fetch — the model selector shows
+"fetching models…" for local providers (Ollama, llama.cpp) that expose a
+`/api/tags` or `/v1/models` endpoint. Cloud providers (Claude, Gemini,
+OpenAI-compatible) fall back to a free-text input so you can type the model
+name directly.
+
+### Inline API key prompt
+
+A JSON provider definition can include `"api_key_prompt": true` to tell the
+web sidebar to show an inline password field for that provider whenever it is
+selected:
+
+```json
+{
+  "name": "my-openrouter",
+  "adapter": "req_llm",
+  "req_llm_provider_tag": "openai",
+  "base_url": "https://openrouter.ai/api/v1",
+  "api_key_prompt": true,
+  "default_model": "anthropic/claude-opus-4-5"
+}
+```
+
+When a user selects `my-openrouter` from the dropdown, the sidebar renders:
+
+```
+┌──────────────┐
+│ Provider     │
+│ [my-openrouter]
+│              │
+│ API key      │
+│ [••••••••••] │
+└──────────────┘
+```
+
+The key is held in LiveView socket state for the duration of the browser
+session. It is sent to the server only over the WebSocket connection and is
+never written to disk — each page load starts with an empty key field.
+
+For providers where the key is set via `api_key_env` or `config.exs`, the
+prompt field is not shown. `api_key_prompt: true` is intended for shared
+deployments where different users supply their own keys.
+
+## Session persistence
+
+Every completed turn is auto-saved. The persistence layout under
+`~/.ex_athena/web/`:
+
+```
+~/.ex_athena/web/
+├── secret.key          # stable secret_key_base — generated once
+├── recent.json         # recently opened project directories (max 20)
+└── sessions/
+    ├── <id>.session    # full session binary
+    ├── <id>.session
+    └── …
+```
+
+**Session files** are Erlang binary terms written with
+`:erlang.term_to_binary/1`. Each file contains:
+
+| Field | Description |
+|---|---|
+| `id` | UUID — stable across saves |
+| `title` | First user message, truncated |
+| `cwd` | Working directory for this session |
+| `provider` | Provider name at save time |
+| `model` | Model name at save time |
+| `mode` | Agent mode at save time |
+| `created_at` / `updated_at` | `DateTime.t()` |
+| `display_messages` | Rendered message list for fast reload |
+| `ex_messages` | Raw `ExAthena.Messages` for resuming the loop |
+| `tool_uis` | Diff / file / process payloads keyed by tool call ID |
+| `details_stream` | Full right-pane event log |
+
+Sessions survive server restarts because `secret.key` persists the
+`secret_key_base` — the same key is used every run, so existing browser
+cookies remain valid. A fresh random key would cause the old session cookie to
+fail CSRF validation, triggering a LiveView reload with a multi-second delay.
+
+**`recent.json`** tracks the working directories you have opened, newest
+first, capped at 20 entries. The sidebar "Recent" section and the empty-state
+screen both read from this file.
+
+### Loading and managing sessions
+
+Click **▼ Sessions** in the sidebar to expand the session list. Sessions are
+filtered to the active working directory; click a session title to load it, or
+× to delete the file.
+
+**Fork**: every assistant message has a `⑂ fork` button. It duplicates the
+conversation history up to that point and opens a new session — the original
+session is untouched.
+
+## Features at a glance
+
+| Feature | Description |
+|---|---|
+| **Streaming** | Tokens stream in real time over the LiveView WebSocket. |
+| **Thinking** | Models that emit `<think>` blocks show reasoning in the details pane while the answer builds in the main area. |
+| **Action indicator** | While the model runs, a `⚡ Reading · foo.ex` pill tracks the current tool call in real time. |
+| **Diff viewer** | File edits show a **▼ view** button. Click it for a color-coded line diff (`+` green / `−` red) computed server-side. |
+| **Bash output** | Bash tool calls show exit code, runtime, and stdout in a collapsible block. |
+| **Markdown** | Completed responses render headings, fenced code blocks (with language label), inline code, bold/italic, lists, links, and horizontal rules — no CDN needed. |
+| **Git panel** | The ± button opens a live `git diff HEAD` panel, refreshed after each tool result. |
+| **Fork** | Snapshot any assistant message and branch the conversation from that point. |
+| **Session recall** | Reload any past session; the full conversation and tool-call details restore instantly. |
+
+## Tips
+
+- **Working directory**: click the **+** button at the top of the sidebar (or
+  select a recent project from the empty state) to open a folder. The agent's
+  filesystem tools are scoped to that directory.
+- **Multiple providers**: drop several JSON files into
+  `~/.config/ex_athena/providers/` before starting — they all appear in the
+  sidebar dropdown immediately.
+- **Shared server**: because the UI binds to `0.0.0.0`, team members on the
+  same network can reach it at `http://<host-ip>:4000`. Use `api_key_prompt:
+  true` in provider JSON files to let each user supply their own key without
+  sharing credentials.
+- **Session cleanup**: sessions accumulate in `~/.ex_athena/web/sessions/`.
+  Delete them from the sidebar × button or remove `*.session` files directly.

--- a/lib/ex_athena.ex
+++ b/lib/ex_athena.ex
@@ -43,13 +43,28 @@ defmodule ExAthena do
 
       ExAthena.query("…", provider: :claude, model: "claude-sonnet-4-6")
 
+  ## Runtime JSON providers
+
+  You can define additional named providers without touching `config.exs` by
+  dropping a JSON file into `~/.config/ex_athena/providers/`. Each file's
+  `"name"` field becomes the string you pass as `provider:`:
+
+      ExAthena.query("…", provider: "my-groq")
+      ExAthena.query("…", provider: "my-groq", model: "mixtral-8x7b-32768")
+
+  Files are loaded once at application startup via `ExAthena.ProviderRegistry`.
+  Per-call opts still override JSON-file defaults. See the
+  [Providers guide](guides/providers.md) for the full schema, security notes, and
+  ready-to-copy examples for Groq, Together AI, Fireworks, and DeepSeek.
+
   ## Providers
 
   * `ExAthena.Providers.ReqLLM` — multi-backend via `req_llm`. Covers `:gemini`
     (Google Gemini), `:openai`, `:claude`/`:anthropic`, `:ollama`, and `:llamacpp`.
   * `ExAthena.Providers.Mock` — test double with scripted responses.
 
-  Consumers can also pass a custom module that implements `ExAthena.Provider`.
+  Consumers can also pass a custom module that implements `ExAthena.Provider`, or
+  define JSON-file providers as described above.
   """
 
   alias ExAthena.{Config, Request, Response}
@@ -60,8 +75,10 @@ defmodule ExAthena do
   ## Options
 
     * `:provider` — provider atom (`:ollama`, `:openai_compatible`, `:claude`,
-      `:gemini`, `:mock`) or a module that implements `ExAthena.Provider`. Defaults to
-      `Application.get_env(:ex_athena, :default_provider)`.
+      `:gemini`, `:mock`), a module that implements `ExAthena.Provider`, or a
+      string matching a JSON-defined provider loaded from
+      `~/.config/ex_athena/providers/` (see the [Providers guide](guides/providers.md)).
+      Defaults to `Application.get_env(:ex_athena, :default_provider)`.
     * `:model` — model name string. Defaults to the provider's configured model.
     * `:system_prompt` — optional system prompt string.
     * `:messages` — list of canonical messages; `prompt` is prepended as a user
@@ -91,7 +108,8 @@ defmodule ExAthena do
   and its return value is ignored. Callbacks must not block the caller; if you
   need to do expensive work per-delta, hand off to a `Task`.
 
-  Options are the same as `query/2`, including `:images`.
+  Options are the same as `query/2`, including `:images` and the `:provider`
+  string form for JSON-defined providers.
   """
   @spec stream(String.t() | nil, function(), keyword()) ::
           {:ok, Response.t()} | {:error, term()}

--- a/lib/ex_athena/config.ex
+++ b/lib/ex_athena/config.ex
@@ -2,15 +2,24 @@ defmodule ExAthena.Config do
   @moduledoc """
   Resolves the provider and per-call options for an ExAthena request.
 
-  Resolution order (per key):
+  Resolution order (per key, highest to lowest priority):
 
     1. `opts[:key]` — per-call override always wins.
-    2. `Application.get_env(:ex_athena, provider)[:key]` — provider-specific config.
+    2. For atom-named providers: `Application.get_env(:ex_athena, provider)[:key]`
+       — provider-specific `config.exs` entry.
+       For string-named providers: the matching JSON file loaded from
+       `~/.config/ex_athena/providers/` by `ExAthena.ProviderRegistry`.
     3. `Application.get_env(:ex_athena, :key)` — top-level library config.
     4. Provider default (if the provider declares one).
 
   Matches the `stripity_stripe` / `ex_aws` pattern: per-call overrides win,
   application config is the default, no global mutable state.
+
+  String provider names (e.g. `provider: "my-groq"`) are resolved through
+  `ExAthena.ProviderRegistry`, which loads `*.json` files from
+  `~/.config/ex_athena/providers/` at application startup. See the
+  [Providers guide](guides/providers.md) for the full JSON schema, security
+  notes, and ready-to-copy examples.
 
   ## Known providers
 
@@ -27,7 +36,8 @@ defmodule ExAthena.Config do
   | `:req_llm` | `ExAthena.Providers.ReqLLM` |
   | `:mock` | `ExAthena.Providers.Mock` |
 
-  You may also pass any module that implements `ExAthena.Provider` directly.
+  You may also pass any module that implements `ExAthena.Provider` directly, or a
+  string name matching a JSON-defined provider.
   """
 
   @builtin_providers %{

--- a/lib/mix/tasks/athena.chat.ex
+++ b/lib/mix/tasks/athena.chat.ex
@@ -8,6 +8,9 @@ defmodule Mix.Tasks.Athena.Chat do
   (falls back to `:ollama` when unset). The model is read from the provider's
   config block, e.g. `config :ex_athena, :llamacpp, model: "my-model"`.
 
+  For a full walkthrough — keybindings, mode switching, JSON provider setup,
+  and screenshot tour — see the [TUI guide](guides/tui.md).
+
   ## Usage
 
       mix athena.chat

--- a/lib/mix/tasks/athena.web.ex
+++ b/lib/mix/tasks/athena.web.ex
@@ -10,6 +10,9 @@ defmodule Mix.Tasks.Athena.Web do
   Opens a Phoenix LiveView chat interface backed by the same agent loop as
   `mix athena.chat`. Provider, model, and mode are configurable in the sidebar.
 
+  For a full walkthrough — sidebar controls, session persistence, JSON provider
+  setup, and screenshot tour — see the [Web UI guide](guides/web.md).
+
   ## Flags
 
     * `--port PORT` — HTTP port (default 4000).

--- a/mix.exs
+++ b/mix.exs
@@ -90,6 +90,7 @@ defmodule ExAthena.MixProject do
         "guides/permissions.md",
         "guides/agents_subagents.md",
         "guides/sessions_and_checkpoints.md",
+        "guides/upgrading.md",
         "LICENSE"
       ],
       groups_for_extras: [

--- a/mix.exs
+++ b/mix.exs
@@ -79,6 +79,8 @@ defmodule ExAthena.MixProject do
         "CHANGELOG.md",
         "guides/getting_started.md",
         "guides/providers.md",
+        "guides/tui.md",
+        "guides/web.md",
         "guides/gemini.md",
         "guides/multimodal.md",
         "guides/tool_calls.md",

--- a/priv/provider_examples/README.md
+++ b/priv/provider_examples/README.md
@@ -1,0 +1,14 @@
+# Provider Examples
+
+Copy any file from this directory to `~/.config/ex_athena/providers/` and set
+the environment variable named in `api_key_env` — ExAthena will load the
+provider automatically at startup with no changes to `config/config.exs`. Each
+file is a minimal valid JSON spec; add `default_model` or any other optional
+field to customise. See the [Providers guide](../../guides/providers.md#runtime-json-config)
+for the full schema reference and security recommendations.
+
+- **[openrouter.json](openrouter.json)** — OpenRouter gateway; routes to hundreds of models from Anthropic, Google, Meta, and Mistral through a single endpoint.
+- **[groq.json](groq.json)** — Groq LPU inference; ultra-low-latency open-source models including Llama 3.3 and Mixtral.
+- **[together.json](together.json)** — Together AI; broad catalog of hosted open-source models with optional fine-tuning support.
+- **[fireworks.json](fireworks.json)** — Fireworks AI; fast serverless inference for popular open-source models.
+- **[deepseek.json](deepseek.json)** — DeepSeek; cost-effective inference for DeepSeek-series models including the reasoning variant.

--- a/priv/provider_examples/deepseek.json
+++ b/priv/provider_examples/deepseek.json
@@ -1,0 +1,8 @@
+{
+  "name": "deepseek",
+  "adapter": "req_llm",
+  "req_llm_provider_tag": "openai",
+  "base_url": "https://api.deepseek.com/v1",
+  "api_key_env": "DEEPSEEK_API_KEY",
+  "default_model": "deepseek-chat"
+}

--- a/priv/provider_examples/fireworks.json
+++ b/priv/provider_examples/fireworks.json
@@ -1,0 +1,8 @@
+{
+  "name": "fireworks",
+  "adapter": "req_llm",
+  "req_llm_provider_tag": "openai",
+  "base_url": "https://api.fireworks.ai/inference/v1",
+  "api_key_env": "FIREWORKS_API_KEY",
+  "default_model": "accounts/fireworks/models/llama-v3p3-70b-instruct"
+}

--- a/priv/provider_examples/groq.json
+++ b/priv/provider_examples/groq.json
@@ -1,0 +1,8 @@
+{
+  "name": "groq",
+  "adapter": "req_llm",
+  "req_llm_provider_tag": "openai",
+  "base_url": "https://api.groq.com/openai/v1",
+  "api_key_env": "GROQ_API_KEY",
+  "default_model": "llama-3.3-70b-versatile"
+}

--- a/priv/provider_examples/openrouter.json
+++ b/priv/provider_examples/openrouter.json
@@ -1,0 +1,8 @@
+{
+  "name": "openrouter",
+  "adapter": "req_llm",
+  "req_llm_provider_tag": "openai",
+  "base_url": "https://openrouter.ai/api/v1",
+  "api_key_env": "OPENROUTER_API_KEY",
+  "default_model": "anthropic/claude-opus-4-5"
+}

--- a/priv/provider_examples/together.json
+++ b/priv/provider_examples/together.json
@@ -1,0 +1,8 @@
+{
+  "name": "together",
+  "adapter": "req_llm",
+  "req_llm_provider_tag": "openai",
+  "base_url": "https://api.together.xyz/v1",
+  "api_key_env": "TOGETHER_API_KEY",
+  "default_model": "meta-llama/Llama-3-70b-chat-hf"
+}


### PR DESCRIPTION
## Description

GitHub Issue: https://github.com/udin-io/ex_athena/issues/112

## Goal

Update ex_athena documentation to cover the new runtime provider config layer (ex_athena#111) and the example providers it ships (OpenRouter, Groq, Together, Fireworks, DeepSeek, etc.). Today's docs only describe Application-config wiring for the hardcoded built-ins, which will be wrong once #111 lands.

## Depends on

- ex_athena#111 — runtime JSON provider config. Doc work cannot be merged until that PR is in, so the API and examples are final.

## Scope

### 1. README — configuration section

- Add a "Configuring providers" section right after the install snippet.
- Explain the three layers, in order of precedence:
  1. Per-call opts: `ExAthena.query(prompt, provider: :openrouter, api_key: "...")` — highest.
  2. Application config: `config :ex_athena, :ollama, base_url: "..."` — for code-level wiring.
  3. **NEW:** JSON files at `~/.config/ex_athena/providers/*.json` — for adding providers without recompiling.
- Quickstart: copy an example, add an env var, run `mix athena.chat`.

### 2. New page: `docs/providers.md`

- One H2 per built-in provider with required + optional fields.
- An H2 for the JSON config layer with the full schema (every field that #111 supports, with type + default + required-or-not).
- An H2 per example JSON in `priv/provider_examples/` with a copy-paste block and the env var to set:
  - OpenRouter
  - Groq
  - Together.ai
  - Fireworks.ai
  - DeepSeek
  - (others as the example dir grows)
- A "Writing your own" subsection with the schema + validation rules + how to test (`mix athena.chat` and confirm the provider appears in the picker).

### 3. New page: `docs/tui.md`

- Walkthrough of `mix athena.chat`: launch, pick a provider in the picker, where the picker reads from (built-ins + JSON registry).
- Document the API-key prompt flow for `api_key_prompt: true` providers — keys are session-scoped, never written to disk by ex_athena.
- All slash commands as they exist today: `/help`, `/clear`, `/tools`, `/mode`, `/model`, `/tab`, `/mouse`, `/diff`, `/timeline`, `/cd`, `/pwd`, `/details`, `/expand`, `/exit`.
- Screenshot or terminal capture of the provider picker showing built-in + JSON-defined providers side by side.

### 4. New page: `docs/web.md`

- Walkthrough of `mix athena.web`: launch flags (`--port`), default 4000, what gets persisted under `~/.ex_athena/web/`.
- Sidebar provider/model selector documentation — same registry source as the TUI.
- API key field UX when `api_key_prompt: true`.
- Session persistence model (`~/.ex_athena/web/sessions/`).
- Screenshot of the sidebar with multiple providers loaded.

### 5. Migration guide: `docs/upgrading.md`

- Section: "Upgrading to runtime provider config (vX.Y)"
- For users who had `config :ex_athena, :ollama, ...` in their `config.exs` — that still works, nothing to change.
- For users adopting OpenRouter et al — point at `priv/provider_examples/`, env vars, and the picker.

### 6. CHANGELOG

- Move the "Added: `:openrouter` provider" entry from ex_athena#110 (now closed) into the broader "Added: runtime JSON provider config" entry, with a bullet list of the example providers that ship.

### 7. `priv/provider_examples/README.md`

- One-paragraph intro: "These files demonstrate the JSON provider config introduced in #111. Copy any of them to `~/.config/ex_athena/providers/` and set the noted env var."
- One bullet per file with the env var and a one-line description.

### 8. hexdocs.pm front page

- Update `@moduledoc` on `ExAthena` (the top-level module) to mention the JSON config layer and link to `docs/providers.md`.
- Update `@moduledoc` on `ExAthena.Config` to describe the resolution order with the new JSON layer included.

### 9. Inline doc updates

- `ExAthena.query/2` and `ExAthena.stream/3` `@doc` — note that `provider: :atom_name` accepts any JSON-defined provider, not just built-ins.
- `Mix.Tasks.Athena.Chat` and `Mix.Tasks.Athena.Web` `@moduledoc` — point at the new docs pages.

### 10. Security note

- Add a security subsection to `docs/providers.md`:
  - ex_athena never writes API keys to disk.
  - JSON files in `~/.config/ex_athena/providers/` should not contain raw `api_key` values — use `api_key_env` to reference an env var instead. (#111 should make the loader reject a raw `api_key` field with a clear error.)
  - Recommend `chmod 600` on the directory if env vars feel inconvenient and the user is determined to put secrets there.

## Acceptance criteria

- [ ] README has a "Configuring providers" section that covers the three-layer model.
- [ ] `docs/providers.md`, `docs/tui.md`, `docs/web.md` exist and render on hexdocs.
- [ ] `docs/upgrading.md` exists with a section for the new config layer.
- [ ] CHANGELOG entry describes the JSON layer and lists shipped examples.
- [ ] `priv/provider_examples/README.md` exists with one entry per shipped example.
- [ ] `mix docs` builds cleanly with no broken links.
- [ ] All inline `@doc`s on touched functions reference the new docs.

## Related

- ex_athena#111 — runtime provider config (blocking dep for this ticket).
- ex_athena#110 — closed by #111; this ticket subsumes its CHANGELOG note.
- udin_code#1622 — downstream UI integration. Out of scope for ex_athena docs but worth a one-line mention in `docs/providers.md` ("If you're using udin_code, the per-project provider picker is documented separately at <repo URL>").

## Summary

This PR implements: **Docs: runtime provider config (JSON), OpenRouter & friends, TUI/GUI provider management**

---
*Created by UdinCode*

Closes https://github.com/udin-io/ex_athena/issues/112