### PR TITLE
Runtime JSON provider config in ~/.config/ex_athena/providers/ — TUI + GUI + library load it on boot

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -8,6 +8,10 @@ config :ex_athena, enable_lsp: false
 config :ex_athena, enable_worktree_sweeper: false
 config :ex_athena, enable_checkpoint_sweeper: false
 
+# Disable ProviderRegistry at the application level so each test can start
+# its own isolated instance via start_supervised!/1.
+config :ex_athena, enable_provider_registry: false
+
 # Disable implicit LSP diagnostics hook globally in tests so existing tests
 # are not affected. Individual ImplicitDiagnostics tests opt back in.
 config :ex_athena, lsp_implicit_diagnostics_enabled: false

--- a/lib/ex_athena/application.ex
+++ b/lib/ex_athena/application.ex
@@ -42,7 +42,8 @@ defmodule ExAthena.Application do
         [
           ExAthena.Sessions.Stores.InMemory,
           ExAthena.Sessions.Stores.ETS,
-          ExAthena.ContextWindow
+          ExAthena.ContextWindow,
+          ExAthena.ModelDiscovery
         ]
 
     children =

--- a/lib/ex_athena/application.ex
+++ b/lib/ex_athena/application.ex
@@ -46,6 +46,13 @@ defmodule ExAthena.Application do
         ]
 
     children =
+      if Application.get_env(:ex_athena, :enable_provider_registry, true) do
+        children ++ [ExAthena.ProviderRegistry]
+      else
+        children
+      end
+
+    children =
       if Application.get_env(:ex_athena, :enable_lsp, true) do
         children ++ [ExAthena.Lsp.Supervisor]
       else

--- a/lib/ex_athena/chat/commands.ex
+++ b/lib/ex_athena/chat/commands.ex
@@ -37,7 +37,8 @@ defmodule ExAthena.Chat.Commands do
     "timeline" => :timeline,
     "mouse" => :mouse,
     "help" => :help,
-    "?" => :help
+    "?" => :help,
+    "provider" => :provider
   }
 
   @spec parse(String.t() | :eof) :: result()
@@ -87,7 +88,8 @@ defmodule ExAthena.Chat.Commands do
       "timeline",
       "mouse",
       "help",
-      "exit"
+      "exit",
+      "provider"
     ]
 
     canonical |> Enum.sort() |> Enum.map(&("/" <> &1))
@@ -113,7 +115,8 @@ defmodule ExAthena.Chat.Commands do
       "/timeline" => "show the Timeline tab",
       "/mouse" => "toggle mouse capture (off lets the terminal copy/paste natively)",
       "/help" => "show full usage help",
-      "/exit" => "leave the chat"
+      "/exit" => "leave the chat",
+      "/provider" => "pick or switch the active provider"
     }
   end
 
@@ -144,6 +147,7 @@ defmodule ExAthena.Chat.Commands do
                          scrolling + tab clicks). Many terminals also let
                          you bypass capture by holding Option (macOS) or
                          Shift while click-dragging.
+      /provider [name]   open the provider picker, or set provider directly
       /help, /?          show this help
       /exit, /quit, /q   leave the chat
 

--- a/lib/ex_athena/chat/session.ex
+++ b/lib/ex_athena/chat/session.ex
@@ -87,6 +87,11 @@ defmodule ExAthena.Chat.Session do
     %{session | mode: mode}
   end
 
