### PR TITLE
fix: compact existing context on overflow instead of erroring out

### DIFF
--- a/lib/ex_athena/compactor.ex
+++ b/lib/ex_athena/compactor.ex
@@ -71,11 +71,21 @@ defmodule ExAthena.Compactor do
   Best-effort token estimator. Counts ~4 chars per token for text
   content, plus a small fixed cost per tool-call to cover the JSON
   envelope. Good enough for compaction triggers; not a billing number.
+
+  Pass the request's `system_prompt` as the second argument to include its
+  cost in the estimate. The system prompt (which carries tool descriptions
+  and skill catalogs) is part of every request and can run to thousands of
+  tokens, so omitting it makes the proactive `should_compact?` trigger fire
+  later than it should — or not at all on prompt-heavy agents.
   """
-  @spec estimate_tokens([Message.t()]) :: non_neg_integer()
-  def estimate_tokens(messages) do
-    Enum.reduce(messages, 0, fn msg, acc -> acc + tokens_for(msg) end)
+  @spec estimate_tokens([Message.t()], String.t() | nil) :: non_neg_integer()
+  def estimate_tokens(messages, system_prompt \\ nil) do
+    msg_tokens = Enum.reduce(messages, 0, fn msg, acc -> acc + tokens_for(msg) end)
+    msg_tokens + system_prompt_tokens(system_prompt)
   end
+
+  defp system_prompt_tokens(prompt) when is_binary(prompt), do: div(byte_size(prompt), 4)
+  defp system_prompt_tokens(_), do: 0
 
   defp tokens_for(%Message{content: nil, tool_calls: calls}) when is_list(calls) do
     Enum.reduce(calls, 0, fn tc, acc ->

--- a/lib/ex_athena/loop.ex
+++ b/lib/ex_athena/loop.ex
@@ -213,7 +213,7 @@ defmodule ExAthena.Loop do
     compactor = compactor_module(state)
 
     estimate = %{
-      tokens: ExAthena.Compactor.estimate_tokens(state.messages),
+      tokens: ExAthena.Compactor.estimate_tokens(state.messages, system_prompt(state)),
       max_tokens: state.capabilities[:max_tokens] || 128_000,
       force: true
     }
@@ -313,7 +313,7 @@ defmodule ExAthena.Loop do
     compactor = compactor_module(state)
 
     estimate = %{
-      tokens: ExAthena.Compactor.estimate_tokens(state.messages),
+      tokens: ExAthena.Compactor.estimate_tokens(state.messages, system_prompt(state)),
       max_tokens: state.capabilities[:max_tokens] || 128_000
     }
 
@@ -360,6 +360,11 @@ defmodule ExAthena.Loop do
       Application.get_env(:ex_athena, :compactor_module) ||
       ExAthena.Compactor.Pipeline
   end
+
+  # The system prompt is part of every request (it carries tool descriptions
+  # and the skill catalog), so the compaction estimate must include it.
+  defp system_prompt(%State{request_template: %{system_prompt: sp}}), do: sp
+  defp system_prompt(_), do: nil
 
   defp set_finish_reason(%State{} = state, reason) do
     put_in(state.meta[:finish_reason], reason)

--- a/lib/ex_athena/modes/plan_and_solve.ex
+++ b/lib/ex_athena/modes/plan_and_solve.ex
@@ -77,6 +77,12 @@ defmodule ExAthena.Modes.PlanAndSolve do
 
         {:continue, %{state | messages: new_messages, mode_state: %{phase: :executing}}}
 
+      # Context overflow during planning: surface the kernel's typed capacity
+      # signal so it force-compacts the existing context and retries planning,
+      # rather than dying as a generic execution error. Mirrors ReAct.
+      {:error, %ExAthena.Error{kind: :context_length_exceeded}} ->
+        {:error, :error_prompt_too_long}
+
       {:error, reason} ->
         {:error, {:plan_and_solve_planning_failed, reason}}
     end

--- a/lib/ex_athena/modes/react.ex
+++ b/lib/ex_athena/modes/react.ex
@@ -156,6 +156,13 @@ defmodule ExAthena.Modes.ReAct do
 
         {:halt, state}
 
+      # The prompt exceeded the model's context window (req_llm maps an HTTP
+      # 413 to `:context_length_exceeded`). Surface the kernel's typed
+      # capacity signal so it force-compacts the existing context and retries
+      # this iteration once, rather than dying as a generic execution error.
+      {:error, %ExAthena.Error{kind: :context_length_exceeded}} ->
+        {:error, :error_prompt_too_long}
+
       {:error, reason} ->
         state =
           %{state | halted_reason: reason}

--- a/test/ex_athena/compactor_test.exs
+++ b/test/ex_athena/compactor_test.exs
@@ -4,6 +4,24 @@ defmodule ExAthena.CompactorTest do
   alias ExAthena.Compactor
   alias ExAthena.Messages.{Message, ToolCall, ToolResult}
 
+  describe "estimate_tokens/2 (system prompt)" do
+    test "adds the system prompt's token cost on top of the messages" do
+      msgs = [%Message{role: :user, content: "hi"}]
+      # A large system prompt — tool descriptions / skill catalogs routinely
+      # run to thousands of tokens and are part of every request, yet were
+      # previously excluded from the proactive estimate.
+      prompt = String.duplicate("x", 4000)
+
+      assert Compactor.estimate_tokens(msgs, prompt) ==
+               Compactor.estimate_tokens(msgs) + div(4000, 4)
+    end
+
+    test "a nil system prompt is equivalent to estimate_tokens/1" do
+      msgs = [%Message{role: :user, content: "hi"}]
+      assert Compactor.estimate_tokens(msgs, nil) == Compactor.estimate_tokens(msgs)
+    end
+  end
+
   describe "estimate_tokens/1" do
     test "counts text content at ~4 chars per token + 8 fixed overhead" do
       msg = %Message{role: :user, content: String.duplicate("x", 4000)}

--- a/test/ex_athena/loop/proactive_compaction_test.exs
+++ b/test/ex_athena/loop/proactive_compaction_test.exs
@@ -1,0 +1,50 @@
+defmodule ExAthena.Loop.ProactiveCompactionTest do
+  @moduledoc """
+  Verifies the kernel's proactive `maybe_compact` builds its token estimate
+  from the full request — including the system prompt — not just the
+  messages. A prompt-heavy agent (large tool descriptions / skill catalog)
+  must trip `should_compact?` before the real prompt overflows the window.
+  """
+  use ExUnit.Case, async: true
+
+  alias ExAthena.{Loop, Result}
+
+  # Records the estimate `maybe_compact` passes to `should_compact?`, then
+  # declines to compact so the run proceeds normally. Runs in the loop
+  # process, which is the test process — so the process dictionary is shared.
+  defmodule EstimateSpy do
+    @behaviour ExAthena.Compactor
+
+    @impl true
+    def should_compact?(_state, estimate) do
+      Process.put(:proactive_estimate, estimate)
+      false
+    end
+
+    @impl true
+    def compact(_state, _estimate), do: :skip
+  end
+
+  test "proactive estimate includes the system prompt, not just the messages" do
+    # ~10_000 tokens of system prompt (40_000 bytes / 4) with a trivial
+    # message history — the prompt is the dominant cost.
+    big_prompt = String.duplicate("x", 40_000)
+
+    {:ok, %Result{}} =
+      Loop.run("hi",
+        provider: :mock,
+        mock: [text: "done"],
+        tools: [],
+        system_prompt: big_prompt,
+        compactor: EstimateSpy,
+        memory: false,
+        skills: %{}
+      )
+
+    estimate = Process.get(:proactive_estimate)
+    assert estimate != nil, "should_compact? was never called"
+
+    assert estimate.tokens >= 10_000,
+           "proactive estimate must account for the system prompt (got #{estimate.tokens})"
+  end
+end

--- a/test/ex_athena/loop/reactive_compaction_test.exs
+++ b/test/ex_athena/loop/reactive_compaction_test.exs
@@ -250,6 +250,79 @@ defmodule ExAthena.Loop.ReactiveCompactionTest do
            "Expected the multi-result tool message to be pinned when any result matches"
   end
 
+  # Stateful provider: the first `query/2` reports a context-length overflow
+  # (as req_llm does for an HTTP 413), the second — after the kernel has
+  # force-compacted the existing context and retried — succeeds. Proves the
+  # default ReAct mode translates the provider's `:context_length_exceeded`
+  # error into the `:error_prompt_too_long` recovery signal.
+  defmodule OverflowThenRecoverProvider do
+    @behaviour ExAthena.Provider
+
+    alias ExAthena.{Error, Response}
+
+    @impl true
+    def capabilities, do: %{native_tool_calls: true, streaming: false, max_tokens: 128_000}
+
+    @impl true
+    def query(_request, opts) do
+      counter = Keyword.fetch!(opts, :counter)
+      :counters.add(counter, 1, 1)
+
+      case :counters.get(counter, 1) do
+        1 ->
+          {:error,
+           %Error{
+             kind: :context_length_exceeded,
+             message: "context length exceeded",
+             provider: :test
+           }}
+
+        _ ->
+          {:ok,
+           %Response{text: "recovered after compaction", finish_reason: :stop, provider: :test}}
+      end
+    end
+  end
+
+  test "ReAct recovers from a provider context-length error by compacting the existing context and retrying" do
+    counter = :counters.new(1, [:atomics])
+
+    {:ok, %Result{} = result} =
+      Loop.run("hi",
+        provider: OverflowThenRecoverProvider,
+        counter: counter,
+        tools: [],
+        mode: ExAthena.Modes.ReAct,
+        memory: false,
+        skills: %{}
+      )
+
+    assert result.finish_reason == :stop
+    assert result.text == "recovered after compaction"
+
+    assert :counters.get(counter, 1) == 2,
+           "expected the provider to be retried once after compacting the existing context"
+  end
+
+  test "PlanAndSolve recovers from a context-length error during the planning phase" do
+    counter = :counters.new(1, [:atomics])
+
+    {:ok, %Result{} = result} =
+      Loop.run("hi",
+        provider: OverflowThenRecoverProvider,
+        counter: counter,
+        tools: [],
+        mode: ExAthena.Modes.PlanAndSolve,
+        memory: false,
+        skills: %{}
+      )
+
+    assert result.finish_reason == :stop
+
+    assert :counters.get(counter, 1) >= 2,
+           "expected the planning call to be retried after compacting the existing context"
+  end
+
   test "with reactive compaction disabled, prompt-too-long terminates immediately" do
     responder = fn _req ->
       %Response{text: "x", finish_reason: :stop, provider: :mock}


### PR DESCRIPTION
## Summary

The TUI chat surfaced a red error (`run error: …`) instead of compacting when a conversation exceeded the model's context window. The reactive-recovery machinery to *compact the existing context and retry* already existed in the kernel — it was simply never wired to the provider's context-overflow error. This connects it, and tightens the proactive trigger so compaction can fire before the overflow happens.

## Root cause

When the prompt exceeds the model's context window, `req_llm` returns `%ExAthena.Error{kind: :context_length_exceeded}` (HTTP 413 → `error.ex`). But:

- **ReAct** (`react.ex`) only special-cased `:unauthorized`; the overflow error fell into the generic `{:error, reason}` branch → `:error_during_execution`.
- **PlanAndSolve** planning phase (`plan_and_solve.ex`) wrapped it as `:plan_and_solve_planning_failed`.

The kernel's reactive path (`loop.ex` `handle_prompt_too_long` → `force_compact` → retry) only fires on `{:error, :error_prompt_too_long}`, so it was never reached.

Separately, the **proactive** trigger under-read prompt size: `estimate_tokens/1` counted only the message history, omitting the system prompt (tool descriptions + skill catalog — often thousands of tokens), so `should_compact?` fired late or not at all.

## Changes

1. **Reactive recovery** — ReAct and PlanAndSolve now translate `:context_length_exceeded` into the kernel's `:error_prompt_too_long` capacity signal. The kernel force-compacts the existing context and retries the turn once; only if it's *still* over does it terminate (now as a clean `:error_prompt_too_long`). The TUI already renders the `⤵ compacted N→M tokens` event.
2. **Proactive estimate** — `estimate_tokens/2` adds the system prompt's cost; `maybe_compact`/`force_compact` feed `request_template.system_prompt` through, so compaction triggers against the full request.

## Test plan

- TDD throughout (failing test first, then fix):
  - ReAct recovers from a context-length error by compacting + retrying (asserts retry happened).
  - PlanAndSolve recovers during the planning phase.
  - `estimate_tokens/2` adds the system prompt cost; nil prompt == `/1`.
  - Loop's proactive estimate includes the system prompt (spy compactor captures the estimate).
- Full suite: **1003 tests + 2 doctests, 0 failures**. `mix compile --warnings-as-errors` clean.

## Notes

- Not changed: the proactive estimate still omits native tool-call *schemas* (sent out-of-band, not in the prompt). The reactive net covers the residual; quantifying schema cost is a larger follow-up.