### PR TITLE
chore(release): prepare v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and ExAthena adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+## v0.15.0 — Runtime JSON provider config + per-provider request queue
+
+Two coordinated upgrades to provider handling: a runtime JSON registry so users
+can add providers (OpenRouter, Groq, Together, Fireworks, DeepSeek, …) by
+dropping a config file — no code change or redeploy required — and a built-in
+per-provider request queue with telemetry for safe concurrency control across
+every public entry point.
+
 ### Added
 
 - **Request queue wired into all public entry points.** `query/2`, `stream/3`,
@@ -49,6 +57,19 @@ and ExAthena adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   See the [Providers guide](guides/providers.md#runtime-json-config) for the
   full schema reference and the new [Upgrading guide](guides/upgrading.md) for
   migration notes (existing `config.exs` setups require no changes).
+
+### Fixed
+
+- **`Config.req_llm_provider_tag/1` now consults the registry first.** When a
+  JSON-defined provider's name collided with a built-in atom (in practice:
+  `:openrouter`, which is in both the built-in tag map and the example JSON
+  spec), the built-in map was consulted first and the JSON spec's
+  `req_llm_provider_tag` was silently ignored. OpenRouter requests on the
+  JSON-registry path went out tagged `"openai"` instead of `"openrouter"`. The
+  registry spec is now authoritative; the built-in map is the fallback when no
+  spec is loaded for the atom or the spec's tag is unset. `provider_module/1`
+  is unchanged — its built-in-first order is correct (a JSON spec can't
+  override which Elixir module backs a built-in atom).
 
 ## v0.14.0 — Mid-loop intervention hook + structured completion signal
 

--- a/lib/ex_athena/config.ex
+++ b/lib/ex_athena/config.ex
@@ -193,16 +193,22 @@ defmodule ExAthena.Config do
   `"tag:model-id"` specs. Returns `nil` when the atom doesn't map to req_llm
   (e.g. `:mock`, or a user-supplied module).
 
-  For registry-loaded providers the tag is taken from the spec's
-  `req_llm_provider_tag` field when the static map has no entry.
+  Resolution order: a registry-loaded JSON spec wins (its `req_llm_provider_tag`
+  field), with the static built-in map as fallback when no spec is loaded for
+  the atom or the spec's tag is unset. This matters when a JSON-defined
+  provider's name collides with a built-in atom (e.g. `:openrouter`, which is
+  also present in the built-in map for `config.exs` users) — the user's JSON
+  file is authoritative.
   """
   @spec req_llm_provider_tag(atom() | module()) :: String.t() | nil
   def req_llm_provider_tag(atom) when is_atom(atom) do
-    Map.get(@req_llm_provider_tag, atom) ||
-      case registry_lookup(atom) do
-        {:ok, spec} -> spec.req_llm_provider_tag
-        :error -> nil
-      end
+    case registry_lookup(atom) do
+      {:ok, %{req_llm_provider_tag: tag}} when is_binary(tag) and tag != "" ->
+        tag
+
+      _ ->
+        Map.get(@req_llm_provider_tag, atom)
+    end
   end
 
   def req_llm_provider_tag(_), do: nil

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExAthena.MixProject do
   use Mix.Project
 
-  @version "0.14.0"
+  @version "0.15.0"
   @source_url "https://github.com/udin-io/ex_athena"
 
   def project do
@@ -134,6 +134,15 @@ defmodule ExAthena.MixProject do
           ExAthena.Providers.ReqLLM,
           ExAthena.Providers.Mock
         ],
+        "Provider configuration": [
+          ExAthena.ProviderRegistry,
+          ExAthena.ProviderSpec,
+          ExAthena.ModelDiscovery
+        ],
+        "Request queue": [
+          ExAthena.RequestQueue,
+          ExAthena.RequestQueue.Supervisor
+        ],
         "Tool calls": [
           ExAthena.ToolCalls,
           ExAthena.ToolCalls.Native,
@@ -186,6 +195,7 @@ defmodule ExAthena.MixProject do
           ExAthena.Checkpoint.Sweeper
         ],
         Streaming: [ExAthena.Streaming, ExAthena.Streaming.Event],
+        Telemetry: [ExAthena.Telemetry],
         Errors: [ExAthena.Error],
         MCP: [
           ExAthena.Mcp,


### PR DESCRIPTION
## Summary

Cuts **v0.15.0** — runtime JSON provider config + per-provider request queue, with a release-blocking precedence fix folded in.

### Headline features (already on main)
- **Runtime JSON provider config** (#117). Drop `*.json` into `~/.config/ex_athena/providers/` to define a named provider — no code change, no redeploy. `ExAthena.ProviderRegistry` loads/validates at boot; invalid files are skipped with a warning. Ships five ready-to-copy examples in `priv/provider_examples/` (openrouter, groq, together, fireworks, deepseek).
- **Per-provider request queue + telemetry** (#115). `query/2`, `stream/3`, `run/2`, `extract_structured/2` acquire/release a semaphore around the provider call, with `queue: false` / `queue_timeout: ms` per-call escape hatches. Four telemetry events (`:wait`, `:acquired`, `:released`, `:timeout`) carrying `%{provider: atom}`. Opt-in (default-disabled).
- **Docs refresh** (#116) — runtime-config schema in `guides/providers.md`, new `guides/tui.md`, `guides/web.md`, `guides/upgrading.md`.
- **OpenRouter built-in atom** (#113) — also registered for `config.exs` users.

### Release-blocking fix folded in
- **`Config.req_llm_provider_tag/1` precedence swap.** Two tests on `main` were failing because the function checked the built-in tag map *before* the registry. With the example `openrouter.json` (which says `req_llm_provider_tag: "openrouter"`) loaded, requests still went out tagged `"openai"` from the built-in map — silently breaking OpenRouter on v0.15.0's headline path. Registry is now authoritative; built-in map is the fallback. `provider_module/1` left unchanged (its built-in-first order is correct).

### Release housekeeping
- `@version` `0.14.0` → `0.15.0`.
- Promote populated `Unreleased` to `v0.15.0` with title + intro.
- Register new public modules in `groups_for_modules`: `ProviderRegistry`/`ProviderSpec`/`ModelDiscovery` (Provider configuration), `RequestQueue` + `Supervisor` (Request queue), `Telemetry`.

## Test plan

- [x] `mix compile --force --warnings-as-errors` — clean
- [x] `mix format --check-formatted` — clean
- [x] `mix test` — **995 tests, 0 failures** (the two previously-failing `req_llm_openrouter`/`config` precedence tests now pass)
- [x] `mix hex.build` — packs `ex_athena-0.15.0.tar`
- [x] `mix docs` — builds clean

## After merge

Tag `v0.15.0` on `main` and run `mix hex.publish` (Hex's latest is currently 0.14.0).