+  @spec set_provider(t(), atom()) :: t()
+  def set_provider(%__MODULE__{} = session, provider) when is_atom(provider) do
+    %{session | provider: provider}
+  end
+
   @doc """
   Extract every `ToolResult` from the session's message history, ordered
   most-recent first.

--- a/lib/ex_athena/chat/tui.ex
+++ b/lib/ex_athena/chat/tui.ex
@@ -394,7 +394,7 @@ if Code.ensure_loaded?(ExRatatui.App) do
           {:noreply, State.close_popup(state)}
 
         name when is_binary(name) ->
-          provider_atom = String.to_atom(name)
+          provider_atom = provider_name_to_atom(name)
 
           state
           |> State.set_provider(provider_atom)
@@ -466,18 +466,33 @@ if Code.ensure_loaded?(ExRatatui.App) do
       raw = read_textarea(state) |> String.trim()
       if state.input_ref, do: ExRatatui.textarea_set_value(state.input_ref, "")
 
-      if raw == "" do
-        append_and_noreply(state, {:warning, "API key cannot be empty. Enter it below:"})
-      else
-        pending = state.pending_message
+      cond do
+        raw == "" ->
+          append_and_noreply(
+            state,
+            {:warning, "API key cannot be empty. Enter it below (or /cancel to abort):"}
+          )
 
-        state =
+        raw in ["/exit", "/quit"] ->
+          {:stop, restore_logger(state)}
+
+        raw == "/cancel" ->
           state
-          |> State.set_api_key(raw)
+          |> Map.put(:api_key_pending, false)
           |> Map.put(:pending_message, nil)
-          |> State.append_event({:info, "API key saved for this session."})
+          |> State.append_event({:info, "API key prompt cancelled."})
+          |> noreply()
 
-        if pending, do: do_dispatch_message(pending, state), else: noreply(state)
+        true ->
+          pending = state.pending_message
+
+          state =
+            state
+            |> State.set_api_key(raw)
+            |> Map.put(:pending_message, nil)
+            |> State.append_event({:info, "API key saved for this session."})
+
+          if pending, do: do_dispatch_message(pending, state), else: noreply(state)
       end
     end
 
@@ -611,7 +626,7 @@ if Code.ensure_loaded?(ExRatatui.App) do
     end
 
     defp dispatch_command(:provider, [arg | _], state) when is_binary(arg) do
-      provider = String.to_atom(arg)
+      provider = provider_name_to_atom(arg)
 
       state
       |> State.set_provider(provider)
@@ -1000,6 +1015,12 @@ if Code.ensure_loaded?(ExRatatui.App) do
       |> Enum.reduce(state, fn line, s -> State.append_event(s, {kind, line}) end)
     end
 
+    defp provider_name_to_atom(name) when is_binary(name) do
+      String.to_existing_atom(name)
+    rescue
+      ArgumentError -> String.to_atom(name)
+    end
+
     defp parse_mode_atom(arg) when is_binary(arg) do
       candidate = String.to_existing_atom(arg)
       if candidate in @modes, do: {:ok, candidate}, else: :error
@@ -1017,7 +1038,16 @@ if Code.ensure_loaded?(ExRatatui.App) do
     end
 
     defp list_models_for(%{provider: :llamacpp}), do: LlamaCpp.list_models([])
-    defp list_models_for(_session), do: Ollama.list_models([])
+
+    defp list_models_for(%{provider: provider}) do
+      with pid when not is_nil(pid) <- Process.whereis(ExAthena.ProviderRegistry),
+           {:ok, %ExAthena.ProviderSpec{model_discovery: disc} = spec}
+           when not is_nil(disc) <- ExAthena.ProviderRegistry.lookup(provider) do
+        ExAthena.ModelDiscovery.list_models(spec)
+      else
+        _ -> Ollama.list_models([])
+      end
+    end
 
     defp no_models_message(:llamacpp),
       do: "No models loaded. Start one with: llama-server --model path/to/model.gguf"

--- a/lib/ex_athena/chat/tui.ex
+++ b/lib/ex_athena/chat/tui.ex
@@ -388,6 +388,23 @@ if Code.ensure_loaded?(ExRatatui.App) do
       end
     end
 
+    defp handle_popup_key(%Event.Key{code: "enter"}, %State{popup: {:provider, _, _}} = state) do
+      case State.current_popup_selection(state) do
+        nil ->
+          {:noreply, State.close_popup(state)}
+
+        name when is_binary(name) ->
+          provider_atom = String.to_atom(name)
+
+          state
+          |> State.set_provider(provider_atom)
+          |> State.close_popup()
+          |> State.append_event({:info, "Provider → " <> name})
+          |> append_provider_details(name)
+          |> noreply()
+      end
+    end
+
     defp handle_popup_key(_, state), do: {:noreply, state}
 
     # ── Process messages ─────────────────────────────────────────────────────
@@ -445,6 +462,25 @@ if Code.ensure_loaded?(ExRatatui.App) do
 
     # ── Submission + commands ────────────────────────────────────────────────
 
+    defp submit_input(%State{api_key_pending: true} = state) do
+      raw = read_textarea(state) |> String.trim()
+      if state.input_ref, do: ExRatatui.textarea_set_value(state.input_ref, "")
+
+      if raw == "" do
+        append_and_noreply(state, {:warning, "API key cannot be empty. Enter it below:"})
+      else
+        pending = state.pending_message
+
+        state =
+          state
+          |> State.set_api_key(raw)
+          |> Map.put(:pending_message, nil)
+          |> State.append_event({:info, "API key saved for this session."})
+
+        if pending, do: do_dispatch_message(pending, state), else: noreply(state)
+      end
+    end
+
     defp submit_input(%State{input_ref: nil} = state), do: {:noreply, state}
 
     defp submit_input(%State{input_ref: ref} = state) do
@@ -469,7 +505,22 @@ if Code.ensure_loaded?(ExRatatui.App) do
       end
     end
 
-    defp dispatch_message(text, state) do
+    defp dispatch_message(text, %State{api_key_pending: false} = state) do
+      case check_api_key_needed(state) do
+        {:needs_key, provider_name, api_key_env} ->
+          state
+          |> State.append_event({:info, "Provider '#{provider_name}' requires an API key."})
+          |> State.append_event({:info, "Env: #{api_key_env} (not set). Enter key below:"})
+          |> Map.put(:api_key_pending, true)
+          |> Map.put(:pending_message, text)
+          |> noreply()
+
+        :ok ->
+          do_dispatch_message(text, state)
+      end
+    end
+
+    defp do_dispatch_message(text, state) do
       state =
         state
         |> State.append_event({:user, text})
@@ -479,7 +530,8 @@ if Code.ensure_loaded?(ExRatatui.App) do
         |> State.reset_history_nav()
         |> update_in_session(&Session.append_user(&1, text))
 
-      task_pid = Runner.start(state.session, self())
+      extra_opts = if state.api_key, do: [api_key: state.api_key], else: []
+      task_pid = Runner.start(state.session, self(), extra_opts)
       {:noreply, %{state | run_task: task_pid}}
     end
 
@@ -549,6 +601,21 @@ if Code.ensure_loaded?(ExRatatui.App) do
       state
       |> State.set_model(arg)
       |> State.append_event({:info, "Model → " <> arg})
+      |> noreply()
+    end
+
+    defp dispatch_command(:provider, [], state) do
+      providers = ExAthena.Config.list_providers()
+      items = Enum.map(providers, fn p -> {p.name, p.display_name} end)
+      {:noreply, State.open_popup(state, {:provider, items})}
+    end
+
+    defp dispatch_command(:provider, [arg | _], state) when is_binary(arg) do
+      provider = String.to_atom(arg)
+
+      state
+      |> State.set_provider(provider)
+      |> State.append_event({:info, "Provider → " <> arg})
       |> noreply()
     end
 
@@ -881,6 +948,43 @@ if Code.ensure_loaded?(ExRatatui.App) do
     defp restore_logger(%State{prior_log_level: level} = state) do
       Logger.configure(level: level)
       state
+    end
+
+    defp append_provider_details(state, provider_name) do
+      case lookup_provider_spec(provider_name) do
+        {:ok, spec} when spec.extra_headers != %{} ->
+          state
+          |> State.append_detail_header("provider: #{provider_name}")
+          |> State.append_detail_lines(:info, "extra_headers: #{inspect(spec.extra_headers)}")
+
+        _ ->
+          state
+      end
+    end
+
+    defp lookup_provider_spec(name) when is_binary(name) do
+      case Process.whereis(ExAthena.ProviderRegistry) do
+        nil -> :error
+        _pid -> ExAthena.ProviderRegistry.lookup(name)
+      end
+    end
+
+    defp check_api_key_needed(%State{api_key: api_key, session: session}) do
+      if is_nil(api_key) do
+        case lookup_provider_spec(Atom.to_string(session.provider)) do
+          {:ok, %{api_key_prompt: true, api_key_env: env}} when is_binary(env) ->
+            if is_nil(System.get_env(env)) do
+              {:needs_key, session.provider, env}
+            else
+              :ok
+            end
+
+          _ ->
+            :ok
+        end
+      else
+        :ok
+      end
     end
 
     defp update_in_session(state, fun), do: %{state | session: fun.(state.session)}

--- a/lib/ex_athena/chat/tui/runner.ex
+++ b/lib/ex_athena/chat/tui/runner.ex
@@ -72,6 +72,7 @@ defmodule ExAthena.Chat.Tui.Runner do
     base
     |> maybe_put_cwd(session.cwd)
     |> apply_default_base_url(session.provider)
+    |> apply_provider_spec_extra_headers(session.provider)
   end
 
   defp maybe_put_cwd(opts, cwd) when is_binary(cwd) and cwd != "",
@@ -102,4 +103,22 @@ defmodule ExAthena.Chat.Tui.Runner do
 
   defp provider_base_url_defaults(:llamacpp), do: {:llamacpp, "http://localhost:8080"}
   defp provider_base_url_defaults(_), do: {:ollama, "http://localhost:11434"}
+
+  defp apply_provider_spec_extra_headers(opts, provider) when is_atom(provider) do
+    case lookup_registry_spec(provider) do
+      {:ok, %{extra_headers: headers}} when headers != %{} ->
+        existing = Keyword.get(opts, :extra_headers, %{})
+        Keyword.put(opts, :extra_headers, Map.merge(existing, headers))
+
+      _ ->
+        opts
+    end
+  end
+
+  defp lookup_registry_spec(provider) when is_atom(provider) do
+    case Process.whereis(ExAthena.ProviderRegistry) do
+      nil -> :error
+      _pid -> ExAthena.ProviderRegistry.lookup(provider)
+    end
+  end
 end

--- a/lib/ex_athena/chat/tui/state.ex
+++ b/lib/ex_athena/chat/tui/state.ex
@@ -38,6 +38,7 @@ defmodule ExAthena.Chat.Tui.State do
           nil
           | {:model, [String.t()], non_neg_integer()}
           | {:mode, [atom()], non_neg_integer()}
+          | {:provider, [{String.t(), String.t()}], non_neg_integer()}
 
   defstruct session: nil,
             input_ref: nil,
@@ -102,7 +103,10 @@ defmodule ExAthena.Chat.Tui.State do
             diff_mode: :inline,
             footer: @default_footer,
             prior_log_level: :info,
-            run_task: nil
+            run_task: nil,
+            api_key: nil,
+            api_key_pending: false,
+            pending_message: nil
 
   @type autocomplete ::
           nil | %{required(:items) => [String.t()], required(:idx) => non_neg_integer()}
@@ -136,7 +140,10 @@ defmodule ExAthena.Chat.Tui.State do
           diff_mode: :inline | :side_by_side,
           footer: String.t(),
           prior_log_level: atom(),
-          run_task: pid() | nil
+          run_task: pid() | nil,
+          api_key: String.t() | nil,
+          api_key_pending: boolean(),
+          pending_message: String.t() | nil
         }
 
   @spec new(Session.t()) :: t()
@@ -417,6 +424,16 @@ defmodule ExAthena.Chat.Tui.State do
     %{state | session: Session.set_mode(session, mode)}
   end
 
+  @spec set_provider(t(), atom()) :: t()
+  def set_provider(%__MODULE__{session: session} = state, provider) when is_atom(provider) do
+    %{state | session: Session.set_provider(session, provider)}
+  end
+
+  @spec set_api_key(t(), String.t()) :: t()
+  def set_api_key(%__MODULE__{} = state, key) when is_binary(key) do
+    %{state | api_key: key, api_key_pending: false}
+  end
+
   @spec clear_session(t()) :: t()
   def clear_session(%__MODULE__{session: session} = state) do
     %{
@@ -437,10 +454,17 @@ defmodule ExAthena.Chat.Tui.State do
 
   # ─ Popups ─────────────────────────────────────────────────────────────────
 
-  @spec open_popup(t(), {:model, [String.t()]} | {:mode, [atom()]}) :: t()
+  @spec open_popup(
+          t(),
+          {:model, [String.t()]} | {:mode, [atom()]} | {:provider, [{String.t(), String.t()}]}
+        ) :: t()
   def open_popup(%__MODULE__{} = state, {kind, items})
       when kind in [:model, :mode] and is_list(items) do
     %{state | popup: {kind, items, 0}}
+  end
+
+  def open_popup(%__MODULE__{} = state, {:provider, items}) when is_list(items) do
+    %{state | popup: {:provider, items, 0}}
   end
 
   @spec close_popup(t()) :: t()
@@ -460,6 +484,14 @@ defmodule ExAthena.Chat.Tui.State do
   @spec current_popup_selection(t()) :: any() | nil
   def current_popup_selection(%__MODULE__{popup: nil}), do: nil
   def current_popup_selection(%__MODULE__{popup: {_, [], _}}), do: nil
+
+  def current_popup_selection(%__MODULE__{popup: {:provider, items, idx}}) do
+    case Enum.at(items, idx) do
+      {name, _display} -> name
+      other -> other
+    end
+  end
+
   def current_popup_selection(%__MODULE__{popup: {_, items, idx}}), do: Enum.at(items, idx)
 
   # ─ Details-pane tabs (timeline / changes) ────────────────────────────────

--- a/lib/ex_athena/chat/tui/view.ex
+++ b/lib/ex_athena/chat/tui/view.ex
@@ -988,6 +988,13 @@ if Code.ensure_loaded?(ExRatatui.App) do
       }
     end
 
+    defp footer(%State{api_key_pending: true}) do
+      %Paragraph{
+        text: "Enter API key and press Enter  Ctrl+C: quit",
+        style: %Style{fg: :yellow}
+      }
+    end
+
     defp footer(%State{popup: nil}) do
       %Paragraph{
         text: "Enter: send  Ctrl+C: quit  /help",
@@ -1009,6 +1016,7 @@ if Code.ensure_loaded?(ExRatatui.App) do
         case kind do
           :model -> {" Pick a model ", items}
           :mode -> {" Pick a mode ", Enum.map(items, &inspect/1)}
+          :provider -> {" Pick a provider ", Enum.map(items, fn {_name, display} -> display end)}
         end
 
       list = %List{

--- a/lib/ex_athena/config.ex
+++ b/lib/ex_athena/config.ex
@@ -26,7 +26,9 @@ defmodule ExAthena.Config do
   | `:req_llm` | `ExAthena.Providers.ReqLLM` |
   | `:mock` | `ExAthena.Providers.Mock` |
 
-  You may also pass any module that implements `ExAthena.Provider` directly.
+  You may also pass any module that implements `ExAthena.Provider` directly, or
+  define custom providers by placing JSON files in `~/.config/ex_athena/providers/`
+  (loaded at startup by `ExAthena.ProviderRegistry`).
   """
 
   @builtin_providers %{
@@ -102,14 +104,30 @@ defmodule ExAthena.Config do
   Translate an ExAthena provider atom into the `req_llm` provider tag used in
   `"tag:model-id"` specs. Returns `nil` when the atom doesn't map to req_llm
   (e.g. `:mock`, or a user-supplied module).
+
+  For registry-loaded providers the tag is taken from the spec's
+  `req_llm_provider_tag` field when the static map has no entry.
   """
   @spec req_llm_provider_tag(atom() | module()) :: String.t() | nil
-  def req_llm_provider_tag(atom) when is_atom(atom),
-    do: Map.get(@req_llm_provider_tag, atom)
+  def req_llm_provider_tag(atom) when is_atom(atom) do
+    Map.get(@req_llm_provider_tag, atom) ||
+      case registry_lookup(atom) do
+        {:ok, spec} -> spec.req_llm_provider_tag
+        :error -> nil
+      end
+  end
 
   def req_llm_provider_tag(_), do: nil
 
-  @doc "Resolve a provider atom (or module) to its implementing module."
+  @doc """
+  Resolve a provider atom (or module) to its implementing module.
+
+  Resolution order:
+    1. Built-in provider map (compile-time constant, fastest path).
+    2. `ExAthena.ProviderRegistry` — for providers loaded from JSON config files.
+    3. Module check — accepts any atom that is a loaded module implementing
+       `ExAthena.Provider`.
+  """
   @spec provider_module(atom() | module()) :: module()
   def provider_module(mod) when is_atom(mod) do
     case Map.fetch(@builtin_providers, mod) do
@@ -117,13 +135,19 @@ defmodule ExAthena.Config do
         module
 
       :error ->
-        if Code.ensure_loaded?(mod) and function_exported?(mod, :capabilities, 0) do
-          mod
-        else
-          raise ArgumentError,
-                "unknown provider: #{inspect(mod)}. Known: " <>
-                  inspect(Map.keys(@builtin_providers)) <>
-                  ", or pass a module implementing ExAthena.Provider."
+        case registry_lookup(mod) do
+          {:ok, spec} ->
+            spec.module
+
+          :error ->
+            if Code.ensure_loaded?(mod) and function_exported?(mod, :capabilities, 0) do
+              mod
+            else
+              raise ArgumentError,
+                    "unknown provider: #{inspect(mod)}. Known: " <>
+                      inspect(Map.keys(@builtin_providers)) <>
+                      ", or pass a module implementing ExAthena.Provider."
+            end
         end
     end
   end
@@ -131,6 +155,31 @@ defmodule ExAthena.Config do
   @doc false
   @spec builtin_providers() :: %{atom() => module()}
   def builtin_providers, do: @builtin_providers
+
+  @doc """
+  Return all known providers: built-in atoms plus any specs loaded by
+  `ExAthena.ProviderRegistry`.
+
+  Each entry is a map with:
+    * `:name` — string name of the provider
+    * `:module` — the implementing module
+    * `:source` — `:builtin` or `:registry`
+  """
+  @spec list_providers() :: [%{name: String.t(), module: module(), source: :builtin | :registry}]
+  def list_providers do
+    builtin_entries =
+      Enum.map(@builtin_providers, fn {atom, mod} ->
+        %{name: Atom.to_string(atom), module: mod, source: :builtin}
+      end)
+
+    registry_entries =
+      registry_list()
+      |> Enum.map(fn spec ->
+        %{name: spec.name, module: spec.module, source: :registry}
+      end)
+
+    builtin_entries ++ registry_entries
+  end
 
   @doc """
   Look up a single configuration value for `provider_module` with the tiered
@@ -200,5 +249,19 @@ defmodule ExAthena.Config do
       |> Application.get_env(atom, [])
       |> Keyword.get(key)
     end)
+  end
+
+  defp registry_lookup(name) when is_atom(name) do
+    case Process.whereis(ExAthena.ProviderRegistry) do
+      nil -> :error
+      _pid -> ExAthena.ProviderRegistry.lookup(name)
+    end
+  end
+
+  defp registry_list do
+    case Process.whereis(ExAthena.ProviderRegistry) do
+      nil -> []
+      _pid -> ExAthena.ProviderRegistry.list()
+    end
   end
 end

--- a/lib/ex_athena/config.ex
+++ b/lib/ex_athena/config.ex
@@ -165,17 +165,30 @@ defmodule ExAthena.Config do
     * `:module` — the implementing module
     * `:source` — `:builtin` or `:registry`
   """
-  @spec list_providers() :: [%{name: String.t(), module: module(), source: :builtin | :registry}]
+  @spec list_providers() :: [
+          %{
+            name: String.t(),
+            display_name: String.t(),
+            module: module(),
+            source: :builtin | :registry
+          }
+        ]
   def list_providers do
     builtin_entries =
       Enum.map(@builtin_providers, fn {atom, mod} ->
-        %{name: Atom.to_string(atom), module: mod, source: :builtin}
+        name = Atom.to_string(atom)
+        %{name: name, display_name: name, module: mod, source: :builtin}
       end)
 
     registry_entries =
       registry_list()
       |> Enum.map(fn spec ->
-        %{name: spec.name, module: spec.module, source: :registry}
+        %{
+          name: spec.name,
+          display_name: spec.display_name || spec.name,
+          module: spec.module,
+          source: :registry
+        }
       end)
 
     builtin_entries ++ registry_entries

--- a/lib/ex_athena/config.ex
+++ b/lib/ex_athena/config.ex
@@ -73,6 +73,14 @@ defmodule ExAthena.Config do
   Pop `:provider` from opts and return `{provider_module, remaining_opts}`.
 
   Raises `ArgumentError` if no provider is set in opts or in application env.
+
+  For registry-loaded providers the following spec fields are threaded into opts
+  using `Keyword.put_new/3` so per-call overrides always win:
+
+    * `:req_llm_provider_tag` — from `spec.req_llm_provider_tag`
+    * `:base_url` — from `spec.base_url`
+    * `:extra_headers` — from `spec.extra_headers` (non-empty maps only)
+    * `:api_key` — from `spec.api_key`, or resolved from `spec.api_key_env`
   """
   @spec pop_provider!(keyword()) :: {module(), keyword()}
   def pop_provider!(opts) do
