### PR TITLE
chore(release): prepare v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and ExAthena adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+## v0.15.1
+
+A reliability fix for streaming runs plus a refresh of the default Claude model.
+
+### Changed
+
+- **Default Claude model bumped `claude-opus-4-5` → `claude-opus-4-8` (#121).**
+  Updates the runtime defaults (installer scaffold, config and provider
+  moduledoc examples) and all docs/guides/examples to the current latest Opus.
+  The catalog-lookup test is intentionally left at `claude-opus-4-5` (still
+  present in the bundled `llm_db` snapshot) since it verifies `LLMDB.model/2`
+  lookup, not the default.
+
+### Fixed
+
+- **Mid-stream Mint `:closed` exceptions now classify as retryable (#123).**
+  These exceptions were bypassing the retryable-error classification, causing
+  streaming runs to crash instead of retrying. They are now treated as
+  retryable transport errors like other mid-stream connection drops.
+
 ## v0.15.0 — Runtime JSON provider config + per-provider request queue
 
 Two coordinated upgrades to provider handling: a runtime JSON registry so users

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExAthena.MixProject do
   use Mix.Project
 
-  @version "0.15.0"
+  @version "0.15.1"
   @source_url "https://github.com/udin-io/ex_athena"
 
   def project do


### PR DESCRIPTION
## Summary

Cuts **v0.15.1** — a streaming reliability fix plus a default-model refresh. Both changes are backwards-compatible, so this is a patch bump.

Includes the two commits landed since the `v0.15.0` tag:

- **fix(req_llm): classify mid-stream Mint `:closed` as a retryable transport error (#123).** These exceptions were bypassing retryable-error classification, crashing streaming runs instead of retrying.
- **Bump default Claude model `claude-opus-4-5` → `claude-opus-4-8` (#121).** Updates runtime defaults (installer scaffold, config + provider moduledoc examples) and all docs/guides/examples.

## Changes

- Promote the empty CHANGELOG `## Unreleased` section to `## v0.15.1` with both entries.
- Bump `@version` `0.15.0` → `0.15.1` in `mix.exs`.

## Test plan

- [x] `mix format --check-formatted` — clean
- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix test` — 998 tests, 0 failures, 2 excluded
- [x] `mix hex.build` — packages cleanly as `ex_athena-0.15.1`

## Post-merge

Run `mix hex.publish` from `main` to push v0.15.1 to Hex, then tag `v0.15.1`.