### PR TITLE
Mid-stream transport closure (Mint :closed) crashes the run — streaming exceptions bypass retryable classification

### DIFF
--- a/lib/ex_athena/providers/req_llm.ex
+++ b/lib/ex_athena/providers/req_llm.ex
@@ -107,9 +107,14 @@ defmodule ExAthena.Providers.ReqLLM do
 
       case ReqLLM.stream_text(model_spec, messages, req_opts) do
         {:ok, %ReqLLM.StreamResponse{} = sr} ->
-          response = consume_stream(sr, callback, request)
-          log_response(response)
-          {:ok, response}
+          case consume_stream(sr, callback, request) do
+            {:ok, response} ->
+              log_response(response)
+              {:ok, response}
+
+            {:error, _} = err ->
+              err
+          end
 
         {:error, reason} ->
           log_error(reason)
@@ -447,7 +452,8 @@ defmodule ExAthena.Providers.ReqLLM do
 
   # ── Streaming ─────────────────────────────────────────────────────
 
-  defp consume_stream(%ReqLLM.StreamResponse{stream: stream}, callback, request) do
+  @doc false
+  def consume_stream(%ReqLLM.StreamResponse{stream: stream}, callback, request) do
     state = %{
       text: [],
       thinking: [],
@@ -466,57 +472,74 @@ defmodule ExAthena.Providers.ReqLLM do
 
     heartbeat_pid = start_heartbeat(state.stream_started_ms)
 
-    final =
+    stream_result =
       try do
-        Enum.reduce(stream, state, fn chunk, acc ->
-          acc = maybe_log_first_chunk(chunk, acc)
-          handle_chunk(chunk, callback, acc)
-        end)
+        final =
+          Enum.reduce(stream, state, fn chunk, acc ->
+            acc = maybe_log_first_chunk(chunk, acc)
+            handle_chunk(chunk, callback, acc)
+          end)
+
+        {:ok, final}
+      rescue
+        e in [ReqLLM.Error.API.Stream, Mint.TransportError, Finch.Error] ->
+          Logger.warning(
+            "#{@log_prefix} transport/stream error during consume: #{Exception.message(e)}"
+          )
+
+          {:error, to_error(e)}
       after
         stop_heartbeat(heartbeat_pid)
       end
 
-    ExAthena.Streaming.stop(callback, final.finish_reason || :stop)
+    case stream_result do
+      {:error, _} = err ->
+        err
 
-    tool_calls = patch_tool_call_args(final.tool_calls, final.tool_call_args_buffer)
+      {:ok, final} ->
+        ExAthena.Streaming.stop(callback, final.finish_reason || :stop)
 
-    text = final.text |> Enum.reverse() |> IO.iodata_to_binary()
-    thinking = final.thinking |> Enum.reverse() |> IO.iodata_to_binary()
+        tool_calls = patch_tool_call_args(final.tool_calls, final.tool_call_args_buffer)
 
-    # Log the resolved tool calls. Warn when args are still empty after patching
-    # (means neither fragments nor raw_arguments provided usable JSON).
-    if Enum.any?(tool_calls, fn tc ->
-         args = if is_struct(tc), do: tc.arguments, else: Map.get(tc, :arguments)
-         args == %{} or is_nil(args)
-       end) do
-      Logger.warning(
-        "#{@log_prefix} [diag] tool_call with empty args after patching — " <>
-          "buffer=#{inspect(final.tool_call_args_buffer)} " <>
-          "text_snippet=#{preview(text, 200)} " <>
-          "calls=#{inspect(Enum.map(tool_calls, fn tc -> {Map.get(tc, :name) || (is_struct(tc) && tc.name), Map.get(tc, :arguments) || (is_struct(tc) && tc.arguments)} end))}"
-      )
-    else
-      Logger.debug(fn ->
-        calls_preview =
-          Enum.map_join(tool_calls, ", ", fn tc ->
-            name = if is_struct(tc), do: tc.name, else: Map.get(tc, :name)
-            args = if is_struct(tc), do: tc.arguments, else: Map.get(tc, :arguments)
-            "#{name}(#{inspect(args, limit: 5, printable_limit: 200)})"
+        text = final.text |> Enum.reverse() |> IO.iodata_to_binary()
+        thinking = final.thinking |> Enum.reverse() |> IO.iodata_to_binary()
+
+        # Log the resolved tool calls. Warn when args are still empty after patching
+        # (means neither fragments nor raw_arguments provided usable JSON).
+        if Enum.any?(tool_calls, fn tc ->
+             args = if is_struct(tc), do: tc.arguments, else: Map.get(tc, :arguments)
+             args == %{} or is_nil(args)
+           end) do
+          Logger.warning(
+            "#{@log_prefix} [diag] tool_call with empty args after patching — " <>
+              "buffer=#{inspect(final.tool_call_args_buffer)} " <>
+              "text_snippet=#{preview(text, 200)} " <>
+              "calls=#{inspect(Enum.map(tool_calls, fn tc -> {Map.get(tc, :name) || (is_struct(tc) && tc.name), Map.get(tc, :arguments) || (is_struct(tc) && tc.arguments)} end))}"
+          )
+        else
+          Logger.debug(fn ->
+            calls_preview =
+              Enum.map_join(tool_calls, ", ", fn tc ->
+                name = if is_struct(tc), do: tc.name, else: Map.get(tc, :name)
+                args = if is_struct(tc), do: tc.arguments, else: Map.get(tc, :arguments)
+                "#{name}(#{inspect(args, limit: 5, printable_limit: 200)})"
+              end)
+
+            "#{@log_prefix} ←tool_calls_resolved #{calls_preview}"
           end)
+        end
 
-        "#{@log_prefix} ←tool_calls_resolved #{calls_preview}"
-      end)
+        {:ok,
+         %Response{
+           text: text,
+           thinking: if(thinking == "", do: nil, else: thinking),
+           tool_calls: tool_calls,
+           finish_reason: final.finish_reason || :stop,
+           model: final.model,
+           provider: :req_llm,
+           usage: final.usage
+         }}
     end
-
-    %Response{
-      text: text,
-      thinking: if(thinking == "", do: nil, else: thinking),
-      tool_calls: tool_calls,
-      finish_reason: final.finish_reason || :stop,
-      model: final.model,
-      provider: :req_llm,
-      usage: final.usage
-    }
   end
 
   # Merge accumulated argument fragments back into each tool call.

--- a/test/ex_athena/providers/req_llm_test.exs
+++ b/test/ex_athena/providers/req_llm_test.exs
@@ -411,6 +411,87 @@ defmodule ExAthena.Providers.ReqLLMTest do
     end
   end
 
+  describe "consume_stream/3 transport error handling" do
+    alias ExAthena.Request
+
+    test "returns {:error, %ExAthena.Error{}} when the stream raises ReqLLM.Error.API.Stream" do
+      # Simulate a mid-stream transport closure: the req_llm lazy stream raises
+      # ReqLLM.Error.API.Stream when it cannot receive the next HTTP chunk (e.g. the
+      # upstream TCP connection was reset). consume_stream/3 must rescue this and
+      # return {:error, %ExAthena.Error{}} rather than letting it crash.
+      error = %ReqLLM.Error.API.Stream{reason: "Stream failed: closed", cause: :closed}
+
+      exploding_stream =
+        Stream.resource(
+          fn -> :start end,
+          fn
+            :start -> raise error
+          end,
+          fn _ -> :ok end
+        )
+
+      sr = %ReqLLM.StreamResponse{
+        stream: exploding_stream,
+        metadata_handle: self(),
+        cancel: fn -> :ok end,
+        model: nil,
+        context: nil
+      }
+
+      request = %Request{messages: [], model: "test-model"}
+      callback = fn _event -> :ok end
+
+      assert {:error, %ExAthena.Error{kind: :server_error}} =
+               Adapter.consume_stream(sr, callback, request)
+    end
+
+    test "returns {:error, %ExAthena.Error{}} when the stream raises Mint.TransportError" do
+      exploding_stream =
+        Stream.resource(
+          fn -> :start end,
+          fn :start -> raise %Mint.TransportError{reason: :closed} end,
+          fn _ -> :ok end
+        )
+
+      sr = %ReqLLM.StreamResponse{
+        stream: exploding_stream,
+        metadata_handle: self(),
+        cancel: fn -> :ok end,
+        model: nil,
+        context: nil
+      }
+
+      request = %Request{messages: [], model: "test-model"}
+      callback = fn _event -> :ok end
+
+      assert {:error, %ExAthena.Error{kind: :server_error}} =
+               Adapter.consume_stream(sr, callback, request)
+    end
+
+    test "returns {:error, %ExAthena.Error{}} when the stream raises Finch.Error" do
+      exploding_stream =
+        Stream.resource(
+          fn -> :start end,
+          fn :start -> raise %Finch.Error{reason: :request_timeout} end,
+          fn _ -> :ok end
+        )
+
+      sr = %ReqLLM.StreamResponse{
+        stream: exploding_stream,
+        metadata_handle: self(),
+        cancel: fn -> :ok end,
+        model: nil,
+        context: nil
+      }
+
+      request = %Request{messages: [], model: "test-model"}
+      callback = fn _event -> :ok end
+
+      assert {:error, %ExAthena.Error{kind: :server_error}} =
+               Adapter.consume_stream(sr, callback, request)
+    end
+  end
+
   describe "build_opts/2 forwards response_format" do
     alias ExAthena.Request
 


### PR DESCRIPTION
## Summary

Fixes a crash where a mid-stream HTTP transport closure (`Mint.TransportError{reason: :closed}`) during LLM streaming would raise an uncaught exception through the entire `ExAthena.run/2` call stack, bypassing the loop's retryable/fatal error classification machinery entirely. The stream consumption now rescues transport exceptions and converts them into `{:error, _}` tuples, feeding them through the existing error handling path.

## Key Changes

- **`consume_stream/3` now returns `{:ok, response} | {:error, reason}`** instead of returning the final accumulator directly or raising. The existing `try` block is extended with a `rescue` clause that catches `ReqLLM.Error.API.Stream`, `Mint.TransportError`, and `Finch.Error`, logs a warning, and converts them via `to_error/1`.
- **`stream/3` propagates the error tuple** — the `{:ok, %ReqLLM.StreamResponse{}}` branch now pattern-matches on `consume_stream/3`'s return value and passes `{:error, _}` through rather than assuming success.
- **`consume_stream/3` visibility changed to `def`** (with `@doc false`) to allow direct unit testing of the rescue path.
- The `after` clause (stopping the heartbeat) still runs unconditionally on both success and error paths, preserving the existing cleanup guarantee.

## Implementation Details

The root cause was that `ReqLLM.Streaming` raises on mid-stream failures rather than returning an error tuple, while `consume_stream/3`'s `try/after` block only ensured heartbeat cleanup — it did not rescue. This meant a transient network blip during stream consumption would propagate as a raised exception through `ReAct.do_iterate/2` → `Loop.loop/1` → `with_request_queue/4`, crashing the caller's task rather than hitting the `:retryable` termination path.

The fix is intentionally minimal: rescue at the provider boundary (the natural seam where `{:ok, _} | {:error, _}` is already the contract), convert to a typed error, and let the existing loop classification handle the rest. The `ExAthena.Streaming.stop/2` call and all downstream response-building logic are skipped on the error branch, which is correct since there is no complete response to build.

Closes https://github.com/udin-io/ex_athena/issues/122