@@ -97,8 +105,36 @@ defmodule ExAthena.Config do
         backend -> Keyword.put_new(rest, :openai_compatible_backend, backend)
       end
 
+    rest =
+      case registry_lookup(provider) do
+        {:ok, spec} -> thread_registry_spec_opts(rest, spec)
+        :error -> rest
+      end
+
     {provider_module(provider), rest}
   end
+
+  defp thread_registry_spec_opts(opts, spec) do
+    opts
+    |> maybe_put_new(:base_url, spec.base_url)
+    |> maybe_put_new(:api_key, resolve_spec_api_key(spec))
+    |> maybe_put_new(:extra_headers, non_empty_headers(spec.extra_headers))
+  end
+
+  defp maybe_put_new(opts, _key, nil), do: opts
+  defp maybe_put_new(opts, key, value), do: Keyword.put_new(opts, key, value)
+
+  defp non_empty_headers(m) when is_map(m) and map_size(m) > 0, do: m
+  defp non_empty_headers(_), do: nil
+
+  defp resolve_spec_api_key(%{api_key: key}) when is_binary(key) and key != "", do: key
+
+  defp resolve_spec_api_key(%{api_key_env: env_var})
+       when is_binary(env_var) and env_var != "" do
+    System.get_env(env_var)
+  end
+
+  defp resolve_spec_api_key(_), do: nil
 
   @doc """
   Translate an ExAthena provider atom into the `req_llm` provider tag used in

--- a/lib/ex_athena/model_discovery.ex
+++ b/lib/ex_athena/model_discovery.ex
@@ -65,7 +65,7 @@ defmodule ExAthena.ModelDiscovery do
     {:error, :no_model_discovery}
   end
 
-  def list_models(%ProviderSpec{name: name, model_discovery: disc}) when is_map(disc) do
+  def list_models(%ProviderSpec{name: name, model_discovery: disc} = spec) when is_map(disc) do
     ttl_ms = Map.get(disc, "ttl_seconds", @default_ttl_seconds) * 1_000
     now_ms = :erlang.monotonic_time(:millisecond)
 
@@ -74,7 +74,7 @@ defmodule ExAthena.ModelDiscovery do
         {:ok, models}
 
       :miss ->
-        fetch_and_cache(name, disc, now_ms)
+        fetch_and_cache(spec, disc, now_ms)
     end
   end
 
@@ -117,27 +117,50 @@ defmodule ExAthena.ModelDiscovery do
     end
   end
 
-  defp fetch_and_cache(name, disc, now_ms) do
-    url = Map.fetch!(disc, "url")
-    raw_headers = Map.get(disc, "headers", %{})
-    path = Map.get(disc, "path", @default_path)
-    header_list = Enum.map(raw_headers, fn {k, v} -> {k, v} end)
+  defp fetch_and_cache(%ProviderSpec{name: name} = spec, disc, now_ms) do
+    case Map.fetch(disc, "url") do
+      :error ->
+        {:error, :missing_url}
 
-    case Req.get(url, headers: header_list) do
-      {:ok, %{status: 200, body: body}} ->
-        models = extract_models(body, path)
-        :ets.insert(@table, {name, models, now_ms})
-        {:ok, models}
+      {:ok, url} ->
+        raw_headers = Map.get(disc, "headers", %{})
+        path = Map.get(disc, "path", @default_path)
+        header_list = Enum.map(raw_headers, fn {k, v} -> {k, v} end)
+        auth_headers = build_auth_headers(spec)
 
-      {:ok, %{status: status}} ->
-        Logger.warning("[ModelDiscovery] HTTP #{status} fetching models for #{inspect(name)}")
-        {:error, {:http_error, status}}
+        case Req.get(url, headers: header_list ++ auth_headers) do
+          {:ok, %{status: 200, body: body}} ->
+            models = extract_models(body, path)
+            :ets.insert(@table, {name, models, now_ms})
+            {:ok, models}
 
-      {:error, reason} ->
-        Logger.warning("[ModelDiscovery] fetch error for #{inspect(name)}: #{inspect(reason)}")
-        {:error, reason}
+          {:ok, %{status: status}} ->
+            Logger.warning("[ModelDiscovery] HTTP #{status} fetching models for #{inspect(name)}")
+            {:error, {:http_error, status}}
+
+          {:error, reason} ->
+            Logger.warning(
+              "[ModelDiscovery] fetch error for #{inspect(name)}: #{inspect(reason)}"
+            )
+
+            {:error, reason}
+        end
     end
   end
+
+  defp build_auth_headers(%ProviderSpec{api_key: key}) when is_binary(key) and key != "" do
+    [{"authorization", "Bearer #{key}"}]
+  end
+
+  defp build_auth_headers(%ProviderSpec{api_key_env: env_var})
+       when is_binary(env_var) and env_var != "" do
+    case System.get_env(env_var) do
+      nil -> []
+      key -> [{"authorization", "Bearer #{key}"}]
+    end
+  end
+
+  defp build_auth_headers(_), do: []
 
   defp extract_by_path(data, []) when is_binary(data), do: [data]
   defp extract_by_path(data, []) when is_list(data), do: Enum.filter(data, &is_binary/1)

--- a/lib/ex_athena/model_discovery.ex
+++ b/lib/ex_athena/model_discovery.ex
@@ -1,0 +1,158 @@
+defmodule ExAthena.ModelDiscovery do
+  @moduledoc """
+  Generic HTTP-based model listing backed by an ETS TTL cache.
+
+  Reads the `model_discovery` block from a `ProviderSpec` and fetches the
+  list of available model IDs from the provider's API endpoint. Results are
+  cached in an ETS table for `ttl_seconds` (default: 300) before re-fetching.
+
+  ## model_discovery block
+
+  ```json
+  {
+    "url": "https://openrouter.ai/api/v1/models",
+    "path": "data.id",
+    "headers": {"Authorization": "Bearer sk-or-..."},
+    "ttl_seconds": 300
+  }
+  ```
+
+  | Field        | Required | Description |
+  |---|---|---|
+  | `url`        | yes      | HTTP GET endpoint that returns model metadata |
+  | `path`       | no       | Dot-delimited path into the JSON response to extract IDs (default: `"data.id"`) |
+  | `headers`    | no       | Additional request headers (e.g. auth) |
+  | `ttl_seconds`| no       | Cache lifetime in seconds (default: `300`) |
+
+  ## Path extraction
+
+  `path` is a dot-delimited string. Traversal descends through map keys; when a
+  list is encountered the remaining path is applied to each element and results
+  are flattened. Examples:
+
+    * `"data.id"` — extracts `resp["data"][*]["id"]`
+    * `"id"` — extracts `resp[*]["id"]` when the root is a list
+    * `""` — returns root list elements (when they are strings)
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias ExAthena.ProviderSpec
+
+  @table :ex_athena_model_discovery_cache
+  @default_ttl_seconds 300
+  @default_path "data.id"
+
+  # ── Public API ────────────────────────────────────────────────────
+
+  @doc false
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc """
+  Return the list of available model IDs for the provider described by `spec`.
+
+  Returns `{:ok, [String.t()]}` from the ETS cache when a fresh entry exists,
+  or fetches from the provider's `model_discovery.url` and caches the result.
+
+  Returns `{:error, :no_model_discovery}` when `spec.model_discovery` is `nil`.
+  """
+  @spec list_models(ProviderSpec.t()) :: {:ok, [String.t()]} | {:error, term()}
+  def list_models(%ProviderSpec{model_discovery: nil}) do
+    {:error, :no_model_discovery}
+  end
+
+  def list_models(%ProviderSpec{name: name, model_discovery: disc}) when is_map(disc) do
+    ttl_ms = Map.get(disc, "ttl_seconds", @default_ttl_seconds) * 1_000
+    now_ms = :erlang.monotonic_time(:millisecond)
+
+    case cache_lookup(name, now_ms, ttl_ms) do
+      {:ok, models} ->
+        {:ok, models}
+
+      :miss ->
+        fetch_and_cache(name, disc, now_ms)
+    end
+  end
+
+  @doc false
+  def clear_cache do
+    :ets.delete_all_objects(@table)
+    :ok
+  end
+
+  @doc false
+  @spec extract_models(term(), String.t()) :: [String.t()]
+  def extract_models(body, path) when is_binary(path) and path != "" do
+    segments = String.split(path, ".")
+    extract_by_path(body, segments)
+  end
+
+  def extract_models(body, _path) when is_list(body) do
+    Enum.filter(body, &is_binary/1)
+  end
+
+  def extract_models(_, _), do: []
+
+  # ── GenServer callbacks ───────────────────────────────────────────
+
+  @impl GenServer
+  def init(_opts) do
+    :ets.new(@table, [:set, :public, :named_table])
+    {:ok, %{}}
+  end
+
+  # ── Private helpers ───────────────────────────────────────────────
+
+  defp cache_lookup(name, now_ms, ttl_ms) do
+    case :ets.lookup(@table, name) do
+      [{^name, models, fetched_at}] when now_ms - fetched_at < ttl_ms ->
+        {:ok, models}
+
+      _ ->
+        :miss
+    end
+  end
+
+  defp fetch_and_cache(name, disc, now_ms) do
+    url = Map.fetch!(disc, "url")
+    raw_headers = Map.get(disc, "headers", %{})
+    path = Map.get(disc, "path", @default_path)
+    header_list = Enum.map(raw_headers, fn {k, v} -> {k, v} end)
+
+    case Req.get(url, headers: header_list) do
+      {:ok, %{status: 200, body: body}} ->
+        models = extract_models(body, path)
+        :ets.insert(@table, {name, models, now_ms})
+        {:ok, models}
+
+      {:ok, %{status: status}} ->
+        Logger.warning("[ModelDiscovery] HTTP #{status} fetching models for #{inspect(name)}")
+        {:error, {:http_error, status}}
+
+      {:error, reason} ->
+        Logger.warning("[ModelDiscovery] fetch error for #{inspect(name)}: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  defp extract_by_path(data, []) when is_binary(data), do: [data]
+  defp extract_by_path(data, []) when is_list(data), do: Enum.filter(data, &is_binary/1)
+  defp extract_by_path(_data, []), do: []
+
+  defp extract_by_path(data, [key | rest]) when is_map(data) do
+    case Map.get(data, key) do
+      nil -> []
+      value -> extract_by_path(value, rest)
+    end
+  end
+
+  defp extract_by_path(list, path) when is_list(list) do
+    Enum.flat_map(list, &extract_by_path(&1, path))
+  end
+
+  defp extract_by_path(_data, _path), do: []
+end

--- a/lib/ex_athena/provider_registry.ex
+++ b/lib/ex_athena/provider_registry.ex
@@ -1,0 +1,125 @@
+defmodule ExAthena.ProviderRegistry do
+  @moduledoc """
+  GenServer that loads provider specs from `~/.config/ex_athena/providers/` at
+  startup and makes them available for lookup.
+
+  Each `.json` file in the directory defines one provider. Files that fail
+  validation (missing required fields, unknown adapter, malformed JSON) are
+  skipped with a warning log — a single bad file does not prevent others from
+  loading.
+
+  ## Configuration
+
+  The directory path defaults to `~/.config/ex_athena/providers/` and can be
+  overridden at startup (primarily for tests):
+
+      start_supervised!({ExAthena.ProviderRegistry, providers_dir: "/tmp/my-dir"})
+
+  To disable the registry in application config (e.g. during tests):
+
+      config :ex_athena, enable_provider_registry: false
+
+  ## Public API
+
+      ProviderRegistry.lookup("my-ollama")
+      ProviderRegistry.lookup(:"my-ollama")
+      ProviderRegistry.list()
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias ExAthena.ProviderSpec
+
+  @default_providers_dir Path.join([System.user_home!(), ".config", "ex_athena", "providers"])
+
+  # ── Public API ────────────────────────────────────────────────────
+
+  @doc false
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc """
+  Look up a provider spec by name. Accepts both atom and string names.
+
+  Returns `{:ok, %ProviderSpec{}}` if found, `:error` otherwise.
+  """
+  @spec lookup(atom() | String.t()) :: {:ok, ProviderSpec.t()} | :error
+  def lookup(name) when is_atom(name), do: lookup(Atom.to_string(name))
+
+  def lookup(name) when is_binary(name) do
+    GenServer.call(__MODULE__, {:lookup, name})
+  end
+
+  @doc "Return all loaded provider specs."
+  @spec list() :: [ProviderSpec.t()]
+  def list do
+    GenServer.call(__MODULE__, :list)
+  end
+
+  # ── GenServer callbacks ───────────────────────────────────────────
+
+  @impl GenServer
+  def init(opts) do
+    dir = Keyword.get(opts, :providers_dir, @default_providers_dir)
+    specs = load_all(dir)
+    {:ok, %{specs: specs}}
+  end
+
+  @impl GenServer
+  def handle_call({:lookup, name}, _from, %{specs: specs} = state) do
+    {:reply, Map.fetch(specs, name), state}
+  end
+
+  def handle_call(:list, _from, %{specs: specs} = state) do
+    {:reply, Map.values(specs), state}
+  end
+
+  # ── Private helpers ───────────────────────────────────────────────
+
+  defp load_all(dir) do
+    case File.ls(dir) do
+      {:ok, files} ->
+        files
+        |> Enum.filter(&String.ends_with?(&1, ".json"))
+        |> Enum.reduce(%{}, fn file, acc ->
+          path = Path.join(dir, file)
+
+          case load_file(path) do
+            {:ok, spec} ->
+              Map.put(acc, spec.name, spec)
+
+            {:error, reason} ->
+              Logger.warning("ProviderRegistry: skipping #{path}: #{reason}")
+              acc
+          end
+        end)
+
+      {:error, :enoent} ->
+        %{}
+
+      {:error, reason} ->
+        Logger.warning("ProviderRegistry: cannot read directory #{dir}: #{inspect(reason)}")
+        %{}
+    end
+  end
+
+  defp load_file(path) do
+    with {:ok, content} <- File.read(path),
+         {:ok, json} <- Jason.decode(content),
+         {:ok, spec} <- ProviderSpec.from_json(json) do
+      {:ok, spec}
+    else
+      {:error, %Jason.DecodeError{} = e} ->
+        {:error, "invalid JSON: #{Exception.message(e)}"}
+
+      {:error, reason} when is_binary(reason) ->
+        {:error, reason}
+
+      {:error, reason} ->
+        {:error, inspect(reason)}
+    end
+  end
+end

--- a/lib/ex_athena/provider_spec.ex
+++ b/lib/ex_athena/provider_spec.ex
@@ -6,18 +6,44 @@ defmodule ExAthena.ProviderSpec do
 
   ```json
   {
-    "name": "my-ollama",
+    "name": "openrouter",
     "adapter": "req_llm",
-    "req_llm_provider_tag": "openai",
-    "base_url": "http://localhost:11434/v1",
-    "api_key": "optional",
-    "default_model": "qwen3-coder",
+    "req_llm_provider_tag": "openrouter",
+    "base_url": "https://openrouter.ai/api/v1",
+    "api_key": "sk-or-...",
+    "api_key_env": "OPENROUTER_API_KEY",
+    "default_model": "openai/gpt-4o",
+    "extra_headers": {
+      "HTTP-Referer": "https://myapp.io",
+      "X-Title": "MyApp"
+    },
+    "model_discovery": {
+      "url": "https://openrouter.ai/api/v1/models",
+      "path": "data.id",
+      "ttl_seconds": 300
+    },
     "metadata": {}
   }
   ```
 
   Required fields: `name`, `adapter`.
   Known adapters: `"req_llm"`, `"mock"`.
+
+  ## Auth resolution
+
+  `api_key` is used as-is. When `api_key` is absent and `api_key_env` is set,
+  `Config.pop_provider!/1` resolves the key from that environment variable.
+
+  ## Extra headers
+
+  `extra_headers` is a string-to-string map of HTTP headers injected into every
+  request through the ReqLLM adapter via `req_http_options`.
+
+  ## Model discovery
+
+  `model_discovery` enables `ExAthena.ModelDiscovery.list_models/1`.  Required
+  sub-field: `url`. Optional: `path` (dot-delimited extraction path, default
+  `"data.id"`), `headers` (map), `ttl_seconds` (default `300`).
   """
 
   @known_adapters %{
@@ -32,7 +58,10 @@ defmodule ExAthena.ProviderSpec do
           req_llm_provider_tag: String.t() | nil,
           base_url: String.t() | nil,
           api_key: String.t() | nil,
+          api_key_env: String.t() | nil,
           default_model: String.t() | nil,
+          extra_headers: %{String.t() => String.t()},
+          model_discovery: map() | nil,
           metadata: map()
         }
 
@@ -43,7 +72,10 @@ defmodule ExAthena.ProviderSpec do
     :req_llm_provider_tag,
     :base_url,
     :api_key,
+    :api_key_env,
     :default_model,
+    :model_discovery,
+    extra_headers: %{},
     metadata: %{}
   ]
 
@@ -65,7 +97,10 @@ defmodule ExAthena.ProviderSpec do
         req_llm_provider_tag: Map.get(json, "req_llm_provider_tag"),
         base_url: Map.get(json, "base_url"),
         api_key: Map.get(json, "api_key"),
+        api_key_env: Map.get(json, "api_key_env"),
         default_model: Map.get(json, "default_model"),
+        extra_headers: Map.get(json, "extra_headers", %{}),
+        model_discovery: Map.get(json, "model_discovery"),
         metadata: Map.get(json, "metadata", %{})
       }
 

--- a/lib/ex_athena/provider_spec.ex
+++ b/lib/ex_athena/provider_spec.ex
@@ -37,7 +37,8 @@ defmodule ExAthena.ProviderSpec do
           display_name: String.t() | nil,
           api_key_prompt: boolean(),
           api_key_env: String.t() | nil,
-          extra_headers: map()
+          extra_headers: map(),
+          model_discovery: map() | nil
         }
 
   defstruct [
@@ -50,6 +51,7 @@ defmodule ExAthena.ProviderSpec do
     :default_model,
     :display_name,
     :api_key_env,
+    :model_discovery,
     metadata: %{},
     api_key_prompt: false,
     extra_headers: %{}
@@ -78,7 +80,8 @@ defmodule ExAthena.ProviderSpec do
         display_name: Map.get(json, "display_name"),
         api_key_prompt: Map.get(json, "api_key_prompt", false),
         api_key_env: Map.get(json, "api_key_env"),
-        extra_headers: Map.get(json, "extra_headers", %{})
+        extra_headers: Map.get(json, "extra_headers", %{}),
+        model_discovery: Map.get(json, "model_discovery")
       }
 
       {:ok, spec}

--- a/lib/ex_athena/provider_spec.ex
+++ b/lib/ex_athena/provider_spec.ex
@@ -1,0 +1,99 @@
+defmodule ExAthena.ProviderSpec do
+  @moduledoc """
+  Represents a provider loaded from a JSON file in the providers config directory.
+
+  ## JSON format
+
+  ```json
+  {
+    "name": "my-ollama",
+    "adapter": "req_llm",
+    "req_llm_provider_tag": "openai",
+    "base_url": "http://localhost:11434/v1",
+    "api_key": "optional",
+    "default_model": "qwen3-coder",
+    "metadata": {}
+  }
+  ```
+
+  Required fields: `name`, `adapter`.
+  Known adapters: `"req_llm"`, `"mock"`.
+  """
+
+  @known_adapters %{
+    "req_llm" => ExAthena.Providers.ReqLLM,
+    "mock" => ExAthena.Providers.Mock
+  }
+
+  @type t :: %__MODULE__{
+          name: String.t(),
+          adapter: atom(),
+          module: module(),
+          req_llm_provider_tag: String.t() | nil,
+          base_url: String.t() | nil,
+          api_key: String.t() | nil,
+          default_model: String.t() | nil,
+          metadata: map()
+        }
+
+  defstruct [
+    :name,
+    :adapter,
+    :module,
+    :req_llm_provider_tag,
+    :base_url,
+    :api_key,
+    :default_model,
+    metadata: %{}
+  ]
+
+  @doc """
+  Parse a decoded JSON map into a `ProviderSpec`.
+
+  Returns `{:ok, spec}` on success or `{:error, reason}` when required fields
+  are missing or the adapter is not recognized.
+  """
+  @spec from_json(map()) :: {:ok, t()} | {:error, String.t()}
+  def from_json(json) when is_map(json) do
+    with {:ok, name} <- fetch_required_string(json, "name"),
+         {:ok, adapter_str} <- fetch_required_string(json, "adapter"),
+         {:ok, adapter, module} <- resolve_adapter(adapter_str) do
+      spec = %__MODULE__{
+        name: name,
+        adapter: adapter,
+        module: module,
+        req_llm_provider_tag: Map.get(json, "req_llm_provider_tag"),
+        base_url: Map.get(json, "base_url"),
+        api_key: Map.get(json, "api_key"),
+        default_model: Map.get(json, "default_model"),
+        metadata: Map.get(json, "metadata", %{})
+      }
+
+      {:ok, spec}
+    end
+  end
+
+  @doc false
+  @spec known_adapters() :: %{String.t() => module()}
+  def known_adapters, do: @known_adapters
+
+  defp fetch_required_string(json, key) do
+    case Map.get(json, key) do
+      nil -> {:error, "missing required field: #{key}"}
+      "" -> {:error, "field #{inspect(key)} must not be empty"}
+      value when is_binary(value) -> {:ok, value}
+      _ -> {:error, "field #{inspect(key)} must be a string"}
+    end
+  end
+
+  defp resolve_adapter(adapter_str) do
+    case Map.fetch(@known_adapters, adapter_str) do
+      {:ok, module} ->
+        {:ok, String.to_atom(adapter_str), module}
+
+      :error ->
+        known = Map.keys(@known_adapters) |> Enum.map(&inspect/1) |> Enum.join(", ")
+        {:error, "unknown adapter: #{inspect(adapter_str)}. Known: #{known}"}
+    end
+  end
+end

--- a/lib/ex_athena/provider_spec.ex
+++ b/lib/ex_athena/provider_spec.ex
@@ -33,7 +33,11 @@ defmodule ExAthena.ProviderSpec do
           base_url: String.t() | nil,
           api_key: String.t() | nil,
           default_model: String.t() | nil,
-          metadata: map()
+          metadata: map(),
+          display_name: String.t() | nil,
+          api_key_prompt: boolean(),
+          api_key_env: String.t() | nil,
+          extra_headers: map()
         }
 
   defstruct [
@@ -44,7 +48,11 @@ defmodule ExAthena.ProviderSpec do
     :base_url,
     :api_key,
     :default_model,
-    metadata: %{}
+    :display_name,
+    :api_key_env,
+    metadata: %{},
+    api_key_prompt: false,
+    extra_headers: %{}
   ]
 
   @doc """
@@ -66,7 +74,11 @@ defmodule ExAthena.ProviderSpec do
         base_url: Map.get(json, "base_url"),
         api_key: Map.get(json, "api_key"),
         default_model: Map.get(json, "default_model"),
-        metadata: Map.get(json, "metadata", %{})
+        metadata: Map.get(json, "metadata", %{}),
+        display_name: Map.get(json, "display_name"),
+        api_key_prompt: Map.get(json, "api_key_prompt", false),
+        api_key_env: Map.get(json, "api_key_env"),
+        extra_headers: Map.get(json, "extra_headers", %{})
       }
 
       {:ok, spec}

--- a/lib/ex_athena/providers/req_llm.ex
+++ b/lib/ex_athena/providers/req_llm.ex
@@ -293,7 +293,23 @@ defmodule ExAthena.Providers.ReqLLM do
       |> Keyword.reject(fn {_k, v} -> is_nil(v) or v == [] end)
 
     provider_opts = Keyword.get(opts, :provider_opts, [])
-    {:ok, Keyword.merge(base_opts, provider_opts)}
+    merged = Keyword.merge(base_opts, provider_opts)
+    merged = fold_extra_headers(merged, Keyword.get(opts, :extra_headers))
+    {:ok, merged}
+  end
+
+  # Converts a string-to-string map of extra headers into the `req_http_options`
+  # keyword list that req_llm uses to inject headers into Req requests.
+  defp fold_extra_headers(opts, nil), do: opts
+  defp fold_extra_headers(opts, headers) when is_map(headers) and map_size(headers) == 0, do: opts
+
+  defp fold_extra_headers(opts, headers) when is_map(headers) do
+    header_list = Enum.map(headers, fn {k, v} -> {k, v} end)
+    existing_http_opts = Keyword.get(opts, :req_http_options, [])
+    existing_headers = Keyword.get(existing_http_opts, :headers, [])
+    merged_headers = existing_headers ++ header_list
+    merged_http_opts = Keyword.put(existing_http_opts, :headers, merged_headers)
+    Keyword.put(opts, :req_http_options, merged_http_opts)
   end
 
   # ex_athena's modes (see `Tools.describe_for_provider/1`) build OpenAI-format

--- a/priv/provider_examples/groq.json
+++ b/priv/provider_examples/groq.json
@@ -1,0 +1,16 @@
+{
+  "name": "groq",
+  "adapter": "req_llm",
+  "req_llm_provider_tag": "groq",
+  "base_url": "https://api.groq.com/openai/v1",
+  "api_key_env": "GROQ_API_KEY",
+  "default_model": "llama3-8b-8192",
+  "model_discovery": {
+    "url": "https://api.groq.com/openai/v1/models",
+    "path": "data.id",
+    "ttl_seconds": 300
+  },
+  "metadata": {
+    "note": "Copy to ~/.config/ex_athena/providers/groq.json and set GROQ_API_KEY"
+  }
+}

--- a/priv/provider_examples/openrouter.json
+++ b/priv/provider_examples/openrouter.json
@@ -1,0 +1,20 @@
+{
+  "name": "openrouter",
+  "adapter": "req_llm",
+  "req_llm_provider_tag": "openrouter",
+  "base_url": "https://openrouter.ai/api/v1",
+  "api_key_env": "OPENROUTER_API_KEY",
+  "default_model": "openai/gpt-4o-mini",
+  "extra_headers": {
+    "HTTP-Referer": "https://yourapp.io",
+    "X-Title": "YourApp"
+  },
+  "model_discovery": {
+    "url": "https://openrouter.ai/api/v1/models",
+    "path": "data.id",
+    "ttl_seconds": 300
+  },
+  "metadata": {
+    "note": "Copy to ~/.config/ex_athena/providers/openrouter.json and set OPENROUTER_API_KEY"
+  }
+}

--- a/priv/provider_examples/together.json
+++ b/priv/provider_examples/together.json
@@ -1,0 +1,16 @@
+{
+  "name": "together",
+  "adapter": "req_llm",
+  "req_llm_provider_tag": "together",
+  "base_url": "https://api.together.xyz/v1",
+  "api_key_env": "TOGETHER_API_KEY",
+  "default_model": "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
+  "model_discovery": {
+    "url": "https://api.together.xyz/v1/models",
+    "path": "id",
+    "ttl_seconds": 300
+  },
+  "metadata": {
+    "note": "Copy to ~/.config/ex_athena/providers/together.json and set TOGETHER_API_KEY"
+  }
+}

--- a/test/ex_athena/chat/tui/state_test.exs
+++ b/test/ex_athena/chat/tui/state_test.exs
@@ -735,6 +735,73 @@ defmodule ExAthena.Chat.Tui.StateTest do
     end
   end
 
+  describe "provider popup" do
+    test "open_popup/2 opens a :provider popup with {name, display_name} tuples" do
+      items = [{"ollama", "ollama"}, {"my-openai", "My OpenAI"}]
+
+      state =
+        Session.new()
+        |> State.new()
+        |> State.open_popup({:provider, items})
+
+      assert state.popup == {:provider, items, 0}
+    end
+
+    test "current_popup_selection/1 returns the name (not display_name) from a provider tuple" do
+      items = [{"ollama", "Ollama"}, {"my-openai", "My OpenAI"}]
+
+      state =
+        Session.new()
+        |> State.new()
+        |> State.open_popup({:provider, items})
+
+      assert State.current_popup_selection(state) == "ollama"
+
+      moved = State.move_popup_selection(state, +1)
+      assert State.current_popup_selection(moved) == "my-openai"
+    end
+
+    test "current_popup_selection/1 returns nil for empty provider popup" do
+      state =
+        Session.new()
+        |> State.new()
+        |> State.open_popup({:provider, []})
+
+      assert State.current_popup_selection(state) == nil
+    end
+  end
+
+  describe "set_provider/2" do
+    test "updates the session provider" do
+      state =
+        Session.new()
+        |> State.new()
+        |> State.set_provider(:openai)
+
+      assert state.session.provider == :openai
+    end
+  end
+
+  describe "set_api_key/2" do
+    test "sets the api_key and clears api_key_pending" do
+      state =
+        Session.new()
+        |> State.new()
+        |> Map.put(:api_key_pending, true)
+        |> State.set_api_key("sk-test-key")
+
+      assert state.api_key == "sk-test-key"
+      assert state.api_key_pending == false
+    end
+
+    test "api_key and api_key_pending default to nil/false in new state" do
+      state = Session.new() |> State.new()
+      assert state.api_key == nil
+      assert state.api_key_pending == false
+      assert state.pending_message == nil
+    end
+  end
+
   describe "details pane" do
     test ":tool_call appends a header + full pretty-printed args to details" do
       tc = %ToolCall{id: "1", name: "Read", arguments: %{"path" => "lib/foo.ex"}}

--- a/test/ex_athena/chat/tui/view_test.exs
+++ b/test/ex_athena/chat/tui/view_test.exs
@@ -302,6 +302,56 @@ defmodule ExAthena.Chat.Tui.ViewTest do
     end
   end
 
+  describe "build_frame/2 — provider popup" do
+    setup do
+      session = Session.new(provider: :ollama, model: "qwen3:8b", mode: :react)
+      frame = %Frame{width: 80, height: 24}
+      {:ok, session: session, frame: frame}
+    end
+
+    test "when state.popup is {:provider, items, idx}, a Popup widget is overlaid with display names",
+         %{session: session, frame: frame} do
+      items = [{"ollama", "Ollama"}, {"my-openai", "My OpenAI"}]
+
+      state =
+        session
+        |> State.new()
+        |> State.open_popup({:provider, items})
+
+      widgets = View.build_frame(state, frame)
+
+      popup =
+        Enum.find(widgets, fn
+          {%Popup{}, _} -> true
+          _ -> false
+        end)
+
+      assert popup, "expected a Popup widget when provider popup is open"
+      {%Popup{content: content, block: block}, _rect} = popup
+      assert %List{items: list_items, selected: 0} = content
+      # Should show display names, not raw names
+      assert "Ollama" in list_items
+      assert "My OpenAI" in list_items
+      refute "ollama" in list_items
+      refute "my-openai" in list_items
+      assert block && block.title =~ "provider"
+    end
+
+    test "footer shows API key hint when api_key_pending is true",
+         %{session: session, frame: frame} do
+      state =
+        session
+        |> State.new()
+        |> Map.put(:api_key_pending, true)
+
+      widgets = View.build_frame(state, frame)
+      {%Paragraph{text: text}, _} = find_footer(widgets, frame)
+
+      assert text =~ "API key"
+      assert text =~ "Enter"
+    end
+  end
+
   describe "build_frame/2 — CellSession snapshot integration" do
     test "the widget list renders without panicking and the header text reaches the buffer" do
       session = Session.new(provider: :ollama, model: "llama3.1", mode: :react)

--- a/test/ex_athena/config_test.exs
+++ b/test/ex_athena/config_test.exs
@@ -235,6 +235,102 @@ defmodule ExAthena.ConfigTest do
     end
   end
 
+  describe "pop_provider!/1 threads registry spec fields" do
+    test "threads base_url from spec into opts" do
+      dir = tmp_dir_create()
+
+      write_json(dir, "openrouter.json", %{
+        name: "openrouter",
+        adapter: "req_llm",
+        req_llm_provider_tag: "openrouter",
+        base_url: "https://openrouter.ai/api/v1"
+      })
+
+      start_supervised!({ExAthena.ProviderRegistry, providers_dir: dir})
+
+      {mod, opts} = Config.pop_provider!(provider: :openrouter)
+      assert mod == ExAthena.Providers.ReqLLM
+      assert opts[:req_llm_provider_tag] == "openrouter"
+      assert opts[:base_url] == "https://openrouter.ai/api/v1"
+    end
+
+    test "threads extra_headers from spec into opts" do
+      dir = tmp_dir_create()
+
+      write_json(dir, "openrouter.json", %{
+        name: "openrouter",
+        adapter: "req_llm",
+        extra_headers: %{"HTTP-Referer" => "https://myapp.io"}
+      })
+
+      start_supervised!({ExAthena.ProviderRegistry, providers_dir: dir})
+
+      {_mod, opts} = Config.pop_provider!(provider: :openrouter)
+      assert opts[:extra_headers] == %{"HTTP-Referer" => "https://myapp.io"}
+    end
+
+    test "does not thread extra_headers when map is empty" do
+      dir = tmp_dir_create()
+      write_json(dir, "groq.json", %{name: "groq", adapter: "req_llm", extra_headers: %{}})
+      start_supervised!({ExAthena.ProviderRegistry, providers_dir: dir})
+
+      {_mod, opts} = Config.pop_provider!(provider: :groq)
+      refute Keyword.has_key?(opts, :extra_headers)
+    end
+
+    test "threads api_key from spec into opts" do
+      dir = tmp_dir_create()
+      write_json(dir, "groq.json", %{name: "groq", adapter: "req_llm", api_key: "gsk-abc123"})
+      start_supervised!({ExAthena.ProviderRegistry, providers_dir: dir})
+
+      {_mod, opts} = Config.pop_provider!(provider: :groq)
+      assert opts[:api_key] == "gsk-abc123"
+    end
+
+    test "resolves api_key from api_key_env" do
+      env_var = "EX_ATHENA_TEST_API_KEY_#{System.unique_integer([:positive])}"
+      System.put_env(env_var, "resolved-key-value")
+      on_exit(fn -> System.delete_env(env_var) end)
+
+      dir = tmp_dir_create()
+
+      write_json(dir, "custom.json", %{
+        name: "custom-prov",
+        adapter: "req_llm",
+        api_key_env: env_var
+      })
+
+      start_supervised!({ExAthena.ProviderRegistry, providers_dir: dir})
+
+      {_mod, opts} = Config.pop_provider!(provider: :"custom-prov")
+      assert opts[:api_key] == "resolved-key-value"
+    end
+
+    test "api_key in opts wins over spec api_key" do
+      dir = tmp_dir_create()
+      write_json(dir, "groq.json", %{name: "groq", adapter: "req_llm", api_key: "spec-key"})
+      start_supervised!({ExAthena.ProviderRegistry, providers_dir: dir})
+
+      {_mod, opts} = Config.pop_provider!(provider: :groq, api_key: "call-key")
+      assert opts[:api_key] == "call-key"
+    end
+
+    test "base_url in opts wins over spec base_url" do
+      dir = tmp_dir_create()
+
+      write_json(dir, "groq.json", %{
+        name: "groq",
+        adapter: "req_llm",
+        base_url: "https://api.groq.com/openai/v1"
+      })
+
+      start_supervised!({ExAthena.ProviderRegistry, providers_dir: dir})
+
+      {_mod, opts} = Config.pop_provider!(provider: :groq, base_url: "https://override.example")
+      assert opts[:base_url] == "https://override.example"
+    end
+  end
+
   # ── Helpers for registry-based tests ─────────────────────────────
 
   defp tmp_dir do

--- a/test/ex_athena/config_test.exs
+++ b/test/ex_athena/config_test.exs
@@ -146,5 +146,109 @@ defmodule ExAthena.ConfigTest do
     test "returns google for :gemini" do
       assert "google" = Config.req_llm_provider_tag(:gemini)
     end
+
+    test "returns nil for unknown atom when registry is not running" do
+      assert nil == Config.req_llm_provider_tag(:nonexistent_provider)
+    end
+
+    test "returns tag from registry spec when registry has the provider" do
+      dir = tmp_dir_create()
+
+      write_json(dir, "custom.json", %{
+        name: "my-local",
+        adapter: "req_llm",
+        req_llm_provider_tag: "openai"
+      })
+
+      start_supervised!({ExAthena.ProviderRegistry, providers_dir: dir})
+
+      assert "openai" == Config.req_llm_provider_tag(:"my-local")
+    end
+
+    test "returns nil for registry spec without req_llm_provider_tag" do
+      dir = tmp_dir_create()
+      write_json(dir, "custom.json", %{name: "my-mock", adapter: "mock"})
+      start_supervised!({ExAthena.ProviderRegistry, providers_dir: dir})
+
+      assert nil == Config.req_llm_provider_tag(:"my-mock")
+    end
+  end
+
+  describe "provider_module/1 with registry fallthrough" do
+    test "resolves registry-loaded providers by atom name" do
+      dir = tmp_dir_create()
+      write_json(dir, "custom.json", %{name: "my-mock", adapter: "mock"})
+      start_supervised!({ExAthena.ProviderRegistry, providers_dir: dir})
+
+      assert ExAthena.Providers.Mock = Config.provider_module(:"my-mock")
+    end
+
+    test "built-in providers still resolve when registry is running" do
+      dir = tmp_dir_create()
+      start_supervised!({ExAthena.ProviderRegistry, providers_dir: dir})
+
+      assert ExAthena.Providers.Mock = Config.provider_module(:mock)
+      assert ExAthena.Providers.ReqLLM = Config.provider_module(:ollama)
+    end
+
+    test "raises for unknown atom not in registry" do
+      dir = tmp_dir_create()
+      start_supervised!({ExAthena.ProviderRegistry, providers_dir: dir})
+
+      assert_raise ArgumentError, ~r/unknown provider/, fn ->
+        Config.provider_module(:totally_unknown)
+      end
+    end
+  end
+
+  describe "list_providers/0" do
+    test "includes all built-in provider atoms" do
+      providers = Config.list_providers()
+      names = Enum.map(providers, & &1.name)
+      assert "ollama" in names
+      assert "mock" in names
+      assert "openai" in names
+      assert "gemini" in names
+    end
+
+    test "all built-in entries have source: :builtin" do
+      providers = Config.list_providers()
+      builtin = Enum.filter(providers, &(&1.source == :builtin))
+      assert length(builtin) == map_size(ExAthena.Config.builtin_providers())
+    end
+
+    test "includes registry specs when registry is running" do
+      dir = tmp_dir_create()
+      write_json(dir, "custom.json", %{name: "custom-prov", adapter: "mock"})
+      start_supervised!({ExAthena.ProviderRegistry, providers_dir: dir})
+
+      providers = Config.list_providers()
+      registry_entry = Enum.find(providers, &(&1.name == "custom-prov"))
+      assert registry_entry != nil
+      assert registry_entry.source == :registry
+      assert registry_entry.module == ExAthena.Providers.Mock
+    end
+
+    test "returns only built-ins when registry is not running" do
+      providers = Config.list_providers()
+      assert Enum.all?(providers, &(&1.source == :builtin))
+    end
+  end
+
+  # ── Helpers for registry-based tests ─────────────────────────────
+
+  defp tmp_dir do
+    Path.join(System.tmp_dir!(), "ex_athena_cfg_#{System.unique_integer([:positive])}")
+  end
+
+  defp tmp_dir_create do
+    dir = tmp_dir()
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+    dir
+  end
+
+  defp write_json(dir, filename, data) do
+    File.write!(Path.join(dir, filename), Jason.encode!(data))
   end
 end

--- a/test/ex_athena/model_discovery_test.exs
+++ b/test/ex_athena/model_discovery_test.exs
@@ -1,0 +1,163 @@
+defmodule ExAthena.ModelDiscoveryTest do
+  use ExUnit.Case, async: false
+
+  alias ExAthena.{ModelDiscovery, ProviderSpec}
+
+  setup do
+    ModelDiscovery.clear_cache()
+    :ok
+  end
+
+  describe "list_models/1 with no model_discovery block" do
+    test "returns {:error, :no_model_discovery} when model_discovery is nil" do
+      spec = %ProviderSpec{
+        name: "no-disc",
+        adapter: :mock,
+        module: ExAthena.Providers.Mock,
+        extra_headers: %{}
+      }
+
+      assert {:error, :no_model_discovery} = ModelDiscovery.list_models(spec)
+    end
+  end
+
+  describe "extract_models/2 path extraction (pure)" do
+    test "extracts from data.id path" do
+      body = %{"data" => [%{"id" => "model-a"}, %{"id" => "model-b"}]}
+      assert ["model-a", "model-b"] = ModelDiscovery.extract_models(body, "data.id")
+    end
+
+    test "extracts from root list with single-key path" do
+      body = [%{"id" => "m1"}, %{"id" => "m2"}]
+      assert ["m1", "m2"] = ModelDiscovery.extract_models(body, "id")
+    end
+
+    test "returns root strings when path is empty and body is a list of strings" do
+      body = ["m1", "m2", "m3"]
+      assert ["m1", "m2", "m3"] = ModelDiscovery.extract_models(body, "")
+    end
+
+    test "returns empty list when path key is missing" do
+      body = %{"items" => [%{"name" => "m1"}]}
+      assert [] = ModelDiscovery.extract_models(body, "data.id")
+    end
+
+    test "returns empty list for non-list, non-map body" do
+      assert [] = ModelDiscovery.extract_models("not-a-map", "data.id")
+    end
+
+    test "handles nested path with intermediate list" do
+      body = %{"results" => %{"models" => [%{"id" => "x"}, %{"id" => "y"}]}}
+      assert ["x", "y"] = ModelDiscovery.extract_models(body, "results.models.id")
+    end
+  end
+
+  describe "list_models/1 with HTTP (Bypass)" do
+    setup do
+      bypass = Bypass.open()
+      {:ok, bypass: bypass, base_url: "http://localhost:#{bypass.port}"}
+    end
+
+    test "fetches models and returns extracted list", %{bypass: bypass, base_url: base_url} do
+      Bypass.expect_once(bypass, "GET", "/v1/models", fn conn ->
+        body =
+          Jason.encode!(%{
+            "data" => [%{"id" => "model-alpha"}, %{"id" => "model-beta"}]
+          })
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, body)
+      end)
+
+      spec = %ProviderSpec{
+        name: "test-provider-#{System.unique_integer([:positive])}",
+        adapter: :req_llm,
+        module: ExAthena.Providers.ReqLLM,
+        extra_headers: %{},
+        model_discovery: %{
+          "url" => "#{base_url}/v1/models",
+          "path" => "data.id"
+        }
+      }
+
+      assert {:ok, models} = ModelDiscovery.list_models(spec)
+      assert "model-alpha" in models
+      assert "model-beta" in models
+    end
+
+    test "caches result on second call without hitting HTTP again",
+         %{bypass: bypass, base_url: base_url} do
+      name = "caching-prov-#{System.unique_integer([:positive])}"
+
+      Bypass.expect_once(bypass, "GET", "/models", fn conn ->
+        body = Jason.encode!(%{"data" => [%{"id" => "cached-model"}]})
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, body)
+      end)
+
+      spec = %ProviderSpec{
+        name: name,
+        adapter: :req_llm,
+        module: ExAthena.Providers.ReqLLM,
+        extra_headers: %{},
+        model_discovery: %{
+          "url" => "#{base_url}/models",
+          "path" => "data.id",
+          "ttl_seconds" => 60
+        }
+      }
+
+      assert {:ok, ["cached-model"]} = ModelDiscovery.list_models(spec)
+      # Second call uses cache — Bypass would raise if a second request hit
+      assert {:ok, ["cached-model"]} = ModelDiscovery.list_models(spec)
+    end
+
+    test "returns error tuple on HTTP error status", %{bypass: bypass, base_url: base_url} do
+      Bypass.expect_once(bypass, "GET", "/models", fn conn ->
+        Plug.Conn.resp(conn, 401, ~s({"error":"unauthorized"}))
+      end)
+
+      spec = %ProviderSpec{
+        name: "err-prov-#{System.unique_integer([:positive])}",
+        adapter: :req_llm,
+        module: ExAthena.Providers.ReqLLM,
+        extra_headers: %{},
+        model_discovery: %{"url" => "#{base_url}/models", "path" => "data.id"}
+      }
+
+      assert {:error, {:http_error, 401}} = ModelDiscovery.list_models(spec)
+    end
+
+    test "sends extra headers in the request when headers are in model_discovery",
+         %{bypass: bypass, base_url: base_url} do
+      name = "header-prov-#{System.unique_integer([:positive])}"
+
+      Bypass.expect_once(bypass, "GET", "/models", fn conn ->
+        assert Plug.Conn.get_req_header(conn, "x-custom-auth") == ["my-token"]
+
+        body = Jason.encode!(%{"data" => [%{"id" => "m1"}]})
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, body)
+      end)
+
+      spec = %ProviderSpec{
+        name: name,
+        adapter: :req_llm,
+        module: ExAthena.Providers.ReqLLM,
+        extra_headers: %{},
+        model_discovery: %{
+          "url" => "#{base_url}/models",
+          "path" => "data.id",
+          "headers" => %{"x-custom-auth" => "my-token"}
+        }
+      }
+
+      assert {:ok, ["m1"]} = ModelDiscovery.list_models(spec)
+    end
+  end
+end

--- a/test/ex_athena/provider_registry_test.exs
+++ b/test/ex_athena/provider_registry_test.exs
@@ -1,0 +1,163 @@
+defmodule ExAthena.ProviderRegistryTest do
+  use ExUnit.Case, async: false
+
+  alias ExAthena.{ProviderRegistry, ProviderSpec}
+
+  # ── Helpers ───────────────────────────────────────────────────────
+
+  defp tmp_dir do
+    Path.join(System.tmp_dir!(), "ex_athena_reg_#{System.unique_integer([:positive])}")
+  end
+
+  defp tmp_dir_create do
+    dir = tmp_dir()
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+    dir
+  end
+
+  defp write_json(dir, filename, data) do
+    File.write!(Path.join(dir, filename), Jason.encode!(data))
+  end
+
+  defp start_registry(opts) do
+    start_supervised!({ProviderRegistry, opts})
+  end
+
+  # ── Tests: empty / missing directory ──────────────────────────────
+
+  describe "with empty or missing directory" do
+    test "starts successfully when directory does not exist" do
+      dir = tmp_dir()
+      start_registry(providers_dir: dir)
+      assert ProviderRegistry.list() == []
+    end
+
+    test "returns empty list when directory exists but is empty" do
+      dir = tmp_dir_create()
+      start_registry(providers_dir: dir)
+      assert ProviderRegistry.list() == []
+    end
+  end
+
+  # ── Tests: loading valid specs ─────────────────────────────────────
+
+  describe "loading valid specs" do
+    test "loads a single valid JSON file" do
+      dir = tmp_dir_create()
+      write_json(dir, "prov.json", %{name: "my-ollama", adapter: "req_llm"})
+      start_registry(providers_dir: dir)
+
+      assert [spec] = ProviderRegistry.list()
+      assert spec.name == "my-ollama"
+      assert spec.module == ExAthena.Providers.ReqLLM
+    end
+
+    test "loads optional fields from JSON" do
+      dir = tmp_dir_create()
+
+      write_json(dir, "prov.json", %{
+        name: "custom",
+        adapter: "req_llm",
+        req_llm_provider_tag: "openai",
+        base_url: "http://localhost:11434/v1",
+        default_model: "llama3"
+      })
+
+      start_registry(providers_dir: dir)
+
+      assert [spec] = ProviderRegistry.list()
+      assert spec.req_llm_provider_tag == "openai"
+      assert spec.base_url == "http://localhost:11434/v1"
+      assert spec.default_model == "llama3"
+    end
+
+    test "loads multiple valid JSON files" do
+      dir = tmp_dir_create()
+      write_json(dir, "a.json", %{name: "prov-a", adapter: "req_llm"})
+      write_json(dir, "b.json", %{name: "prov-b", adapter: "mock"})
+      start_registry(providers_dir: dir)
+
+      names = ProviderRegistry.list() |> Enum.map(& &1.name) |> Enum.sort()
+      assert names == ["prov-a", "prov-b"]
+    end
+
+    test "lookup/1 returns spec by string name" do
+      dir = tmp_dir_create()
+      write_json(dir, "x.json", %{name: "my-provider", adapter: "mock"})
+      start_registry(providers_dir: dir)
+
+      assert {:ok, %ProviderSpec{name: "my-provider"}} = ProviderRegistry.lookup("my-provider")
+    end
+
+    test "lookup/1 returns spec by atom name" do
+      dir = tmp_dir_create()
+      write_json(dir, "x.json", %{name: "my-provider", adapter: "mock"})
+      start_registry(providers_dir: dir)
+
+      assert {:ok, %ProviderSpec{}} = ProviderRegistry.lookup(:"my-provider")
+    end
+
+    test "lookup/1 returns :error for unknown name" do
+      dir = tmp_dir_create()
+      start_registry(providers_dir: dir)
+
+      assert :error = ProviderRegistry.lookup("nonexistent")
+    end
+  end
+
+  # ── Tests: validation and skip-and-log on failure ─────────────────
+
+  describe "validation on load — skip-and-log" do
+    test "skips files with missing required name field" do
+      dir = tmp_dir_create()
+      write_json(dir, "bad.json", %{adapter: "req_llm"})
+      start_registry(providers_dir: dir)
+
+      assert ProviderRegistry.list() == []
+    end
+
+    test "skips files with missing required adapter field" do
+      dir = tmp_dir_create()
+      write_json(dir, "bad.json", %{name: "no-adapter"})
+      start_registry(providers_dir: dir)
+
+      assert ProviderRegistry.list() == []
+    end
+
+    test "skips files with unknown adapter" do
+      dir = tmp_dir_create()
+      write_json(dir, "bad.json", %{name: "x", adapter: "not_real"})
+      start_registry(providers_dir: dir)
+
+      assert ProviderRegistry.list() == []
+    end
+
+    test "skips malformed JSON files" do
+      dir = tmp_dir_create()
+      File.write!(Path.join(dir, "bad.json"), "not valid json {{{")
+      start_registry(providers_dir: dir)
+
+      assert ProviderRegistry.list() == []
+    end
+
+    test "skips invalid files but loads valid ones in the same directory" do
+      dir = tmp_dir_create()
+      write_json(dir, "good.json", %{name: "good", adapter: "mock"})
+      write_json(dir, "bad.json", %{name: "bad"})
+      start_registry(providers_dir: dir)
+
+      assert [spec] = ProviderRegistry.list()
+      assert spec.name == "good"
+    end
+
+    test "ignores non-JSON files" do
+      dir = tmp_dir_create()
+      File.write!(Path.join(dir, "readme.txt"), "not a spec")
+      File.write!(Path.join(dir, "notes.md"), "# notes")
+      start_registry(providers_dir: dir)
+
+      assert ProviderRegistry.list() == []
+    end
+  end
+end

--- a/test/ex_athena/provider_spec_test.exs
+++ b/test/ex_athena/provider_spec_test.exs
@@ -1,0 +1,77 @@
+defmodule ExAthena.ProviderSpecTest do
+  use ExUnit.Case, async: true
+
+  alias ExAthena.ProviderSpec
+
+  describe "from_json/1" do
+    test "parses a full valid spec" do
+      json = %{
+        "name" => "my-ollama",
+        "adapter" => "req_llm",
+        "req_llm_provider_tag" => "openai",
+        "base_url" => "http://localhost:11434/v1",
+        "api_key" => "not-needed",
+        "default_model" => "qwen3-coder",
+        "metadata" => %{"note" => "local"}
+      }
+
+      assert {:ok, spec} = ProviderSpec.from_json(json)
+      assert spec.name == "my-ollama"
+      assert spec.adapter == :req_llm
+      assert spec.module == ExAthena.Providers.ReqLLM
+      assert spec.req_llm_provider_tag == "openai"
+      assert spec.base_url == "http://localhost:11434/v1"
+      assert spec.api_key == "not-needed"
+      assert spec.default_model == "qwen3-coder"
+      assert spec.metadata == %{"note" => "local"}
+    end
+
+    test "parses a minimal spec (only required fields)" do
+      assert {:ok, spec} = ProviderSpec.from_json(%{"name" => "min", "adapter" => "mock"})
+      assert spec.name == "min"
+      assert spec.adapter == :mock
+      assert spec.module == ExAthena.Providers.Mock
+      assert spec.req_llm_provider_tag == nil
+      assert spec.base_url == nil
+      assert spec.api_key == nil
+      assert spec.default_model == nil
+    end
+
+    test "defaults metadata to empty map when not provided" do
+      assert {:ok, spec} = ProviderSpec.from_json(%{"name" => "x", "adapter" => "mock"})
+      assert spec.metadata == %{}
+    end
+
+    test "parses mock adapter" do
+      assert {:ok, spec} = ProviderSpec.from_json(%{"name" => "test", "adapter" => "mock"})
+      assert spec.module == ExAthena.Providers.Mock
+    end
+
+    test "returns error for missing name" do
+      assert {:error, reason} = ProviderSpec.from_json(%{"adapter" => "req_llm"})
+      assert reason =~ "name"
+    end
+
+    test "returns error for missing adapter" do
+      assert {:error, reason} = ProviderSpec.from_json(%{"name" => "x"})
+      assert reason =~ "adapter"
+    end
+
+    test "returns error for empty name string" do
+      assert {:error, reason} = ProviderSpec.from_json(%{"name" => "", "adapter" => "mock"})
+      assert reason =~ "name"
+    end
+
+    test "returns error for non-string name" do
+      assert {:error, reason} = ProviderSpec.from_json(%{"name" => 123, "adapter" => "mock"})
+      assert reason =~ "name"
+    end
+
+    test "returns error for unknown adapter" do
+      assert {:error, reason} =
+               ProviderSpec.from_json(%{"name" => "x", "adapter" => "unknown_thing"})
+
+      assert reason =~ "unknown adapter"
+    end
+  end
+end

--- a/test/ex_athena/provider_spec_test.exs
+++ b/test/ex_athena/provider_spec_test.exs
@@ -42,6 +42,58 @@ defmodule ExAthena.ProviderSpecTest do
       assert spec.metadata == %{}
     end
 
+    test "parses extra_headers map" do
+      json = %{
+        "name" => "openrouter",
+        "adapter" => "req_llm",
+        "extra_headers" => %{"HTTP-Referer" => "https://myapp.io", "X-Title" => "MyApp"}
+      }
+
+      assert {:ok, spec} = ProviderSpec.from_json(json)
+      assert spec.extra_headers == %{"HTTP-Referer" => "https://myapp.io", "X-Title" => "MyApp"}
+    end
+
+    test "defaults extra_headers to empty map when not provided" do
+      assert {:ok, spec} = ProviderSpec.from_json(%{"name" => "x", "adapter" => "mock"})
+      assert spec.extra_headers == %{}
+    end
+
+    test "parses api_key_env" do
+      json = %{"name" => "x", "adapter" => "req_llm", "api_key_env" => "OPENROUTER_API_KEY"}
+      assert {:ok, spec} = ProviderSpec.from_json(json)
+      assert spec.api_key_env == "OPENROUTER_API_KEY"
+    end
+
+    test "defaults api_key_env to nil when not provided" do
+      assert {:ok, spec} = ProviderSpec.from_json(%{"name" => "x", "adapter" => "mock"})
+      assert spec.api_key_env == nil
+    end
+
+    test "parses model_discovery block" do
+      json = %{
+        "name" => "x",
+        "adapter" => "req_llm",
+        "model_discovery" => %{
+          "url" => "https://openrouter.ai/api/v1/models",
+          "path" => "data.id",
+          "ttl_seconds" => 300
+        }
+      }
+
+      assert {:ok, spec} = ProviderSpec.from_json(json)
+
+      assert spec.model_discovery == %{
+               "url" => "https://openrouter.ai/api/v1/models",
+               "path" => "data.id",
+               "ttl_seconds" => 300
+             }
+    end
+
+    test "defaults model_discovery to nil when not provided" do
+      assert {:ok, spec} = ProviderSpec.from_json(%{"name" => "x", "adapter" => "mock"})
+      assert spec.model_discovery == nil
+    end
+
     test "parses mock adapter" do
       assert {:ok, spec} = ProviderSpec.from_json(%{"name" => "test", "adapter" => "mock"})
       assert spec.module == ExAthena.Providers.Mock

--- a/test/ex_athena/provider_spec_test.exs
+++ b/test/ex_athena/provider_spec_test.exs
@@ -73,5 +73,37 @@ defmodule ExAthena.ProviderSpecTest do
 
       assert reason =~ "unknown adapter"
     end
+
+    test "parses display_name, api_key_prompt, api_key_env, extra_headers" do
+      json = %{
+        "name" => "my-openai",
+        "adapter" => "req_llm",
+        "display_name" => "My OpenAI",
+        "api_key_prompt" => true,
+        "api_key_env" => "MY_OPENAI_API_KEY",
+        "extra_headers" => %{"X-Custom" => "value"}
+      }
+
+      assert {:ok, spec} = ProviderSpec.from_json(json)
+      assert spec.display_name == "My OpenAI"
+      assert spec.api_key_prompt == true
+      assert spec.api_key_env == "MY_OPENAI_API_KEY"
+      assert spec.extra_headers == %{"X-Custom" => "value"}
+    end
+
+    test "display_name defaults to nil when not provided" do
+      assert {:ok, spec} = ProviderSpec.from_json(%{"name" => "x", "adapter" => "mock"})
+      assert spec.display_name == nil
+    end
+
+    test "api_key_prompt defaults to false when not provided" do
+      assert {:ok, spec} = ProviderSpec.from_json(%{"name" => "x", "adapter" => "mock"})
+      assert spec.api_key_prompt == false
+    end
+
+    test "extra_headers defaults to empty map when not provided" do
+      assert {:ok, spec} = ProviderSpec.from_json(%{"name" => "x", "adapter" => "mock"})
+      assert spec.extra_headers == %{}
+    end
   end
 end

--- a/test/ex_athena/providers/req_llm_openrouter_test.exs
+++ b/test/ex_athena/providers/req_llm_openrouter_test.exs
@@ -1,0 +1,107 @@
+defmodule ExAthena.Providers.ReqLLMOpenRouterTest do
+  @moduledoc """
+  Integration test: verifies that an openrouter.json ProviderSpec resolves end-to-end
+  through Config.pop_provider!/1 and ReqLLM.build_opts/2 with all spec fields wired
+  correctly (module, req_llm_provider_tag, base_url, api_key, extra_headers).
+  """
+
+  use ExUnit.Case, async: false
+
+  alias ExAthena.{Config, Request}
+  alias ExAthena.Providers.ReqLLM, as: Adapter
+
+  @env_var "EX_ATHENA_TEST_OPENROUTER_KEY_#{System.unique_integer([:positive])}"
+
+  setup_all do
+    System.put_env(@env_var, "sk-or-test-abc123")
+    on_exit(fn -> System.delete_env(@env_var) end)
+    :ok
+  end
+
+  setup do
+    dir = tmp_dir_create()
+
+    write_json(dir, "openrouter.json", %{
+      name: "openrouter",
+      adapter: "req_llm",
+      req_llm_provider_tag: "openrouter",
+      base_url: "https://openrouter.ai/api/v1",
+      api_key_env: @env_var,
+      extra_headers: %{
+        "HTTP-Referer" => "https://myapp.io",
+        "X-Title" => "MyApp"
+      }
+    })
+
+    start_supervised!({ExAthena.ProviderRegistry, providers_dir: dir})
+    :ok
+  end
+
+  describe "openrouter spec resolves correctly through Config.pop_provider!/1" do
+    test "resolves provider atom to ExAthena.Providers.ReqLLM" do
+      {mod, _opts} = Config.pop_provider!(provider: :openrouter)
+      assert mod == ExAthena.Providers.ReqLLM
+    end
+
+    test "threads req_llm_provider_tag from spec" do
+      {_mod, opts} = Config.pop_provider!(provider: :openrouter)
+      assert opts[:req_llm_provider_tag] == "openrouter"
+    end
+
+    test "threads base_url from spec" do
+      {_mod, opts} = Config.pop_provider!(provider: :openrouter)
+      assert opts[:base_url] == "https://openrouter.ai/api/v1"
+    end
+
+    test "resolves api_key from api_key_env" do
+      {_mod, opts} = Config.pop_provider!(provider: :openrouter)
+      assert opts[:api_key] == "sk-or-test-abc123"
+    end
+
+    test "threads extra_headers from spec" do
+      {_mod, opts} = Config.pop_provider!(provider: :openrouter)
+
+      assert opts[:extra_headers] == %{
+               "HTTP-Referer" => "https://myapp.io",
+               "X-Title" => "MyApp"
+             }
+    end
+  end
+
+  describe "extra_headers fold through build_opts" do
+    test "extra_headers appear in req_http_options after build_opts" do
+      {_mod, opts} = Config.pop_provider!(provider: :openrouter, model: "openai/gpt-4o")
+      request = %Request{messages: []}
+
+      {:ok, built_opts} = Adapter.build_opts(request, opts)
+
+      http_opts = Keyword.get(built_opts, :req_http_options, [])
+      headers = Keyword.get(http_opts, :headers, [])
+
+      assert {"HTTP-Referer", "https://myapp.io"} in headers
+      assert {"X-Title", "MyApp"} in headers
+    end
+
+    test "api_key is present in built_opts" do
+      {_mod, opts} = Config.pop_provider!(provider: :openrouter, model: "openai/gpt-4o")
+      request = %Request{messages: []}
+
+      {:ok, built_opts} = Adapter.build_opts(request, opts)
+
+      assert built_opts[:api_key] == "sk-or-test-abc123"
+    end
+  end
+
+  # ── Helpers ───────────────────────────────────────────────────────
+
+  defp tmp_dir_create do
+    dir = Path.join(System.tmp_dir!(), "ex_athena_or_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+    dir
+  end
+
+  defp write_json(dir, filename, data) do
+    File.write!(Path.join(dir, filename), Jason.encode!(data))
+  end
+end

--- a/test/ex_athena/providers/req_llm_test.exs
+++ b/test/ex_athena/providers/req_llm_test.exs
@@ -342,6 +342,56 @@ defmodule ExAthena.Providers.ReqLLMTest do
     end
   end
 
+  describe "build_opts/2 folds extra_headers into req_http_options" do
+    alias ExAthena.Request
+
+    test "folds extra_headers map into req_http_options headers list" do
+      request = %Request{messages: []}
+      headers = %{"HTTP-Referer" => "https://myapp.io", "X-Title" => "MyApp"}
+
+      {:ok, opts} = Adapter.build_opts(request, extra_headers: headers)
+
+      http_opts = Keyword.get(opts, :req_http_options, [])
+      headers_list = Keyword.get(http_opts, :headers, [])
+
+      assert {"HTTP-Referer", "https://myapp.io"} in headers_list
+      assert {"X-Title", "MyApp"} in headers_list
+    end
+
+    test "does not add req_http_options when extra_headers is absent" do
+      request = %Request{messages: []}
+      {:ok, opts} = Adapter.build_opts(request, [])
+      refute Keyword.has_key?(opts, :req_http_options)
+    end
+
+    test "does not add req_http_options when extra_headers is an empty map" do
+      request = %Request{messages: []}
+      {:ok, opts} = Adapter.build_opts(request, extra_headers: %{})
+      refute Keyword.has_key?(opts, :req_http_options)
+    end
+
+    test "extra_headers is not forwarded as a top-level opt" do
+      request = %Request{messages: []}
+      {:ok, opts} = Adapter.build_opts(request, extra_headers: %{"X-Custom" => "val"})
+      refute Keyword.has_key?(opts, :extra_headers)
+    end
+
+    test "merges extra_headers with existing req_http_options headers" do
+      request = %Request{messages: []}
+      existing = [headers: [{"X-Existing", "old"}]]
+
+      {:ok, opts} =
+        Adapter.build_opts(request,
+          extra_headers: %{"X-New" => "new"},
+          provider_opts: [req_http_options: existing]
+        )
+
+      http_opts = Keyword.get(opts, :req_http_options, [])
+      headers_list = Keyword.get(http_opts, :headers, [])
+      assert {"X-New", "new"} in headers_list
+    end
+  end
+
   describe "build_opts/2 forwards response_format" do
     alias ExAthena.Request
 


### PR DESCRIPTION
## Description

GitHub Issue: https://github.com/udin-io/ex_athena/issues/111

## Goal

Make adding a new provider (OpenRouter today, others in the future) a **runtime configuration** action, not a code change. Users drop a JSON file into `~/.config/ex_athena/providers/` and that provider becomes available everywhere: library callers, `mix athena.chat` (TUI), `mix athena.web` (GUI).

This generalises ex_athena#110: instead of hardcoding `:openrouter` in `@builtin_providers`, we add a runtime layer that loads any provider defined in JSON.

## Why

- The only providers users can pick today are the ones hardcoded in `lib/ex_athena/config.ex` (`:ollama`, `:openai`, `:openai_compatible`, `:llamacpp`, `:claude`, `:anthropic`, `:gemini`, `:mock`). Adding a new one means editing two maps, releasing, bumping deps.
- OpenRouter is one such case but there will be more: Together.ai, Fireworks.ai, Groq, DeepSeek, Cerebras, self-hosted Mistral, local MLX endpoints with quirks, etc. All OpenAI-compatible. None should require a code change.
- The TUI and GUI both have provider/model pickers that read from the same registry. A runtime layer means both surfaces work without per-provider UI code.

## Config layout

**Directory:** `~/.config/ex_athena/providers/` (aligns with existing XDG convention used for `agents/`, `skills/`, `AGENTS.md`).

> Note: the user originally asked for `~/.exathena/config`. We're using `~/.config/ex_athena/providers/` instead because ex_athena already standardised on the XDG path for agents/skills/memory. Worth a one-line redirect symlink check (`~/.exathena → ~/.config/ex_athena`) if you want both to work.

**One JSON file per provider:** `~/.config/ex_athena/providers/<name>.json`

**Example: `~/.config/ex_athena/providers/openrouter.json`**

```json
{
  "name": "openrouter",
  "display_name": "OpenRouter",
  "adapter": "req_llm",
  "req_llm_tag": "openai",
  "base_url": "https://openrouter.ai/api/v1",
  "api_key_env": "OPENROUTER_API_KEY",
  "api_key_prompt": true,
  "default_model": "anthropic/claude-3.5-sonnet",
  "model_discovery": {
    "endpoint": "/models",
    "method": "GET",
    "auth": "bearer",
    "response_path": "data",
    "cache_seconds": 300
  },
  "extra_headers": {
    "HTTP-Referer": "https://github.com/udin-io/ex_athena",
    "X-Title": "ex_athena"
  },
  "error_hints": {
    "402": "Out of OpenRouter credits — top up at https://openrouter.ai/credits"
  }
}
```

**Example: `~/.config/ex_athena/providers/groq.json`** — same shape, different base_url + env var.

## What this enables

- **Library callers**: `ExAthena.query(prompt, provider: :openrouter, ...)` works the moment the JSON file exists, no recompile.
- **TUI** (`mix athena.chat`): the `/model` and `/provider` pickers list every JSON-defined provider alongside built-ins. The chat header shows the configured `display_name`.
- **GUI** (`mix athena.web`): the sidebar selector includes JSON-defined providers. API key field appears automatically when `api_key_prompt: true` and `api_key_env` is unset. Live model dropdown populates from `model_discovery` config.
- **OpenRouter ranking headers** flow through `extra_headers` — no special-case code.
- **Future-proof**: adding Together.ai is a 12-line JSON file.

## Implementation

### 1. New module: `ExAthena.ProviderRegistry`

- `lib/ex_athena/provider_registry.ex` — loads all JSON files from `~/.config/ex_athena/providers/` at startup, validates them against a schema, returns a merged map of `%{atom_name => %ProviderSpec{}}`.
- Started under the ex_athena supervision tree so reloads are explicit (`ProviderRegistry.reload/0`).
- File watcher (optional, behind a flag): auto-reload on file change for TUI/GUI dev ergonomics.

### 2. Provider spec struct

```elixir
defmodule ExAthena.ProviderSpec do
  defstruct [
    :name, :display_name, :adapter, :req_llm_tag,
    :base_url, :api_key_env, :api_key_prompt,
    :default_model, :model_discovery, :extra_headers,
    :error_hints, :source  # :builtin | :user_json
  ]
end
```

### 3. Modify `ExAthena.Config`

- `provider_module/1` and `req_llm_tag_for/1` consult `ProviderRegistry.get/1` first, fall back to the existing `@builtin_providers` / `@req_llm_provider_tag` maps.
- `list_providers/0` returns built-ins ∪ user JSON entries, deduped.

### 4. ReqLLM adapter pickup

- `lib/ex_athena/providers/req_llm.ex` `build_opts/2` reads `extra_headers` from the resolved provider spec and folds them into `provider_opts[:headers]`.
- `api_key` resolution: if `api_key_env` is set, read from env; else if `api_key_prompt: true`, the TUI/GUI prompts and caches in-memory (never written to disk by ex_athena itself).

### 5. Live model discovery

- Generic `ExAthena.ModelDiscovery.list/1` that drives any provider with a `model_discovery` block by HTTP-ing the configured endpoint, applying the `response_path`, and caching with the configured TTL.
- The TUI's `/model` picker and the GUI's sidebar both use this.

### 6. TUI changes (`lib/ex_athena/chat/tui/`)

- Provider picker popup lists JSON-defined providers with their `display_name`.
- When the active provider has `api_key_prompt: true` and no env var set, prompt for the key on first request (cached for the session).
- Show `extra_headers` in `/details` so the user can see what's being sent.

### 7. GUI changes (`lib/ex_athena/web/live/chat_live.ex`)

- Sidebar provider list reads `ExAthena.Config.list_providers/0`.
- API key form field renders when `api_key_prompt: true`. Stored in the LiveView session (encrypted via the existing `~/.ex_athena/web/secret.key`), never persisted to disk by ex_athena.
- Model dropdown calls `ModelDiscovery.list/1` and groups by vendor prefix when applicable.

### 8. Backward compatibility

- Existing `config :ex_athena, :ollama, base_url: ...` style still works — Application config wins over JSON for the same field, JSON adds providers not defined in code.
- The hardcoded `@builtin_providers` map is preserved as the floor.

### 9. Validation

- Schema validation on load: required fields (`name`, `adapter`, `base_url`), known `adapter` values (`req_llm` for now; future: `gemini_native`, etc.), known `req_llm_tag`.
- On validation failure: log a clear error, skip that file, don't crash boot.

### 10. Tests

- Unit: `ProviderRegistry` loads + validates a directory of JSON files; returns errors for malformed files without crashing.
- Integration: with a temp `~/.config/ex_athena/providers/openrouter.json`, `ExAthena.query(..., provider: :openrouter, ...)` resolves correctly through `ReqLLM`.
- TUI: provider picker lists JSON-defined providers (Ratatui snapshot test).
- GUI: LiveView shows OpenRouter in sidebar after writing the JSON.
- Security: `api_key_prompt` keys never appear in `inspect/1` output of state structs.

## Files to change

- **New:** `lib/ex_athena/provider_registry.ex`
- **New:** `lib/ex_athena/provider_spec.ex`
- **New:** `lib/ex_athena/model_discovery.ex` (generic version; existing per-provider discovery folds in)
- `lib/ex_athena/config.ex` — fall-through to registry for unknown atoms
- `lib/ex_athena/providers/req_llm.ex` — pick up `extra_headers`, generic auth
- `lib/ex_athena/chat/tui/` — picker reads from `Config.list_providers/0`, API-key prompt
- `lib/ex_athena/web/live/chat_live.ex` — sidebar reads from registry, API-key field, discovery-backed model dropdown
- Application supervision tree — start `ProviderRegistry`
- New tests (listed above)

## What this ticket does NOT do

- Does not ship OpenRouter's JSON file. The repo ships **example** JSONs in `priv/provider_examples/` (openrouter.json, groq.json, together.json) for users to copy. Users opt in.
- Does not add a CLI to manage providers (no `mix athena.providers add`). Trivial follow-up; not blocking.
- Does not persist API keys to disk. ex_athena reads keys from env vars or prompts the user; it never writes them.

## Relationship to ex_athena#110

ex_athena#110 (register `:openrouter` as a built-in) is now **superseded by this ticket**. Close #110 in favor of this — once this ships, OpenRouter is just `priv/provider_examples/openrouter.json` and users copy it to their `~/.config/ex_athena/providers/`.

## Acceptance criteria

- [ ] Dropping a JSON file in `~/.config/ex_athena/providers/` makes that provider usable via library, TUI, and GUI without recompile.
- [ ] OpenRouter works end-to-end via `priv/provider_examples/openrouter.json` (live model list, auth, ranking headers, 402 error hint).
- [ ] All existing built-in providers (`:ollama`, `:openai`, `:openai_compatible`, `:llamacpp`, `:claude`, `:anthropic`, `:gemini`) still work unchanged.
- [ ] Malformed JSON files log clear errors and don't crash boot.
- [ ] API keys are never written to disk by ex_athena.
- [ ] TUI and GUI both list the new provider in their pickers within one screen render of the JSON file appearing.

## Related

- **Closes:** ex_athena#110 (replaced by this ticket's broader scope).
- **Downstream:** udin_code#1622 — once this ships and is published to hex, udin_code bumps the dep and ships the per-project UI (which is separate from the TUI/GUI surfaces this ticket covers).

## Summary

This PR implements: **Runtime JSON provider config in ~/.config/ex_athena/providers/ — TUI + GUI + library load it on boot**

---
*Created by UdinCode*

Closes https://github.com/udin-io/ex_athena/issues/111